### PR TITLE
Add plans 41-43: provider abstraction layer

### DIFF
--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -191,6 +191,18 @@ plan/
 **Description**: Pass the last N conversation turns to `define_route` so the routing LLM can correctly resolve follow-up utterances. Fixes misrouting of clarifications (e.g. "I mean the FIFA World Cup" after a realtime_websearch query routing to `news`).
 
 
+### Priority 41: Provider Interface ABCs
+**Document**: [backlog/41-provider-abcs.md](./backlog/41-provider-abcs.md)
+**Description**: Define `LLMProvider`, `TTSProvider`, and `STTProvider` abstract base classes in `common/providers/base.py`. Purely additive — no existing code changed. Foundation for Plans 42 and 43.
+
+### Priority 42: OpenAI Provider Implementations
+**Document**: [backlog/42-openai-provider-implementations.md](./backlog/42-openai-provider-implementations.md)
+**Description**: Implement `OpenAILLMProvider`, `OpenAITTSProvider`, and `OpenAISTTProvider` in `common/providers/`. Logic moved from `AI` class; `AI` is unchanged in this plan. Requires Plan 41.
+
+### Priority 43: AI Facade Migration
+**Document**: [backlog/43-ai-facade-migration.md](./backlog/43-ai-facade-migration.md)
+**Description**: Refactor `AI` into a thin facade: owns `conversation_history`, delegates capabilities to provider instances, and exposes `AI.from_config(config)` factory. Adds `llm_provider`, `tts_provider`, `stt_provider` config keys (all default to `openai`). All call sites unchanged. Requires Plans 41 and 42.
+
 ### Future Enhancements
 **Document**: [backlog/FUTURE.md](./backlog/FUTURE.md)
 **Description**: Long-term feature ideas including API Cost Management, Conversation History Management, Code Deduplication, Timers & Reminders, Music Control, Smart Home Integration, Calendar Integration, Todo List Management, Multi-User Support, and Conversation Memory.

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -201,7 +201,7 @@ plan/
 
 ### Priority 43: AI Facade Migration
 **Document**: [backlog/43-ai-facade-migration.md](./backlog/43-ai-facade-migration.md)
-**Description**: Refactor `AI` into a thin facade: owns `conversation_history`, delegates capabilities to provider instances, and exposes `AI.from_config(config)` factory. Adds `llm_provider`, `tts_provider`, `stt_provider` config keys (all default to `openai`). All call sites unchanged. Requires Plans 41 and 42.
+**Description**: Refactor `AI` into a thin facade: owns `conversation_history`, delegates capabilities to provider instances, and exposes `AI.from_config(config)` factory. Adds `llm_provider`, `tts_provider`, `stt_provider` config keys (all default to `openai`). Runtime method call sites (`generate_response`, `text_to_speech`, etc.) remain unchanged; only construction changes to `AI.from_config(config)`. Requires Plans 41 and 42.
 
 ### Future Enhancements
 **Document**: [backlog/FUTURE.md](./backlog/FUTURE.md)

--- a/plan/backlog/41-provider-abcs.md
+++ b/plan/backlog/41-provider-abcs.md
@@ -1,0 +1,100 @@
+# Plan 41: Provider Interface ABCs
+
+## Problem
+
+`common/ai.py` wraps OpenAI directly — `openai.OpenAI` is the only client ever
+instantiated. Every capability (text generation, TTS, STT) shares a single class and
+a single provider. Swapping any one capability for a different service (e.g. a local
+TTS engine on the Pi, a self-hosted STT model, an alternative LLM) requires forking the
+entire `AI` class rather than replacing one component.
+
+## Goal
+
+Define three abstract base classes that describe the capability contracts for LLM, TTS,
+and STT. No existing code is changed in this plan — the ABCs are additive. Future plans
+implement these interfaces and wire them into `AI`.
+
+## Approach
+
+### New module: `common/providers/base.py`
+
+Three ABCs, one per capability:
+
+```python
+from abc import ABC, abstractmethod
+
+class LLMProvider(ABC):
+    @abstractmethod
+    def generate_response(self, user_input, conversation_history, extra_info=None, model=None):
+        """Return a response object with a `.content` attribute (str)."""
+
+    @abstractmethod
+    def stream_response_deltas(self, user_input, conversation_history, extra_info=None, model=None):
+        """Yield str deltas from the LLM stream."""
+
+    @abstractmethod
+    def define_route(self, user_input, model=None, extra_routes=None):
+        """Return a route dict: {"route": str, "reason": str}."""
+
+    @abstractmethod
+    def text_summary(self, user_input, extra_info=None, words="100", model=None):
+        """Return a summary dict: {"title": str, "text": str}."""
+
+
+class TTSProvider(ABC):
+    @abstractmethod
+    def text_to_speech(self, text, model=None, voice=None) -> list:
+        """Convert text to audio. Return a list of audio file paths (str)."""
+
+
+class STTProvider(ABC):
+    @abstractmethod
+    def transcribe(self, audio_file_path, model=None) -> str:
+        """Transcribe audio file to text. Return the transcript string."""
+```
+
+### New file: `common/providers/__init__.py`
+
+Export the three ABCs for clean imports:
+
+```python
+from common.providers.base import LLMProvider, TTSProvider, STTProvider
+
+__all__ = ["LLMProvider", "TTSProvider", "STTProvider"]
+```
+
+### Conversation history ownership
+
+`LLMProvider` methods receive `conversation_history` as a parameter — the list is owned
+by the caller (`AI` in Plan 43), not by the provider. This allows:
+
+- Providers to remain stateless (no `self.conversation_history`)
+- Swapping providers mid-session without losing history
+- Scheduler to pass an isolated history (or empty list) without affecting interactive history
+
+### Notes on the `generate_response` return type
+
+The current `AI.generate_response` returns either a `completion.choices[0].message`
+object (OpenAI SDK) or a `SimpleNamespace(content=...)`, both accessed via `.content`.
+The ABC codifies `.content` as the contract — providers must return an object with a
+string `.content` attribute, or a plain `SimpleNamespace`.
+
+## Acceptance Criteria
+
+- [ ] `common/providers/__init__.py` and `common/providers/base.py` exist
+- [ ] `LLMProvider`, `TTSProvider`, `STTProvider` are importable from `common.providers`
+- [ ] All three classes are ABCs: instantiating without implementing all abstract methods
+      raises `TypeError`
+- [ ] Tests cover ABC enforcement for each class
+- [ ] No existing files are modified
+- [ ] Coverage >80% for the new module
+
+## Dependencies
+
+None — this plan is purely additive.
+
+## Notes
+
+- Keep `base.py` minimal: only the interface, no helper code
+- Do not add provider-specific imports to `base.py`
+- Plan 42 implements the OpenAI providers; Plan 43 wires them into `AI`

--- a/plan/backlog/41-provider-abcs.md
+++ b/plan/backlog/41-provider-abcs.md
@@ -49,8 +49,12 @@ class TTSProvider(ABC):
 
 class STTProvider(ABC):
     @abstractmethod
-    def transcribe(self, audio_file_path, model=None) -> str:
-        """Transcribe audio file to text. Return the transcript string."""
+    def transcribe(self, audio_file_path=None, model=None) -> str:
+        """Transcribe audio file to text.
+
+        If `audio_file_path` is None, use the configured temporary recording path.
+        Return the transcript string.
+        """
 ```
 
 ### New file: `common/providers/__init__.py`

--- a/plan/backlog/42-openai-provider-implementations.md
+++ b/plan/backlog/42-openai-provider-implementations.md
@@ -1,0 +1,132 @@
+# Plan 42: OpenAI Provider Implementations
+
+## Problem
+
+Plan 41 defines the three provider ABCs. This plan implements them for OpenAI — moving
+the existing logic from `AI` into dedicated provider classes. The `AI` class is **not
+changed** in this plan; the new providers coexist with the existing class and are not
+yet wired in. This keeps the PR small and reviewable independently.
+
+## Goal
+
+Create `OpenAILLMProvider`, `OpenAITTSProvider`, and `OpenAISTTProvider` — each
+implementing the matching ABC from Plan 41. All OpenAI-specific logic lives in these
+classes after this plan; Plan 43 removes the duplicate from `AI`.
+
+## Approach
+
+### `common/providers/openai_llm.py` — `OpenAILLMProvider`
+
+Implements `LLMProvider`. Receives `openai_client` and `config` in `__init__`.
+
+**Key differences from the current `AI` methods:**
+
+- No `self.conversation_history` — history is passed in as a parameter to each method.
+  Methods do not mutate the list; the caller (`AI` in Plan 43) appends turns.
+- `generate_response` and `stream_response_deltas` build the system prompt internally
+  (same logic as today). The verbosity instruction and system role template move here.
+- `define_route` reads `routes.yaml` path from config (same as today).
+- `text_summary` is unchanged in logic.
+
+```python
+class OpenAILLMProvider(LLMProvider):
+    def __init__(self, openai_client, config):
+        self._client = openai_client
+        self._config = config
+
+    def generate_response(self, user_input, conversation_history, extra_info=None, model=None):
+        ...
+
+    def stream_response_deltas(self, user_input, conversation_history, extra_info=None, model=None):
+        ...
+
+    def define_route(self, user_input, model=None, extra_routes=None):
+        ...
+
+    def text_summary(self, user_input, extra_info=None, words="100", model=None):
+        ...
+```
+
+### `common/providers/openai_tts.py` — `OpenAITTSProvider`
+
+Implements `TTSProvider`. Receives `openai_client` and `config`.
+
+Logic moved verbatim from `AI._generate_tts_files` and `AI.text_to_speech`. The
+`@retry_with_backoff` decorator stays on `_generate_tts_files`.
+
+```python
+class OpenAITTSProvider(TTSProvider):
+    def __init__(self, openai_client, config):
+        self._client = openai_client
+        self._config = config
+
+    def text_to_speech(self, text, model=None, voice=None) -> list:
+        ...
+
+    @retry_with_backoff(max_attempts=3, initial_delay=1)
+    def _generate_tts_files(self, text, model, voice):
+        ...
+```
+
+### `common/providers/openai_stt.py` — `OpenAISTTProvider`
+
+Implements `STTProvider`. Receives `openai_client` and `config`.
+
+`transcribe_and_translate` is renamed to `transcribe` to match the ABC. All existing
+logic (task=transcribe/translate, language_hint, translate_provider, translate_model)
+is preserved unchanged.
+
+```python
+class OpenAISTTProvider(STTProvider):
+    def __init__(self, openai_client, config):
+        self._client = openai_client
+        self._config = config
+
+    @retry_with_backoff(max_attempts=3, initial_delay=1)
+    def transcribe(self, audio_file_path=None, model=None) -> str:
+        ...
+```
+
+### `common/providers/__init__.py` — updated
+
+Add the OpenAI implementations to the module exports:
+
+```python
+from common.providers.base import LLMProvider, TTSProvider, STTProvider
+from common.providers.openai_llm import OpenAILLMProvider
+from common.providers.openai_tts import OpenAITTSProvider
+from common.providers.openai_stt import OpenAISTTProvider
+
+__all__ = [
+    "LLMProvider", "TTSProvider", "STTProvider",
+    "OpenAILLMProvider", "OpenAITTSProvider", "OpenAISTTProvider",
+]
+```
+
+### `common/ai.py` — unchanged
+
+The existing `AI` class continues to work as before. The providers exist in parallel.
+Duplication is intentional and temporary — Plan 43 removes it.
+
+## Acceptance Criteria
+
+- [ ] `OpenAILLMProvider`, `OpenAITTSProvider`, `OpenAISTTProvider` each implement their
+      ABC without `TypeError`
+- [ ] Provider classes are importable from `common.providers`
+- [ ] No existing files are modified
+- [ ] Full test coverage (>80%) for all three provider classes using mocked `openai_client`
+- [ ] Tests verify that conversation history is not mutated by provider methods
+- [ ] Existing `tests/test_ai.py` suite still passes unchanged
+
+## Dependencies
+
+- Plan 41 merged
+
+## Notes
+
+- Do not add `OPENAI_API_KEY` validation inside providers — that belongs in the factory
+  (`AI.from_config`) in Plan 43
+- Retry decorator stays on the methods where it lives today
+- `split_text_for_tts`, `pop_streaming_chunk`, `ErrorMessage`, `_normalize_route_response`,
+  and `normalize_route_name` remain in `common/ai.py` for now; Plan 43 decides whether
+  to move or import them

--- a/plan/backlog/42-openai-provider-implementations.md
+++ b/plan/backlog/42-openai-provider-implementations.md
@@ -113,7 +113,8 @@ Duplication is intentional and temporary — Plan 43 removes it.
 - [ ] `OpenAILLMProvider`, `OpenAITTSProvider`, `OpenAISTTProvider` each implement their
       ABC without `TypeError`
 - [ ] Provider classes are importable from `common.providers`
-- [ ] No existing files are modified
+- [ ] No existing runtime code paths are modified; only `common/providers/__init__.py`
+      (introduced in Plan 41) is updated to export the new provider classes
 - [ ] Full test coverage (>80%) for all three provider classes using mocked `openai_client`
 - [ ] Tests verify that conversation history is not mutated by provider methods
 - [ ] Existing `tests/test_ai.py` suite still passes unchanged

--- a/plan/backlog/43-ai-facade-migration.md
+++ b/plan/backlog/43-ai-facade-migration.md
@@ -8,8 +8,10 @@ class, which still owns all the logic directly. This plan completes the migratio
 to provider instances, and exposes a factory (`AI.from_config`) that reads config to
 pick and instantiate the right providers.
 
-All call sites (`sandvoice.py`, `wake_word.py`, plugins, scheduler) remain unchanged —
-`s.ai.generate_response(...)` still works.
+Runtime method call sites (`sandvoice.py`, `wake_word.py`, plugins, scheduler) remain
+unchanged — `s.ai.generate_response(...)` still works. The only change to entry points
+is construction: `sandvoice.py` and `wake_word.py` switch from `AI(config)` to
+`AI.from_config(config)`.
 
 ## Goal
 

--- a/plan/backlog/43-ai-facade-migration.md
+++ b/plan/backlog/43-ai-facade-migration.md
@@ -143,7 +143,9 @@ Helpers that are not provider-specific remain in `ai.py`:
 - [ ] All existing tests pass; `test_ai.py` updated to use `AI(llm, tts, stt, config)`
       direct constructor with mock providers
 - [ ] Coverage >80% for updated `ai.py`
-- [ ] No OpenAI-specific code remains in `AI` (only in provider classes)
+- [ ] No OpenAI-specific code in `AI` instance methods; `AI.from_config` is the
+      intentional provider wiring point and may contain OpenAI client construction
+      (via `_build_*_provider` helpers) — that is by design, not a violation
 
 ## Dependencies
 
@@ -152,7 +154,7 @@ Helpers that are not provider-specific remain in `ai.py`:
 
 ## Notes
 
-- `_SchedulerContext` in `scheduler.py` creates its own `AI` instance — it should also
+- `_SchedulerContext` in `sandvoice.py` creates its own `AI` instance — it should also
   call `AI.from_config`; verify it still passes an isolated `conversation_history`
   (it does, because history is now on `AI`, not shared between instances)
 - Keep `transcribe_and_translate` as the public name on `AI` to avoid touching all

--- a/plan/backlog/43-ai-facade-migration.md
+++ b/plan/backlog/43-ai-facade-migration.md
@@ -1,0 +1,159 @@
+# Plan 43: AI Facade Migration
+
+## Problem
+
+After Plans 41 and 42, three OpenAI provider classes exist alongside the original `AI`
+class, which still owns all the logic directly. This plan completes the migration:
+`AI` becomes a thin facade that owns conversation history, delegates all capability calls
+to provider instances, and exposes a factory (`AI.from_config`) that reads config to
+pick and instantiate the right providers.
+
+All call sites (`sandvoice.py`, `wake_word.py`, plugins, scheduler) remain unchanged —
+`s.ai.generate_response(...)` still works.
+
+## Goal
+
+- `AI` owns `conversation_history` and delegates to `LLMProvider`, `TTSProvider`,
+  `STTProvider`
+- `AI.from_config(config)` is the standard constructor; the bare `AI(config)` constructor
+  is removed or kept only for tests that pass providers directly
+- Three new config keys (`llm_provider`, `tts_provider`, `stt_provider`) select the
+  provider; all default to `openai`
+- Duplicate logic in `ai.py` is deleted once providers own it
+
+## Approach
+
+### `AI` class redesign
+
+```python
+class AI:
+    def __init__(self, llm: LLMProvider, tts: TTSProvider, stt: STTProvider, config):
+        self.config = config
+        self._llm = llm
+        self._tts = tts
+        self._stt = stt
+        self.conversation_history = []
+
+    @classmethod
+    def from_config(cls, config):
+        setup_error_logging(config)
+        _check_api_key(config)  # validates OPENAI_API_KEY (or future provider keys)
+        openai_client = OpenAI(timeout=config.api_timeout)
+        llm = _build_llm_provider(config, openai_client)
+        tts = _build_tts_provider(config, openai_client)
+        stt = _build_stt_provider(config, openai_client)
+        return cls(llm, tts, stt, config)
+```
+
+### Public API — unchanged for all callers
+
+`AI` wraps provider calls and manages history:
+
+```python
+def generate_response(self, user_input, extra_info=None, model=None):
+    user_message = "User: " + user_input
+    if not self.conversation_history or self.conversation_history[-1] != user_message:
+        self.conversation_history.append(user_message)
+    result = self._llm.generate_response(
+        user_input, self.conversation_history, extra_info=extra_info, model=model
+    )
+    self.conversation_history.append(f"{self.config.botname}: " + result.content)
+    return result
+
+def stream_response_deltas(self, user_input, extra_info=None, model=None):
+    user_message = "User: " + user_input
+    if not self.conversation_history or self.conversation_history[-1] != user_message:
+        self.conversation_history.append(user_message)
+    collected = []
+    for piece in self._llm.stream_response_deltas(
+        user_input, self.conversation_history, extra_info=extra_info, model=model
+    ):
+        collected.append(piece)
+        yield piece
+    self.conversation_history.append(f"{self.config.botname}: " + "".join(collected))
+
+def text_to_speech(self, text, model=None, voice=None):
+    return self._tts.text_to_speech(text, model=model, voice=voice)
+
+def transcribe_and_translate(self, model=None, audio_file_path=None):
+    return self._stt.transcribe(audio_file_path=audio_file_path, model=model)
+
+def define_route(self, user_input, model=None, extra_routes=None):
+    return self._llm.define_route(user_input, model=model, extra_routes=extra_routes)
+
+def text_summary(self, user_input, extra_info=None, words="100", model=None):
+    return self._llm.text_summary(user_input, extra_info=extra_info, words=words, model=model)
+```
+
+Note: `transcribe_and_translate` is kept as the public name (callers use this name) but
+delegates to `stt.transcribe`.
+
+### Provider factory helpers
+
+```python
+def _build_llm_provider(config, openai_client):
+    provider = getattr(config, "llm_provider", "openai")
+    if provider == "openai":
+        return OpenAILLMProvider(openai_client, config)
+    raise ValueError(f"Unknown llm_provider: {provider!r}")
+
+def _build_tts_provider(config, openai_client): ...
+def _build_stt_provider(config, openai_client): ...
+```
+
+Raising `ValueError` on unknown provider names fails fast at startup — better than
+silent fallback to a wrong provider.
+
+### New config keys
+
+Add to `configuration.py` defaults and `load_config()`:
+
+```python
+"llm_provider": "openai",
+"tts_provider": "openai",
+"stt_provider": "openai",
+```
+
+No validation beyond the factory raise is needed for now (only `openai` is valid).
+
+### Cleanup in `common/ai.py`
+
+Once providers own all logic, remove from `AI`:
+- Direct `openai.OpenAI` client construction (moves to `from_config`)
+- `OPENAI_API_KEY` check (moves to `from_config`)
+- All method bodies that now delegate to providers
+- `setup_error_logging` call (stays in `from_config`)
+
+Helpers that are not provider-specific remain in `ai.py`:
+- `split_text_for_tts`, `pop_streaming_chunk` — pure text utilities used elsewhere
+- `normalize_route_name`, `_normalize_route_response` — used in `define_route`
+- `ErrorMessage` — used by tests and providers
+
+## Acceptance Criteria
+
+- [ ] `AI.from_config(config)` is the standard construction path; `sandvoice.py` and
+      `wake_word.py` updated to call it
+- [ ] `llm_provider`, `tts_provider`, `stt_provider` config keys added with `openai` default
+- [ ] `conversation_history` lives on `AI`; provider methods do not own or mutate it
+- [ ] Unknown provider name raises `ValueError` at startup (tested)
+- [ ] All existing call sites (`sandvoice.py`, `wake_word.py`, plugins, scheduler,
+      `_SchedulerContext`) work without modification beyond the construction call
+- [ ] All existing tests pass; `test_ai.py` updated to use `AI(llm, tts, stt, config)`
+      direct constructor with mock providers
+- [ ] Coverage >80% for updated `ai.py`
+- [ ] No OpenAI-specific code remains in `AI` (only in provider classes)
+
+## Dependencies
+
+- Plan 41 merged
+- Plan 42 merged
+
+## Notes
+
+- `_SchedulerContext` in `scheduler.py` creates its own `AI` instance — it should also
+  call `AI.from_config`; verify it still passes an isolated `conversation_history`
+  (it does, because history is now on `AI`, not shared between instances)
+- Keep `transcribe_and_translate` as the public name on `AI` to avoid touching all
+  callers; the rename to `transcribe` is internal to the STT provider
+- Do not add provider config keys for future providers in this plan — add them only
+  when a second provider is implemented


### PR DESCRIPTION
## Summary

- **Plan 41** — Define `LLMProvider`, `TTSProvider`, `STTProvider` ABCs in `common/providers/base.py`. Purely additive.
- **Plan 42** — Implement `OpenAILLMProvider`, `OpenAITTSProvider`, `OpenAISTTProvider`. Logic moved from `AI`; `AI` untouched.
- **Plan 43** — Refactor `AI` into a facade: owns `conversation_history`, delegates to providers, adds `AI.from_config()` factory and three config keys.

## Motivation

`common/ai.py` is tightly coupled to OpenAI — one class, one client, three capabilities mixed together. These plans introduce a clean interface so any capability (LLM, TTS, STT) can be swapped for a different provider independently, without touching call sites.

## Planning Documents

- `plan/backlog/41-provider-abcs.md`
- `plan/backlog/42-openai-provider-implementations.md`
- `plan/backlog/43-ai-facade-migration.md`

## No code changes in this PR

This PR only adds planning documents and updates the index. Implementation follows in separate PRs per plan.