### PR TITLE
Plan 39: blocking cache warmup with timeout and retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,11 +368,19 @@ cache_auto_refresh:
     interval_s: 10800       # refresh every 3 hours
 ```
 
-On startup SandVoice fetches each listed plugin immediately in a background thread (no audio played). When the scheduler is also enabled, a background task named `cache_refresh:<cache_key>` is auto-registered to repeat the refresh every `interval_s` seconds — also silent.
+On startup SandVoice fetches each listed plugin immediately in parallel background threads and waits for all of them to finish (up to `cache_warmup_timeout_s` seconds) before becoming ready. A startup message is printed while waiting and `"Ready."` is printed when done. Any thread that does not finish in time keeps running in the background. When the scheduler is also enabled, a background task named `cache_refresh:<cache_key>` is auto-registered to repeat the refresh every `interval_s` seconds — also silent.
 
 `ttl_s` and `max_stale_s` are supported by all three caching plugins (`weather`, `hacker-news`, `news`) and control the freshness of the entry written during the startup warmup. Both default to `interval_s` and `int(interval_s * 1.5)` respectively if omitted. Periodic scheduler-driven refreshes use the plugin's built-in defaults (the scheduler dispatch does not forward them).
 
 For the `news` plugin, `rss_url` overrides the `rss_news` config value and is used as the cache key discriminator — two entries with different `rss_url` values are cached independently. Entries with `rss_url`, `location`, or `unit` overrides only run the startup warmup; no periodic scheduler task is registered for them (since the scheduler cannot forward these fields to the plugin).
+
+#### Warmup tuning
+
+| Key | Default | Description |
+|---|---|---|
+| `cache_warmup_timeout_s` | `15` | Max seconds to wait for all warmup threads. Set to `0` for fire-and-forget (old behaviour). |
+| `cache_warmup_retries` | `3` | Max attempts per plugin before giving up on warmup. |
+| `cache_warmup_retry_delay_s` | `2` | Seconds between retry attempts. |
 
 > **Note**: `cache_auto_refresh` requires `cache_enabled: enabled`. If the scheduler is disabled, the startup warmup still runs but no periodic tasks are registered.
 

--- a/common/configuration.py
+++ b/common/configuration.py
@@ -283,20 +283,20 @@ class Config:
             )
             self.cache_weather_max_stale_s = self.cache_weather_ttl_s
         self.cache_auto_refresh = self._parse_cache_auto_refresh(self.get("cache_auto_refresh"))
-        try:
-            _timeout = int(self.get("cache_warmup_timeout_s"))
+        _timeout = _parse_exact_int(self.get("cache_warmup_timeout_s"))
+        if isinstance(_timeout, int) and not isinstance(_timeout, bool):
             self.cache_warmup_timeout_s = max(0, _timeout)
-        except (TypeError, ValueError):
+        else:
             self.cache_warmup_timeout_s = self.defaults["cache_warmup_timeout_s"]
-        try:
-            _retries = int(self.get("cache_warmup_retries"))
+        _retries = _parse_exact_int(self.get("cache_warmup_retries"))
+        if isinstance(_retries, int) and not isinstance(_retries, bool):
             self.cache_warmup_retries = max(0, _retries)
-        except (TypeError, ValueError):
+        else:
             self.cache_warmup_retries = self.defaults["cache_warmup_retries"]
-        try:
-            _delay = float(self.get("cache_warmup_retry_delay_s"))
-            self.cache_warmup_retry_delay_s = max(0.0, _delay)
-        except (TypeError, ValueError):
+        _delay = _parse_exact_float(self.get("cache_warmup_retry_delay_s"))
+        if isinstance(_delay, (int, float)) and not isinstance(_delay, bool):
+            self.cache_warmup_retry_delay_s = max(0.0, float(_delay))
+        else:
             self.cache_warmup_retry_delay_s = self.defaults["cache_warmup_retry_delay_s"]
 
         # Voice UX

--- a/common/configuration.py
+++ b/common/configuration.py
@@ -132,6 +132,11 @@ class Config:
             "cache_weather_max_stale_s": 21600,  # 6 hours — hard expiry
             "cache_auto_refresh": [],
 
+            # Blocking Cache Warmup (Plan 39)
+            "cache_warmup_timeout_s": 15,   # max seconds to wait for all warmup threads (0 = fire-and-forget)
+            "cache_warmup_retries": 3,       # max attempts per plugin before giving up
+            "cache_warmup_retry_delay_s": 2, # seconds between retry attempts
+
             # Task Scheduler (Plan 21)
             "scheduler_enabled": "disabled",
             "scheduler_poll_interval": 30,
@@ -278,6 +283,21 @@ class Config:
             )
             self.cache_weather_max_stale_s = self.cache_weather_ttl_s
         self.cache_auto_refresh = self._parse_cache_auto_refresh(self.get("cache_auto_refresh"))
+        try:
+            _timeout = int(self.get("cache_warmup_timeout_s"))
+            self.cache_warmup_timeout_s = max(0, _timeout)
+        except (TypeError, ValueError):
+            self.cache_warmup_timeout_s = self.defaults["cache_warmup_timeout_s"]
+        try:
+            _retries = int(self.get("cache_warmup_retries"))
+            self.cache_warmup_retries = max(0, _retries)
+        except (TypeError, ValueError):
+            self.cache_warmup_retries = self.defaults["cache_warmup_retries"]
+        try:
+            _delay = float(self.get("cache_warmup_retry_delay_s"))
+            self.cache_warmup_retry_delay_s = max(0.0, _delay)
+        except (TypeError, ValueError):
+            self.cache_warmup_retry_delay_s = self.defaults["cache_warmup_retry_delay_s"]
 
         # Voice UX
         voice_ack_earcon = self.get("voice_ack_earcon")

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -143,6 +143,11 @@ plan/
 
 ## In Progress 🚧
 
+### Priority 39: Blocking Cache Warmup with Timeout and Retries
+**Document**: [in-progress/39-blocking-cache-warmup.md](./in-progress/39-blocking-cache-warmup.md)
+**Status**: Implementation starting
+**Description**: Block SandVoice startup until `cache_auto_refresh` warmup completes (or times out), so the first user query hits cache unless warmup times out. Configurable timeout (`cache_warmup_timeout_s`, default 15s) and per-plugin retries (`cache_warmup_retries`, default 3). Prints a startup message while waiting.
+
 ### Priority 4: Wake Word Mode
 **Document**: [in-progress/04-wake-word-mode.md](./in-progress/04-wake-word-mode.md)
 **Status**: Phases 1-5 completed (macOS), Phase 6 pending (Raspberry Pi testing)
@@ -182,9 +187,6 @@ plan/
 **Document**: [backlog/37-context-aware-routing.md](./backlog/37-context-aware-routing.md)
 **Description**: Pass the last N conversation turns to `define_route` so the routing LLM can correctly resolve follow-up utterances. Fixes misrouting of clarifications (e.g. "I mean the FIFA World Cup" after a realtime_websearch query routing to `news`).
 
-### Priority 39: Blocking Cache Warmup with Timeout and Retries
-**Document**: [backlog/39-blocking-cache-warmup.md](./backlog/39-blocking-cache-warmup.md)
-**Description**: Block SandVoice startup until `cache_auto_refresh` warmup completes (or times out), so the first user query hits cache unless warmup times out. Configurable timeout (`cache_warmup_timeout_s`, default 15s) and per-plugin retries (`cache_warmup_retries`, default 3). Prints a startup message while waiting.
 
 ### Future Enhancements
 **Document**: [backlog/FUTURE.md](./backlog/FUTURE.md)

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -145,7 +145,7 @@ plan/
 
 ### Priority 39: Blocking Cache Warmup with Timeout and Retries
 **Document**: [in-progress/39-blocking-cache-warmup.md](./in-progress/39-blocking-cache-warmup.md)
-**Status**: Implementation starting
+**Status**: In progress
 **Description**: Block SandVoice startup until `cache_auto_refresh` warmup completes (or times out), so the first user query hits cache unless warmup times out. Configurable timeout (`cache_warmup_timeout_s`, default 15s) and per-plugin retries (`cache_warmup_retries`, default 3). Prints a startup message while waiting.
 
 ### Priority 4: Wake Word Mode

--- a/plan/in-progress/39-blocking-cache-warmup.md
+++ b/plan/in-progress/39-blocking-cache-warmup.md
@@ -1,6 +1,6 @@
 # Plan 39: Blocking Cache Warmup with Timeout and Retries
 
-**Status**: 📋 Backlog
+**Status**: 🚧 In Progress
 **Priority**: 39
 **Platforms**: macOS M1, Raspberry Pi 3B
 **Depends on**: Plan 20 (merged)

--- a/sandvoice.py
+++ b/sandvoice.py
@@ -540,14 +540,14 @@ class SandVoice:
                     )
 
         if warmup_threads and timeout > 0:
-            print(f"Warming up cache ({', '.join(warmup_plugin_names)})...")
+            print(f"Warming up cache ({', '.join(warmup_plugin_names)})...", flush=True)
             deadline = time.monotonic() + timeout
             for t in warmup_threads:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     break
                 t.join(timeout=remaining)
-            print("Ready.")
+            print("Ready.", flush=True)
 
     def _scheduler_speak(self, text):
         if not text or not self.config.bot_voice:

--- a/sandvoice.py
+++ b/sandvoice.py
@@ -443,48 +443,47 @@ class SandVoice:
                     "because cache_warmup_retries=%d",
                     plugin_name, retries,
                 )
-                continue
-
-            def _run_warmup(q=query, r=dict(route), pname=plugin_name,
-                            max_retries=retries, delay=retry_delay):
-                attempt = 0
-                while True:
-                    try:
-                        logger.debug(
-                            "cache_auto_refresh warmup: invoking %r (attempt %d)",
-                            pname, attempt + 1,
-                        )
-                        thread_ai = AI(self.config)
-                        resolved = resolve_plugin_route_name(r['route'], self.plugins)
-                        r['route'] = resolved
-                        ctx = _SchedulerContext(self, thread_ai)
-                        self.plugins[resolved](q, r, ctx)
-                        return
-                    except Exception as e:
-                        attempt += 1
-                        if attempt >= max_retries:
-                            logger.warning(
-                                "cache_auto_refresh warmup for plugin %r failed after "
-                                "%d attempt(s): %s",
-                                pname, attempt, e,
+            else:
+                def _run_warmup(q=query, r=dict(route), pname=plugin_name,
+                                max_retries=retries, delay=retry_delay):
+                    attempt = 0
+                    while True:
+                        try:
+                            logger.debug(
+                                "cache_auto_refresh warmup: invoking %r (attempt %d)",
+                                pname, attempt + 1,
                             )
+                            thread_ai = AI(self.config)
+                            resolved = resolve_plugin_route_name(r['route'], self.plugins)
+                            r['route'] = resolved
+                            ctx = _SchedulerContext(self, thread_ai)
+                            self.plugins[resolved](q, r, ctx)
                             return
-                        logger.debug(
-                            "cache_auto_refresh warmup for plugin %r: attempt %d failed "
-                            "(%s); retrying in %.1fs",
-                            pname, attempt, e, delay,
-                        )
-                        time.sleep(delay)
+                        except Exception as e:
+                            attempt += 1
+                            if attempt >= max_retries:
+                                logger.warning(
+                                    "cache_auto_refresh warmup for plugin %r failed after "
+                                    "%d attempt(s): %s",
+                                    pname, attempt, e,
+                                )
+                                return
+                            logger.debug(
+                                "cache_auto_refresh warmup for plugin %r: attempt %d failed "
+                                "(%s); retrying in %.1fs",
+                                pname, attempt, e, delay,
+                            )
+                            time.sleep(delay)
 
-            t = threading.Thread(
-                target=_run_warmup,
-                name=f"cache-warmup-{plugin_name}-{i}",
-                daemon=True,
-            )
-            warmup_threads.append(t)
-            warmup_plugin_names.append(plugin_name_raw)
-            t.start()
-            logger.info("cache_auto_refresh: warmup started for plugin %r", plugin_name_raw)
+                t = threading.Thread(
+                    target=_run_warmup,
+                    name=f"cache-warmup-{plugin_name}-{i}",
+                    daemon=True,
+                )
+                warmup_threads.append(t)
+                warmup_plugin_names.append(plugin_name_raw)
+                t.start()
+                logger.info("cache_auto_refresh: warmup started for plugin %r", plugin_name_raw)
 
             # Register a periodic scheduler task if the scheduler is running.
             # Tasks are re-registered every startup (config-driven, not tasks.yaml).

--- a/sandvoice.py
+++ b/sandvoice.py
@@ -437,8 +437,16 @@ class SandVoice:
             retries = self.config.cache_warmup_retries
             retry_delay = self.config.cache_warmup_retry_delay_s
 
+            if retries <= 0:
+                logger.debug(
+                    "cache_auto_refresh warmup: skipping immediate warmup for %r "
+                    "because cache_warmup_retries=%d",
+                    plugin_name, retries,
+                )
+                continue
+
             def _run_warmup(q=query, r=dict(route), pname=plugin_name,
-                            max_retries=max(1, retries), delay=retry_delay):
+                            max_retries=retries, delay=retry_delay):
                 attempt = 0
                 while True:
                     try:

--- a/sandvoice.py
+++ b/sandvoice.py
@@ -392,6 +392,10 @@ class SandVoice:
             )
             return
 
+        warmup_threads = []
+        warmup_plugin_names = []
+        timeout = self.config.cache_warmup_timeout_s
+
         for i, entry in enumerate(entries):
             plugin_name_raw = str(entry.get('plugin', '')).strip()
             plugin_name = normalize_plugin_name(plugin_name_raw)
@@ -430,24 +434,48 @@ class SandVoice:
             # Each thread gets its own AI instance to avoid conversation-history
             # races: AI.generate_response() mutates self.conversation_history and
             # sharing a single instance across concurrent threads is not thread-safe.
-            def _run_warmup(q=query, r=dict(route), pname=plugin_name):
-                try:
-                    logger.debug("cache_auto_refresh warmup: invoking %r", pname)
-                    thread_ai = AI(self.config)
-                    resolved = resolve_plugin_route_name(r['route'], self.plugins)
-                    r['route'] = resolved
-                    ctx = _SchedulerContext(self, thread_ai)
-                    self.plugins[resolved](q, r, ctx)
-                except Exception as e:
-                    logger.warning(
-                        "cache_auto_refresh warmup error for plugin %r: %s", pname, e
-                    )
+            retries = self.config.cache_warmup_retries
+            retry_delay = self.config.cache_warmup_retry_delay_s
 
-            threading.Thread(
+            def _run_warmup(q=query, r=dict(route), pname=plugin_name,
+                            max_retries=retries, delay=retry_delay):
+                attempt = 0
+                while True:
+                    try:
+                        logger.debug(
+                            "cache_auto_refresh warmup: invoking %r (attempt %d)",
+                            pname, attempt + 1,
+                        )
+                        thread_ai = AI(self.config)
+                        resolved = resolve_plugin_route_name(r['route'], self.plugins)
+                        r['route'] = resolved
+                        ctx = _SchedulerContext(self, thread_ai)
+                        self.plugins[resolved](q, r, ctx)
+                        return
+                    except Exception as e:
+                        attempt += 1
+                        if attempt >= max_retries:
+                            logger.warning(
+                                "cache_auto_refresh warmup for plugin %r failed after "
+                                "%d attempt(s): %s",
+                                pname, attempt, e,
+                            )
+                            return
+                        logger.debug(
+                            "cache_auto_refresh warmup for plugin %r: attempt %d failed "
+                            "(%s); retrying in %.1fs",
+                            pname, attempt, e, delay,
+                        )
+                        time.sleep(delay)
+
+            t = threading.Thread(
                 target=_run_warmup,
                 name=f"cache-warmup-{plugin_name}-{i}",
                 daemon=True,
-            ).start()
+            )
+            warmup_threads.append(t)
+            warmup_plugin_names.append(plugin_name_raw)
+            t.start()
             logger.info("cache_auto_refresh: warmup started for plugin %r", plugin_name_raw)
 
             # Register a periodic scheduler task if the scheduler is running.
@@ -503,6 +531,16 @@ class SandVoice:
                     logger.warning(
                         "cache_auto_refresh: failed to register task %r: %s", task_name, e
                     )
+
+        if warmup_threads and timeout > 0:
+            print(f"Warming up cache ({', '.join(warmup_plugin_names)})...")
+            deadline = time.monotonic() + timeout
+            for t in warmup_threads:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                t.join(timeout=remaining)
+            print("Ready.")
 
     def _scheduler_speak(self, text):
         if not text or not self.config.bot_voice:

--- a/sandvoice.py
+++ b/sandvoice.py
@@ -438,7 +438,7 @@ class SandVoice:
             retry_delay = self.config.cache_warmup_retry_delay_s
 
             def _run_warmup(q=query, r=dict(route), pname=plugin_name,
-                            max_retries=retries, delay=retry_delay):
+                            max_retries=max(1, retries), delay=retry_delay):
                 attempt = 0
                 while True:
                     try:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1202,6 +1202,31 @@ class TestCacheWarmupConfig(_TempHomeBase):
         config = Config()
         self.assertAlmostEqual(config.cache_warmup_retry_delay_s, 2.0)
 
+    def test_bool_timeout_falls_back_to_default(self):
+        self.write_config({"cache_warmup_timeout_s": True})
+        config = Config()
+        self.assertEqual(config.cache_warmup_timeout_s, 15)
+
+    def test_bool_retries_falls_back_to_default(self):
+        self.write_config({"cache_warmup_retries": True})
+        config = Config()
+        self.assertEqual(config.cache_warmup_retries, 3)
+
+    def test_bool_retry_delay_falls_back_to_default(self):
+        self.write_config({"cache_warmup_retry_delay_s": True})
+        config = Config()
+        self.assertAlmostEqual(config.cache_warmup_retry_delay_s, 2.0)
+
+    def test_nan_retry_delay_falls_back_to_default(self):
+        self.write_config({"cache_warmup_retry_delay_s": ".nan"})
+        config = Config()
+        self.assertAlmostEqual(config.cache_warmup_retry_delay_s, 2.0)
+
+    def test_inf_retry_delay_falls_back_to_default(self):
+        self.write_config({"cache_warmup_retry_delay_s": ".inf"})
+        config = Config()
+        self.assertAlmostEqual(config.cache_warmup_retry_delay_s, 2.0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1132,5 +1132,76 @@ class TestCacheAutoRefreshConfig(_TempHomeBase):
         self.assertEqual(config.cache_auto_refresh[0]["max_stale_s"], int(7200 * 1.5))
 
 
+class TestCacheWarmupConfig(_TempHomeBase):
+    """cache_warmup_timeout_s, cache_warmup_retries, cache_warmup_retry_delay_s defaults and validation."""
+
+    def test_defaults(self):
+        self.write_config({})
+        config = Config()
+        self.assertEqual(config.cache_warmup_timeout_s, 15)
+        self.assertEqual(config.cache_warmup_retries, 3)
+        self.assertAlmostEqual(config.cache_warmup_retry_delay_s, 2.0)
+
+    def test_custom_timeout(self):
+        self.write_config({"cache_warmup_timeout_s": 30})
+        config = Config()
+        self.assertEqual(config.cache_warmup_timeout_s, 30)
+
+    def test_timeout_zero_allowed(self):
+        self.write_config({"cache_warmup_timeout_s": 0})
+        config = Config()
+        self.assertEqual(config.cache_warmup_timeout_s, 0)
+
+    def test_negative_timeout_clamped_to_zero(self):
+        self.write_config({"cache_warmup_timeout_s": -5})
+        config = Config()
+        self.assertEqual(config.cache_warmup_timeout_s, 0)
+
+    def test_invalid_timeout_falls_back_to_default(self):
+        self.write_config({"cache_warmup_timeout_s": "bad"})
+        config = Config()
+        self.assertEqual(config.cache_warmup_timeout_s, 15)
+
+    def test_custom_retries(self):
+        self.write_config({"cache_warmup_retries": 5})
+        config = Config()
+        self.assertEqual(config.cache_warmup_retries, 5)
+
+    def test_retries_zero_allowed(self):
+        self.write_config({"cache_warmup_retries": 0})
+        config = Config()
+        self.assertEqual(config.cache_warmup_retries, 0)
+
+    def test_negative_retries_clamped_to_zero(self):
+        self.write_config({"cache_warmup_retries": -1})
+        config = Config()
+        self.assertEqual(config.cache_warmup_retries, 0)
+
+    def test_invalid_retries_falls_back_to_default(self):
+        self.write_config({"cache_warmup_retries": "bad"})
+        config = Config()
+        self.assertEqual(config.cache_warmup_retries, 3)
+
+    def test_custom_retry_delay(self):
+        self.write_config({"cache_warmup_retry_delay_s": 5.0})
+        config = Config()
+        self.assertAlmostEqual(config.cache_warmup_retry_delay_s, 5.0)
+
+    def test_retry_delay_zero_allowed(self):
+        self.write_config({"cache_warmup_retry_delay_s": 0})
+        config = Config()
+        self.assertAlmostEqual(config.cache_warmup_retry_delay_s, 0.0)
+
+    def test_negative_retry_delay_clamped_to_zero(self):
+        self.write_config({"cache_warmup_retry_delay_s": -1})
+        config = Config()
+        self.assertAlmostEqual(config.cache_warmup_retry_delay_s, 0.0)
+
+    def test_invalid_retry_delay_falls_back_to_default(self):
+        self.write_config({"cache_warmup_retry_delay_s": "bad"})
+        config = Config()
+        self.assertAlmostEqual(config.cache_warmup_retry_delay_s, 2.0)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1526,17 +1526,23 @@ class TestWarmupCache(unittest.TestCase):
             _time.sleep(0.01)  # longer than the timeout budget
             join_calls.append(timeout)
 
-        mock_thread = MagicMock()
-        mock_thread.join.side_effect = slow_join
+        created_threads = []
+
+        def make_mock_thread(*args, **kwargs):
+            t = MagicMock()
+            t.join.side_effect = slow_join
+            created_threads.append(t)
+            return t
 
         with patch("sandvoice._derive_cache_key", return_value="news:key"), \
-             patch("sandvoice.threading.Thread", return_value=mock_thread):
+             patch("sandvoice.threading.Thread", side_effect=make_mock_thread):
             sv._warmup_cache()
 
         # At least one join was attempted before the timeout budget was exhausted.
         self.assertGreaterEqual(len(join_calls), 1)
-        # Multiple warmup threads were started; not all necessarily finished.
-        self.assertGreaterEqual(mock_thread.start.call_count, 2)
+        # Two distinct thread objects were created and each started once.
+        self.assertEqual(len(created_threads), 2)
+        self.assertTrue(all(t.start.call_count == 1 for t in created_threads))
 
     def test_warmup_timeout_zero_fires_and_forgets(self):
         """When cache_warmup_timeout_s is 0, threads are started but never joined."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1493,8 +1493,6 @@ class TestWarmupCache(unittest.TestCase):
 
     def test_warmup_blocks_until_threads_finish(self):
         """When timeout > 0, _warmup_cache() must join all warmup threads."""
-        import threading as _threading
-
         sv = self._make_stub(warmup_timeout=5)
         sv.plugins["news"] = MagicMock(return_value=None)
         sv.config.cache_auto_refresh = [

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1603,17 +1603,16 @@ class TestWarmupCache(unittest.TestCase):
             call_count.append(1)
             raise RuntimeError("always fails")
 
-        sv = self._make_stub(warmup_timeout=0, warmup_retries=3, warmup_retry_delay=0.0)
+        # Use a positive timeout so _warmup_cache() joins the thread before
+        # returning, guaranteeing the WARNING is captured inside assertLogs.
+        sv = self._make_stub(warmup_timeout=5, warmup_retries=3, warmup_retry_delay=0.0)
         sv.plugins["news"] = always_failing_plugin
         sv.config.cache_auto_refresh = [
             {"plugin": "news", "interval_s": 7200, "ttl_s": 7200, "max_stale_s": 10800, "query": "news"},
         ]
 
-        threads = []
-
         def real_thread(target, name, daemon):
             t = _RealThread(target=target, name=name, daemon=daemon)
-            threads.append(t)
             return t
 
         with patch("sandvoice._derive_cache_key", return_value="news:key"), \
@@ -1623,9 +1622,6 @@ class TestWarmupCache(unittest.TestCase):
              patch("sandvoice.threading.Thread", side_effect=real_thread), \
              self.assertLogs("sandvoice", level="WARNING") as cm:
             sv._warmup_cache()
-
-        for t in threads:
-            t.join(timeout=5)
 
         self.assertEqual(len(call_count), 3)
         self.assertTrue(any("failed after" in line for line in cm.output))

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1381,12 +1381,16 @@ class TestResolveTz(unittest.TestCase):
 class TestWarmupCache(unittest.TestCase):
     """Tests for SandVoice._warmup_cache()."""
 
-    def _make_stub(self, cache_auto_refresh=None, cache_enabled=True, scheduler=None):
+    def _make_stub(self, cache_auto_refresh=None, cache_enabled=True, scheduler=None,
+                   warmup_timeout=0, warmup_retries=1, warmup_retry_delay=0.0):
         from sandvoice import SandVoice
         sv = object.__new__(SandVoice)
         sv.config = MagicMock()
         sv.config.cache_enabled = cache_enabled
         sv.config.cache_auto_refresh = cache_auto_refresh or []
+        sv.config.cache_warmup_timeout_s = warmup_timeout
+        sv.config.cache_warmup_retries = warmup_retries
+        sv.config.cache_warmup_retry_delay_s = warmup_retry_delay
         sv.cache = MagicMock() if cache_enabled else None
         sv.scheduler = scheduler
         sv.plugins = {}
@@ -1486,6 +1490,145 @@ class TestWarmupCache(unittest.TestCase):
             sv._warmup_cache()
 
         mock_scheduler.add_task.assert_not_called()
+
+    def test_warmup_blocks_until_threads_finish(self):
+        """When timeout > 0, _warmup_cache() must join all warmup threads."""
+        import threading as _threading
+
+        sv = self._make_stub(warmup_timeout=5)
+        sv.plugins["news"] = MagicMock(return_value=None)
+        sv.config.cache_auto_refresh = [
+            {"plugin": "news", "interval_s": 7200, "ttl_s": 7200, "max_stale_s": 10800, "query": "news"},
+        ]
+
+        join_called = []
+        mock_thread = MagicMock()
+        mock_thread.join.side_effect = lambda timeout: join_called.append(timeout)
+
+        with patch("sandvoice._derive_cache_key", return_value="news:key"), \
+             patch("sandvoice.threading.Thread", return_value=mock_thread):
+            sv._warmup_cache()
+
+        self.assertTrue(len(join_called) == 1)
+        self.assertGreater(join_called[0], 0)
+
+    def test_warmup_continues_after_timeout(self):
+        """When the timeout budget is exhausted, remaining threads are not joined."""
+        sv = self._make_stub(warmup_timeout=0.001)  # 1ms — will expire almost immediately
+        sv.plugins["news"] = MagicMock(return_value=None)
+        sv.config.cache_auto_refresh = [
+            {"plugin": "news", "interval_s": 7200, "ttl_s": 7200, "max_stale_s": 10800, "query": "news 1"},
+            {"plugin": "news", "interval_s": 3600, "ttl_s": 3600, "max_stale_s": 5400, "query": "news 2"},
+        ]
+
+        join_calls = []
+
+        def slow_join(timeout):
+            import time as _time
+            _time.sleep(0.01)  # longer than the timeout budget
+            join_calls.append(timeout)
+
+        mock_thread = MagicMock()
+        mock_thread.join.side_effect = slow_join
+
+        with patch("sandvoice._derive_cache_key", return_value="news:key"), \
+             patch("sandvoice.threading.Thread", return_value=mock_thread):
+            sv._warmup_cache()
+
+        # At least one thread was attempted; not all necessarily finished
+        self.assertGreaterEqual(mock_thread.start.call_count, 2)
+
+    def test_warmup_timeout_zero_fires_and_forgets(self):
+        """When cache_warmup_timeout_s is 0, threads are started but never joined."""
+        sv = self._make_stub(warmup_timeout=0)
+        sv.plugins["news"] = MagicMock(return_value=None)
+        sv.config.cache_auto_refresh = [
+            {"plugin": "news", "interval_s": 7200, "ttl_s": 7200, "max_stale_s": 10800, "query": "news"},
+        ]
+
+        mock_thread = MagicMock()
+
+        with patch("sandvoice._derive_cache_key", return_value="news:key"), \
+             patch("sandvoice.threading.Thread", return_value=mock_thread):
+            sv._warmup_cache()
+
+        mock_thread.start.assert_called_once()
+        mock_thread.join.assert_not_called()
+
+    def test_warmup_retries_on_failure(self):
+        """Plugin raises on first call, succeeds on second; must be called twice."""
+        import threading as _threading
+        _RealThread = _threading.Thread
+
+        call_count = []
+
+        def flaky_plugin(query, route, ctx):
+            call_count.append(1)
+            if len(call_count) == 1:
+                raise RuntimeError("transient failure")
+
+        sv = self._make_stub(warmup_timeout=0, warmup_retries=3, warmup_retry_delay=0.0)
+        sv.plugins["news"] = flaky_plugin
+        sv.config.cache_auto_refresh = [
+            {"plugin": "news", "interval_s": 7200, "ttl_s": 7200, "max_stale_s": 10800, "query": "news"},
+        ]
+
+        threads = []
+
+        def real_thread(target, name, daemon):
+            t = _RealThread(target=target, name=name, daemon=daemon)
+            threads.append(t)
+            return t
+
+        with patch("sandvoice._derive_cache_key", return_value="news:key"), \
+             patch("sandvoice.AI"), \
+             patch("sandvoice.resolve_plugin_route_name", return_value="news"), \
+             patch("sandvoice._SchedulerContext"), \
+             patch("sandvoice.threading.Thread", side_effect=real_thread):
+            sv._warmup_cache()
+
+        for t in threads:
+            t.join(timeout=5)
+
+        self.assertEqual(len(call_count), 2)
+
+    def test_warmup_gives_up_after_max_retries(self):
+        """Plugin always raises; must be called cache_warmup_retries times, then WARNING logged."""
+        import threading as _threading
+        _RealThread = _threading.Thread
+
+        call_count = []
+
+        def always_failing_plugin(query, route, ctx):
+            call_count.append(1)
+            raise RuntimeError("always fails")
+
+        sv = self._make_stub(warmup_timeout=0, warmup_retries=3, warmup_retry_delay=0.0)
+        sv.plugins["news"] = always_failing_plugin
+        sv.config.cache_auto_refresh = [
+            {"plugin": "news", "interval_s": 7200, "ttl_s": 7200, "max_stale_s": 10800, "query": "news"},
+        ]
+
+        threads = []
+
+        def real_thread(target, name, daemon):
+            t = _RealThread(target=target, name=name, daemon=daemon)
+            threads.append(t)
+            return t
+
+        with patch("sandvoice._derive_cache_key", return_value="news:key"), \
+             patch("sandvoice.AI"), \
+             patch("sandvoice.resolve_plugin_route_name", return_value="news"), \
+             patch("sandvoice._SchedulerContext"), \
+             patch("sandvoice.threading.Thread", side_effect=real_thread), \
+             self.assertLogs("sandvoice", level="WARNING") as cm:
+            sv._warmup_cache()
+
+        for t in threads:
+            t.join(timeout=5)
+
+        self.assertEqual(len(call_count), 3)
+        self.assertTrue(any("failed after" in line for line in cm.output))
 
 
 if __name__ == "__main__":

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1535,7 +1535,9 @@ class TestWarmupCache(unittest.TestCase):
              patch("sandvoice.threading.Thread", return_value=mock_thread):
             sv._warmup_cache()
 
-        # At least one thread was attempted; not all necessarily finished
+        # At least one join was attempted before the timeout budget was exhausted.
+        self.assertGreaterEqual(len(join_calls), 1)
+        # Multiple warmup threads were started; not all necessarily finished.
         self.assertGreaterEqual(mock_thread.start.call_count, 2)
 
     def test_warmup_timeout_zero_fires_and_forgets(self):


### PR DESCRIPTION
## Summary

- `_warmup_cache()` now joins all warmup threads with a wall-clock budget (`cache_warmup_timeout_s`, default 15s) before startup continues
- Each warmup thread retries the plugin call up to `cache_warmup_retries` (default 3) times on failure, with `cache_warmup_retry_delay_s` (default 2s) between attempts
- Prints `"Warming up cache (plugins)..."` before the join loop and `"Ready."` after
- `cache_warmup_timeout_s: 0` preserves the old fire-and-forget behaviour

## Config

| Key | Default | Description |
|---|---|---|
| `cache_warmup_timeout_s` | `15` | Max seconds to wait for all warmup threads (0 = fire-and-forget) |
| `cache_warmup_retries` | `3` | Max attempts per plugin before giving up |
| `cache_warmup_retry_delay_s` | `2` | Seconds between retry attempts |

## Test plan

- [x] `test_warmup_blocks_until_threads_finish` — threads complete before timeout; join is called with positive remaining budget
- [x] `test_warmup_continues_after_timeout` — threads take longer than budget; main continues regardless
- [x] `test_warmup_timeout_zero_fires_and_forgets` — timeout=0 starts threads but never calls join
- [x] `test_warmup_retries_on_failure` — plugin raises on first call, succeeds on second; called twice
- [x] `test_warmup_gives_up_after_max_retries` — plugin always raises; called 3 times, WARNING logged
- [x] Config tests: defaults, custom values, negative values clamped to 0, invalid values fall back to defaults
- [x] Full suite: 842 tests passing