### PR TITLE
Add configurable TTS inter-chunk pause

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ voice_ack_earcon: disabled
 voice_ack_earcon_freq: 600
 voice_ack_earcon_duration: 0.06
 
+tts_inter_chunk_pause_ms: 0
+
 ```
 
 ### Configuration options
@@ -215,6 +217,8 @@ All configuration keys are loaded from `common/configuration.py` defaults and ca
 - `voice_ack_earcon`: `enabled`/`disabled`; play a short ack earcon after recording and before processing
 - `voice_ack_earcon_freq`: earcon frequency (Hz, integer)
 - `voice_ack_earcon_duration`: earcon duration (seconds)
+
+- `tts_inter_chunk_pause_ms`: non-negative integer; adds a small gap between consecutive TTS chunks during playback
 
 
 Enjoy the experience!

--- a/common/audio.py
+++ b/common/audio.py
@@ -307,10 +307,7 @@ class Audio:
         for idx, file_path in enumerate(file_paths):
             delete_file = True
             try:
-                if stop_event is None:
-                    self.play_audio_file(file_path)
-                else:
-                    self.play_audio_file(file_path, stop_event=stop_event)
+                self.play_audio_file(file_path, stop_event=stop_event)
 
                 # Optional pause between chunks to improve pacing.
                 if pause_ms > 0 and idx < (len(file_paths) - 1):

--- a/common/audio.py
+++ b/common/audio.py
@@ -1,6 +1,6 @@
 #import re, os, pyaudio, wave
 #from pydub import AudioSegment
-import re, os, pyaudio, wave, lameenc, logging
+import re, os, time, pyaudio, wave, lameenc, logging
 from pynput import keyboard
 from ctypes import *
 from common.error_handling import handle_file_error
@@ -264,7 +264,28 @@ class Audio:
             print(f"Error: {error_msg}")
             raise
 
-    def play_audio_files(self, file_paths):
+    def _sleep_interruptible(self, seconds, stop_event=None, step_seconds=0.02):
+        """Sleep for `seconds`, exiting early if stop_event is set.
+
+        Returns:
+            bool: True if full sleep completed, False if interrupted.
+        """
+        if seconds <= 0:
+            return True
+        if stop_event is None:
+            time.sleep(seconds)
+            return True
+
+        deadline = time.monotonic() + seconds
+        while True:
+            if stop_event.is_set():
+                return False
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return True
+            time.sleep(min(step_seconds, remaining))
+
+    def play_audio_files(self, file_paths, stop_event=None):
         """Play a list of audio files sequentially.
 
         Returns:
@@ -277,10 +298,35 @@ class Audio:
         failed_file = None
         error = None
 
+        pause_ms = getattr(self.config, "tts_inter_chunk_pause_ms", 0)
+        try:
+            pause_ms = int(pause_ms) if pause_ms is not None else 0
+        except Exception:
+            pause_ms = 0
+
         for idx, file_path in enumerate(file_paths):
             delete_file = True
             try:
-                self.play_audio_file(file_path)
+                if stop_event is None:
+                    self.play_audio_file(file_path)
+                else:
+                    self.play_audio_file(file_path, stop_event=stop_event)
+
+                # Optional pause between chunks to improve pacing.
+                if pause_ms > 0 and idx < (len(file_paths) - 1):
+                    completed = self._sleep_interruptible(pause_ms / 1000.0, stop_event=stop_event)
+                    if not completed:
+                        # Interrupted: clean up remaining unplayed files and stop.
+                        for remaining_file in file_paths[idx + 1:]:
+                            try:
+                                if os.path.exists(remaining_file):
+                                    os.remove(remaining_file)
+                            except OSError as cleanup_error:
+                                if self.config.debug:
+                                    logging.warning(
+                                        f"Failed to delete remaining temporary audio chunk file '{remaining_file}': {cleanup_error}"
+                                    )
+                        return False, None, None
             except Exception as e:
                 failed_file = file_path
                 error = e

--- a/common/configuration.py
+++ b/common/configuration.py
@@ -77,6 +77,9 @@ class Config:
             "voice_ack_earcon": "disabled",
             "voice_ack_earcon_freq": 600,
             "voice_ack_earcon_duration": 0.06,
+
+            # TTS pacing
+            "tts_inter_chunk_pause_ms": 0,
         }
         self.config = self.load_defaults()
         self.load_config()
@@ -165,6 +168,20 @@ class Config:
             self.voice_ack_earcon = str(voice_ack_earcon or "disabled").lower() == "enabled"
         self.voice_ack_earcon_freq = self.get("voice_ack_earcon_freq")
         self.voice_ack_earcon_duration = self.get("voice_ack_earcon_duration")
+
+        # TTS pacing
+        self.tts_inter_chunk_pause_ms = self.get("tts_inter_chunk_pause_ms")
+        if self.tts_inter_chunk_pause_ms is None:
+            self.tts_inter_chunk_pause_ms = 0
+        if isinstance(self.tts_inter_chunk_pause_ms, float) and self.tts_inter_chunk_pause_ms.is_integer():
+            self.tts_inter_chunk_pause_ms = int(self.tts_inter_chunk_pause_ms)
+        elif isinstance(self.tts_inter_chunk_pause_ms, str):
+            pause_str = self.tts_inter_chunk_pause_ms.strip()
+            try:
+                self.tts_inter_chunk_pause_ms = int(pause_str)
+            except Exception:
+                # Keep as-is for validation to catch
+                pass
 
         # Normalize common YAML representations
         if isinstance(self.voice_ack_earcon_freq, float) and self.voice_ack_earcon_freq.is_integer():
@@ -303,6 +320,9 @@ class Config:
 
             if not isinstance(self.voice_ack_earcon_duration, (int, float)) or self.voice_ack_earcon_duration <= 0:
                 errors.append("voice_ack_earcon_duration must be a positive number")
+
+        if not isinstance(self.tts_inter_chunk_pause_ms, int) or self.tts_inter_chunk_pause_ms < 0:
+            errors.append("tts_inter_chunk_pause_ms must be a non-negative integer")
 
         # Report all errors
         if errors:

--- a/common/configuration.py
+++ b/common/configuration.py
@@ -321,7 +321,7 @@ class Config:
             if not isinstance(self.voice_ack_earcon_duration, (int, float)) or self.voice_ack_earcon_duration <= 0:
                 errors.append("voice_ack_earcon_duration must be a positive number")
 
-        if not isinstance(self.tts_inter_chunk_pause_ms, int) or self.tts_inter_chunk_pause_ms < 0:
+        if isinstance(self.tts_inter_chunk_pause_ms, bool) or not isinstance(self.tts_inter_chunk_pause_ms, int) or self.tts_inter_chunk_pause_ms < 0:
             errors.append("tts_inter_chunk_pause_ms must be a non-negative integer")
 
         # Report all errors

--- a/common/wake_word.py
+++ b/common/wake_word.py
@@ -504,6 +504,7 @@ class WakeWordMode:
             threading.Thread or None: The barge-in thread if started, None otherwise
         """
         barge_in_enabled = getattr(self.config, "barge_in", False)
+
         if not barge_in_enabled or not self.porcupine:
             if barge_in_enabled and not self.porcupine:
                 if self.config.debug:
@@ -1053,6 +1054,12 @@ class WakeWordMode:
 
         barge_in_enabled = getattr(self.config, "barge_in", False)
 
+        pause_ms = getattr(self.config, "tts_inter_chunk_pause_ms", 0)
+        try:
+            pause_ms = int(pause_ms) if pause_ms is not None else 0
+        except Exception:
+            pause_ms = 0
+
         # Play TTS audio if available
         if self.tts_files and len(self.tts_files) > 0:
             # Check if barge-in thread is already running from PROCESSING state
@@ -1124,6 +1131,21 @@ class WakeWordMode:
                     except OSError as e:
                         if self.config.debug:
                             logging.warning(f"Failed to delete TTS file: {e}")
+
+                    # Optional micro-pause between chunks to improve pacing.
+                    if pause_ms > 0 and idx < (len(self.tts_files) - 1):
+                        deadline = time.monotonic() + (pause_ms / 1000.0)
+                        while time.monotonic() < deadline:
+                            if barge_in_enabled and self.barge_in_event and self.barge_in_event.is_set():
+                                if self.config.debug:
+                                    logging.info("Barge-in detected during inter-chunk pause")
+                                self._cleanup_remaining_tts_files(self.tts_files[idx + 1:])
+                                # Ensure the state transition logic below sees barge-in.
+                                break
+                            time.sleep(min(0.02, deadline - time.monotonic()))
+
+                        if barge_in_enabled and self.barge_in_event and self.barge_in_event.is_set():
+                            break
 
             except Exception as e:
                 if self.config.debug:

--- a/common/wake_word.py
+++ b/common/wake_word.py
@@ -1054,11 +1054,7 @@ class WakeWordMode:
 
         barge_in_enabled = getattr(self.config, "barge_in", False)
 
-        pause_ms = getattr(self.config, "tts_inter_chunk_pause_ms", 0)
-        try:
-            pause_ms = int(pause_ms) if pause_ms is not None else 0
-        except Exception:
-            pause_ms = 0
+        pause_ms = getattr(self.config, "tts_inter_chunk_pause_ms", 0) or 0
 
         # Play TTS audio if available
         if self.tts_files and len(self.tts_files) > 0:

--- a/common/wake_word.py
+++ b/common/wake_word.py
@@ -1142,7 +1142,7 @@ class WakeWordMode:
                                 self._cleanup_remaining_tts_files(self.tts_files[idx + 1:])
                                 # Ensure the state transition logic below sees barge-in.
                                 break
-                            time.sleep(min(0.02, deadline - time.monotonic()))
+                            time.sleep(max(0.0, min(0.02, deadline - time.monotonic())))
 
                         if barge_in_enabled and self.barge_in_event and self.barge_in_event.is_set():
                             break

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -51,6 +51,10 @@ plan/
 **Document**: [completed/16-voice-ack-earcon.md](./completed/16-voice-ack-earcon.md)
 **Description**: Play a short ack earcon once per request (after recording, before processing) to reduce perceived latency in voice mode.
 
+### Priority 18: TTS Micro-Pauses and Pacing
+**Document**: [completed/18-tts-micro-pauses-and-pacing.md](./completed/18-tts-micro-pauses-and-pacing.md)
+**Description**: Add configurable pauses between TTS chunks to make speech feel less rushed.
+
 ---
 
 ## In Progress 🚧
@@ -109,10 +113,6 @@ plan/
 ### Priority 17: Voice Lead Sentence
 **Document**: [backlog/17-voice-lead-sentence-early-ack.md](./backlog/17-voice-lead-sentence-early-ack.md)
 **Description**: Speak a one-sentence acknowledgement when processing takes long, then speak the final answer when ready.
-
-### Priority 18: TTS Micro-Pauses and Pacing
-**Document**: [backlog/18-tts-micro-pauses-and-pacing.md](./backlog/18-tts-micro-pauses-and-pacing.md)
-**Description**: Add configurable pauses between TTS chunks to make speech feel less rushed.
 
 ### Priority 20: Background Cache for Frequent Voice Queries
 **Document**: [backlog/20-background-cache-frequent-voice-queries.md](./backlog/20-background-cache-frequent-voice-queries.md)

--- a/plan/completed/18-tts-micro-pauses-and-pacing.md
+++ b/plan/completed/18-tts-micro-pauses-and-pacing.md
@@ -1,6 +1,6 @@
 # Voice UX: TTS Micro-Pauses and Pacing
 
-**Status**: 📋 Backlog
+**Status**: ✅ Completed
 **Priority**: 18
 **Platforms**: macOS M1, Raspberry Pi 3B
 
@@ -73,10 +73,10 @@ Defaults:
 
 ## Acceptance Criteria
 
-- [ ] With pause set > 0, there is a noticeable gap between chunk files
-- [ ] With pause set to 0, behavior remains unchanged
-- [ ] Barge-in can interrupt at any time (including during the pause)
-- [ ] Temporary files are still cleaned up as expected
+- [x] With pause set > 0, there is a noticeable gap between chunk files
+- [x] With pause set to 0, behavior remains unchanged
+- [x] Barge-in can interrupt at any time (including during the pause)
+- [x] Temporary files are still cleaned up as expected
 
 ---
 

--- a/tests/test_audio_playback.py
+++ b/tests/test_audio_playback.py
@@ -172,6 +172,7 @@ class TestAudioPlaybackHelpers(unittest.TestCase):
         self.assertIsNone(err)
         self.assertEqual(events[0], 'play:a.mp3')
         self.assertTrue(any(e.startswith('sleep:') for e in events))
+        self.assertIn('sleep:0.12', events)
         self.assertEqual(events[-1], 'play:b.mp3')
 
     def test_play_audio_files_skips_pause_when_disabled(self):

--- a/tests/test_audio_playback.py
+++ b/tests/test_audio_playback.py
@@ -94,7 +94,7 @@ class TestAudioPlaybackHelpers(unittest.TestCase):
 
         played = []
 
-        def _play(path):
+        def _play(path, stop_event=None):
             played.append(path)
 
         audio.play_audio_file = _play
@@ -117,7 +117,7 @@ class TestAudioPlaybackHelpers(unittest.TestCase):
         audio = self.Audio.__new__(self.Audio)
         audio.config = Mock(debug=True)
 
-        def _play(path):
+        def _play(path, stop_event=None):
             if path.endswith('b.mp3'):
                 raise RuntimeError('boom')
 
@@ -149,7 +149,7 @@ class TestAudioPlaybackHelpers(unittest.TestCase):
 
         events = []
 
-        def _play(path):
+        def _play(path, stop_event=None):
             events.append(f"play:{os.path.basename(path)}")
 
         audio.play_audio_file = _play
@@ -178,7 +178,7 @@ class TestAudioPlaybackHelpers(unittest.TestCase):
         audio = self.Audio.__new__(self.Audio)
         audio.config = Mock(debug=False, tts_inter_chunk_pause_ms=0)
 
-        audio.play_audio_file = lambda _path: None
+        audio.play_audio_file = lambda _path, stop_event=None: None
 
         f1 = os.path.join(self.temp_dir, 'a.mp3')
         f2 = os.path.join(self.temp_dir, 'b.mp3')

--- a/tests/test_audio_playback.py
+++ b/tests/test_audio_playback.py
@@ -3,6 +3,7 @@ import sys
 import types
 import unittest
 import tempfile
+import threading
 from unittest.mock import Mock, patch
 
 
@@ -141,6 +142,86 @@ class TestAudioPlaybackHelpers(unittest.TestCase):
         self.assertTrue(os.path.exists(f2))
         # c never played -> cleaned
         self.assertFalse(os.path.exists(f3))
+
+    def test_play_audio_files_pauses_between_chunks_when_enabled(self):
+        audio = self.Audio.__new__(self.Audio)
+        audio.config = Mock(debug=False, tts_inter_chunk_pause_ms=120)
+
+        events = []
+
+        def _play(path):
+            events.append(f"play:{os.path.basename(path)}")
+
+        audio.play_audio_file = _play
+
+        f1 = os.path.join(self.temp_dir, 'a.mp3')
+        f2 = os.path.join(self.temp_dir, 'b.mp3')
+        open(f1, 'wb').close()
+        open(f2, 'wb').close()
+
+        with patch('common.audio.time.sleep') as mock_sleep:
+            def sleep_side_effect(seconds):
+                events.append(f"sleep:{seconds}")
+                return None
+            mock_sleep.side_effect = sleep_side_effect
+
+            success, failed, err = self.Audio.play_audio_files(audio, [f1, f2])
+
+        self.assertTrue(success)
+        self.assertIsNone(failed)
+        self.assertIsNone(err)
+        self.assertEqual(events[0], 'play:a.mp3')
+        self.assertTrue(any(e.startswith('sleep:') for e in events))
+        self.assertEqual(events[-1], 'play:b.mp3')
+
+    def test_play_audio_files_skips_pause_when_disabled(self):
+        audio = self.Audio.__new__(self.Audio)
+        audio.config = Mock(debug=False, tts_inter_chunk_pause_ms=0)
+
+        audio.play_audio_file = lambda _path: None
+
+        f1 = os.path.join(self.temp_dir, 'a.mp3')
+        f2 = os.path.join(self.temp_dir, 'b.mp3')
+        open(f1, 'wb').close()
+        open(f2, 'wb').close()
+
+        with patch('common.audio.time.sleep') as mock_sleep:
+            success, failed, err = self.Audio.play_audio_files(audio, [f1, f2])
+
+        self.assertTrue(success)
+        self.assertIsNone(failed)
+        self.assertIsNone(err)
+        mock_sleep.assert_not_called()
+
+    def test_play_audio_files_stop_event_interrupts_during_pause(self):
+        audio = self.Audio.__new__(self.Audio)
+        audio.config = Mock(debug=False, tts_inter_chunk_pause_ms=500)
+
+        played = []
+        audio.play_audio_file = lambda path, **kwargs: played.append(os.path.basename(path))
+
+        f1 = os.path.join(self.temp_dir, 'a.mp3')
+        f2 = os.path.join(self.temp_dir, 'b.mp3')
+        open(f1, 'wb').close()
+        open(f2, 'wb').close()
+
+        stop_event = threading.Event()
+
+        # Interrupt on first sleep call
+        with patch('common.audio.time.sleep') as mock_sleep:
+            def sleep_side_effect(_seconds):
+                stop_event.set()
+                return None
+            mock_sleep.side_effect = sleep_side_effect
+
+            success, failed, err = self.Audio.play_audio_files(audio, [f1, f2], stop_event=stop_event)
+
+        self.assertFalse(success)
+        self.assertIsNone(failed)
+        self.assertIsNone(err)
+        self.assertEqual(played, ['a.mp3'])
+        self.assertFalse(os.path.exists(f1))
+        self.assertFalse(os.path.exists(f2))
 
 
 class TestMixerInitialization(unittest.TestCase):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -265,6 +265,16 @@ class TestConfigurationValidation(unittest.TestCase):
 
         self.assertIn("tts_inter_chunk_pause_ms must be a non-negative integer", str(context.exception))
 
+    def test_tts_inter_chunk_pause_ms_rejects_boolean(self):
+        self.write_config({
+            "tts_inter_chunk_pause_ms": True,
+        })
+
+        with self.assertRaises(ValueError) as context:
+            Config()
+
+        self.assertIn("tts_inter_chunk_pause_ms must be a non-negative integer", str(context.exception))
+
     def test_invalid_falsy_verbosity_values(self):
         """Test that explicitly provided falsy verbosity values still fail validation"""
         for v in ["", "   ", False]:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -242,6 +242,29 @@ class TestConfigurationValidation(unittest.TestCase):
         config = Config()
         self.assertEqual(config.voice_ack_earcon_freq, 600)
 
+    def test_tts_inter_chunk_pause_ms_accepts_integer_like_values(self):
+        self.write_config({
+            "tts_inter_chunk_pause_ms": "120",
+        })
+        config = Config()
+        self.assertEqual(config.tts_inter_chunk_pause_ms, 120)
+
+        self.write_config({
+            "tts_inter_chunk_pause_ms": 0.0,
+        })
+        config = Config()
+        self.assertEqual(config.tts_inter_chunk_pause_ms, 0)
+
+    def test_tts_inter_chunk_pause_ms_must_be_non_negative_int(self):
+        self.write_config({
+            "tts_inter_chunk_pause_ms": -1,
+        })
+
+        with self.assertRaises(ValueError) as context:
+            Config()
+
+        self.assertIn("tts_inter_chunk_pause_ms must be a non-negative integer", str(context.exception))
+
     def test_invalid_falsy_verbosity_values(self):
         """Test that explicitly provided falsy verbosity values still fail validation"""
         for v in ["", "   ", False]:

--- a/tests/test_wake_word.py
+++ b/tests/test_wake_word.py
@@ -992,6 +992,7 @@ class TestWakeWordModeResponding(unittest.TestCase):
         self.mock_config.debug = False
         self.mock_config.visual_state_indicator = False
         self.mock_config.barge_in = False
+        self.mock_config.tts_inter_chunk_pause_ms = 0
 
         self.mock_ai = Mock()
         self.mock_audio = Mock()


### PR DESCRIPTION
## Summary
- Add `tts_inter_chunk_pause_ms` config option to insert a small, natural gap between consecutive TTS chunk files.
- Apply pause in both default mode (`Audio.play_audio_files`) and wake-word TTS playback loop (interruptible by barge-in during the pause).
- Mark plan 18 as completed and add unit tests for pause/interrupt behavior.

## Config
```yaml
tts_inter_chunk_pause_ms: 120
```
(Default: `0`)

## Testing
- `./env/bin/python -m pytest -q`