### PR TITLE
Migrate AI to provider facade (Plan 43)

### DIFF
--- a/common/ai.py
+++ b/common/ai.py
@@ -227,15 +227,15 @@ class AI:
         return cls(llm, tts, stt, config)
 
     def generate_response(self, user_input, extra_info=None, model=None):
-        # Pass a snapshot of current history (prior turns) to the provider so that
-        # subsequent mutations to conversation_history don't affect the recorded call.
-        # The provider appends user_input as the final message via _build_messages.
-        result = self._llm.generate_response(
-            user_input, list(self.conversation_history), extra_info=extra_info, model=model
-        )
+        # Append user turn first so history is consistent even if the call fails.
+        # Pass history[:-1] to the provider — provider appends user_input via
+        # _build_messages, avoiding a duplicate if history already ends with this turn.
         user_message = "User: " + user_input
         if not self.conversation_history or self.conversation_history[-1] != user_message:
             self.conversation_history.append(user_message)
+        result = self._llm.generate_response(
+            user_input, self.conversation_history[:-1], extra_info=extra_info, model=model
+        )
         self.conversation_history.append(f"{self.config.botname}: " + result.content)
         return result
 

--- a/common/ai.py
+++ b/common/ai.py
@@ -188,9 +188,10 @@ def _validate_provider_names(config):
 
     Called by from_config before the API-key check so a misconfigured
     provider gives an actionable error rather than a misleading missing-key
-    message.  _build_*_provider functions also validate as a safety net for
-    direct callers; both reference _SUPPORTED_PROVIDERS as the single source
-    of truth.
+    message.  _SUPPORTED_PROVIDERS is the canonical set; _build_*_provider
+    functions also raise ValueError for unknown names as a defensive safety
+    net for direct callers, but they do not reference _SUPPORTED_PROVIDERS
+    directly — update both when adding a new provider.
     """
     for field in ("llm_provider", "tts_provider", "stt_provider"):
         name = getattr(config, field, "openai")

--- a/common/ai.py
+++ b/common/ai.py
@@ -209,7 +209,7 @@ _SUPPORTED_PROVIDERS = {"openai"}
 
 
 class AI:
-    def __init__(self, llm, tts, stt, config, openai_client=None):
+    def __init__(self, llm, tts, stt, config, *, openai_client=None):
         self.config = config
         self._llm = llm
         self._tts = tts

--- a/common/ai.py
+++ b/common/ai.py
@@ -1,8 +1,6 @@
 from openai import OpenAI
-from jinja2 import Template
-import datetime, json, yaml, warnings, os, logging, re, uuid, threading
-from types import SimpleNamespace
-from common.error_handling import retry_with_backoff, setup_error_logging, handle_api_error, handle_file_error
+import os, logging, re
+from common.error_handling import setup_error_logging
 
 logger = logging.getLogger(__name__)
 
@@ -182,414 +180,113 @@ class ErrorMessage:
         self.content = content
 
 
+def _build_llm_provider(config, openai_client):
+    # Deferred import to avoid circular dependency: openai_llm imports from common.ai
+    from common.providers import OpenAILLMProvider
+    provider = getattr(config, "llm_provider", "openai")
+    if provider == "openai":
+        return OpenAILLMProvider(openai_client, config)
+    raise ValueError(f"Unknown llm_provider: {provider!r}")
+
+
+def _build_tts_provider(config, openai_client):
+    from common.providers import OpenAITTSProvider
+    provider = getattr(config, "tts_provider", "openai")
+    if provider == "openai":
+        return OpenAITTSProvider(openai_client, config)
+    raise ValueError(f"Unknown tts_provider: {provider!r}")
+
+
+def _build_stt_provider(config, openai_client):
+    from common.providers import OpenAISTTProvider
+    provider = getattr(config, "stt_provider", "openai")
+    if provider == "openai":
+        return OpenAISTTProvider(openai_client, config)
+    raise ValueError(f"Unknown stt_provider: {provider!r}")
+
+
 class AI:
-    def __init__(self, config):
+    def __init__(self, llm, tts, stt, config):
         self.config = config
+        self._llm = llm
+        self._tts = tts
+        self._stt = stt
+        self.conversation_history = []
 
-        # Set up error logging
+    @classmethod
+    def from_config(cls, config):
         setup_error_logging(config)
-
-        # Check for required API key
         if not os.environ.get('OPENAI_API_KEY'):
             error_msg = "Missing OPENAI_API_KEY environment variable. Please set it and try again."
             print(f"Error: {error_msg}")
             raise ValueError(error_msg)
+        openai_client = OpenAI(timeout=config.api_timeout)
+        llm = _build_llm_provider(config, openai_client)
+        tts = _build_tts_provider(config, openai_client)
+        stt = _build_stt_provider(config, openai_client)
+        return cls(llm, tts, stt, config)
 
-        self.openai_client = OpenAI(timeout=self.config.api_timeout)
-        self.conversation_history = []
-
-    @retry_with_backoff(max_attempts=3, initial_delay=1)
-    def transcribe_and_translate(self, model = None, audio_file_path = None):
-        if not model:
-            model = self.config.speech_to_text_model
-
-        # Use custom file path if provided, otherwise use default tmp_recording
-        file_path = audio_file_path if audio_file_path else (self.config.tmp_recording + ".mp3")
-
-        try:
-            task = getattr(self.config, 'speech_to_text_task', 'translate')
-            language_hint = getattr(self.config, 'speech_to_text_language', '')
-            translate_provider = getattr(self.config, 'speech_to_text_translate_provider', 'whisper')
-            translate_model = getattr(self.config, 'speech_to_text_translate_model', 'gpt-5-mini')
-
-            with open(file_path, "rb") as file:
-                if task == 'transcribe':
-                    kwargs = {"model": model, "file": file}
-                    if language_hint:
-                        kwargs["language"] = language_hint
-                    transcript = self.openai_client.audio.transcriptions.create(**kwargs)
-                    return transcript.text
-
-                if translate_provider == 'whisper':
-                    transcript = self.openai_client.audio.translations.create(
-                        model = model,
-                        file = file
-                    )
-                    return transcript.text
-
-                kwargs = {"model": model, "file": file}
-                if language_hint:
-                    kwargs["language"] = language_hint
-                transcript = self.openai_client.audio.transcriptions.create(**kwargs)
-
-            source_text = transcript.text or ""
-            if not source_text.strip():
-                return ""
-
-            try:
-                completion = self.openai_client.chat.completions.create(
-                    model=translate_model,
-                    messages=[
-                        {
-                            "role": "system",
-                            "content": "Translate the user's text to English. Return only the translated text.",
-                        },
-                        {"role": "user", "content": source_text},
-                    ],
-                )
-                return (completion.choices[0].message.content or "").strip()
-            except Exception as e:
-                error_msg = handle_api_error(e, service_name="OpenAI Chat Completions")
-                logger.error("Translation error (chat completions): %s", e)
-                print(error_msg)
-                raise
-        except FileNotFoundError as e:
-            error_msg = handle_file_error(e, operation="read", filename=os.path.basename(file_path))
-            logger.error("Transcription file error: %s", e)
-            print(error_msg)
-            raise
-        except Exception as e:
-            error_msg = handle_api_error(e, service_name="OpenAI Whisper")
-            logger.error("Transcription error: %s", e)
-            print(error_msg)
-            raise
-
-    @retry_with_backoff(max_attempts=3, initial_delay=1)
-    def generate_response(self, user_input, extra_info = None, model = None):
-        try:
-            if not model:
-                model = self.config.gpt_response_model
-
-            # Add to conversation history only if not already present (prevents duplicates during retries)
-            user_message = "User: " + user_input
-            if not self.conversation_history or self.conversation_history[-1] != user_message:
-                self.conversation_history.append(user_message)
-
-            now = datetime.datetime.now()
-
-            verbosity = getattr(self.config, "verbosity", "brief")
-            if verbosity == "detailed":
-                verbosity_instruction = (
-                    "Verbosity: detailed. Provide thorough, structured answers by default. "
-                    "Include steps/examples when helpful. If the user asks for a short answer, comply."
-                )
-            elif verbosity == "normal":
-                verbosity_instruction = (
-                    "Verbosity: normal. Be concise but complete. "
-                    "Expand when the user explicitly asks for more detail."
-                )
-            else:
-                verbosity_instruction = (
-                    "Verbosity: brief. Keep answers short by default (1-3 sentences). "
-                    "Avoid long lists and excessive detail unless the user explicitly asks to expand, "
-                    "asks for details, or says they want a longer answer."
-                )
-
-            system_role = f"""
-            Your name is {self.config.botname}.
-            You are an assistant written in Python by Breno Brand.
-            You must answer in {self.config.language}.
-            The person that is talking to you is in the {self.config.timezone} time zone.
-            The person that is talking to you is located in {self.config.location}.
-            Current date and time to be considered when answering the message: {now}.
-            Never answer as a chat, for example reading your name in a conversation.
-            DO NOT reply to messages with the format "{self.config.botname}": <message here>.
-            Reply in a natural and human way.
-            {verbosity_instruction}
-            """
-            if extra_info is not None:
-                system_role = system_role + "Consider the following to answer your question: " + extra_info
-            if self.config.debug:
-                print (f"System role: {system_role}")
-            # Be very sympathetic, helpful and don't be rude or have short answers"
-
-            # Only treat explicit boolean True as enabled.
-            # This avoids accidental truthiness with Mock() in tests/callers.
-            stream_responses = (getattr(self.config, "stream_responses", False) is True)
-
-            messages = [
-                {"role": "system", "content": system_role},
-            ] + [{"role": "user", "content": message} for message in self.conversation_history]
-
-            if not stream_responses:
-                completion = self.openai_client.chat.completions.create(
-                    model=model,
-                    messages=messages,
-                )
-                assistant_content = completion.choices[0].message.content
-                self.conversation_history.append(f"{self.config.botname}: " + assistant_content)
-                return completion.choices[0].message
-
-            stream = self.openai_client.chat.completions.create(
-                model=model,
-                messages=messages,
-                stream=True,
-            )
-
-            # Deltas are not printed here — callers always print the assembled response,
-            # so printing deltas too would cause duplicate output (deltas + full response).
-            # For per-delta debug visibility, use stream_response_deltas() instead; its
-            # callers suppress the final assembled-response print in debug mode to avoid
-            # duplication (that gating is in the caller, not inside stream_response_deltas).
-            collected = []
-            for event in stream:
-                try:
-                    delta = event.choices[0].delta
-                    piece = getattr(delta, "content", None)
-                except Exception:
-                    piece = None
-
-                if piece:
-                    collected.append(piece)
-
-            assistant_content = "".join(collected)
-            self.conversation_history.append(f"{self.config.botname}: " + assistant_content)
-            return SimpleNamespace(content=assistant_content)
-        except Exception as e:
-            error_msg = handle_api_error(e, service_name="OpenAI GPT")
-            logger.error("Response generation error: %s", e)
-            print(error_msg)
-            return ErrorMessage("Sorry, I'm having trouble right now. Please try again in a moment.")
+    def generate_response(self, user_input, extra_info=None, model=None):
+        # Pass a snapshot of current history (prior turns) to the provider so that
+        # subsequent mutations to conversation_history don't affect the recorded call.
+        # The provider appends user_input as the final message via _build_messages.
+        result = self._llm.generate_response(
+            user_input, list(self.conversation_history), extra_info=extra_info, model=model
+        )
+        user_message = "User: " + user_input
+        if not self.conversation_history or self.conversation_history[-1] != user_message:
+            self.conversation_history.append(user_message)
+        self.conversation_history.append(f"{self.config.botname}: " + result.content)
+        return result
 
     def stream_response_deltas(self, user_input, extra_info=None, model=None):
         """Yield response text deltas from the LLM stream.
 
-        This is used by Plan 08 Phase 2 to begin TTS before the full response is complete.
-        It also updates conversation history after the stream completes.
+        Appends the user turn to conversation_history immediately, then yields
+        deltas from the provider. The assistant turn is only appended on successful
+        stream completion — partial output is discarded on failure.
 
-        Note: this method updates self.conversation_history with the user input and the
-        final assistant response (assembled from deltas).
+        The provider receives history without the current user turn; it appends
+        user_input via _build_messages.
 
-        Retries are intentionally not applied here because streaming retry semantics are
-        ambiguous (partial output may already have been emitted).
+        Retries are intentionally not applied — streaming retry semantics are
+        ambiguous when partial output has already been emitted.
         """
-        if not model:
-            model = self.config.gpt_response_model
-
-        # Add to conversation history only if not already present.
         user_message = "User: " + user_input
         if not self.conversation_history or self.conversation_history[-1] != user_message:
             self.conversation_history.append(user_message)
 
-        now = datetime.datetime.now()
-        verbosity = getattr(self.config, "verbosity", "brief")
-        if verbosity == "detailed":
-            verbosity_instruction = (
-                "Verbosity: detailed. Provide thorough, structured answers by default. "
-                "Include steps/examples when helpful. If the user asks for a short answer, comply."
-            )
-        elif verbosity == "normal":
-            verbosity_instruction = (
-                "Verbosity: normal. Be concise but complete. "
-                "Expand when the user explicitly asks for more detail."
-            )
-        else:
-            verbosity_instruction = (
-                "Verbosity: brief. Keep answers short by default (1-3 sentences). "
-                "Avoid long lists and excessive detail unless the user explicitly asks to expand, "
-                "asks for details, or says they want a longer answer."
-            )
-
-        system_role = f"""
-            Your name is {self.config.botname}.
-            You are an assistant written in Python by Breno Brand.
-            You must answer in {self.config.language}.
-            The person that is talking to you is in the {self.config.timezone} time zone.
-            The person that is talking to you is located in {self.config.location}.
-            Current date and time to be considered when answering the message: {now}.
-            Never answer as a chat, for example reading your name in a conversation.
-            DO NOT reply to messages with the format "{self.config.botname}": <message here>.
-            Reply in a natural and human way.
-            {verbosity_instruction}
-            """
-
-        if extra_info is not None:
-            system_role = system_role + "Consider the following to answer your question: " + extra_info
-
-        messages = [
-            {"role": "system", "content": system_role},
-        ] + [{"role": "user", "content": message} for message in self.conversation_history]
+        # provider_history excludes the just-appended user turn — provider adds it
+        provider_history = self.conversation_history[:-1]
 
         collected = []
         stream_completed = False
 
         try:
-            stream = self.openai_client.chat.completions.create(
-                model=model,
-                messages=messages,
-                stream=True,
-            )
-
-            for event in stream:
-                piece = None
-                try:
-                    delta = event.choices[0].delta
-                    piece = getattr(delta, "content", None)
-                except Exception:
-                    piece = None
-
-                if piece:
-                    collected.append(piece)
-                    if self.config.debug:
-                        print(piece, end="", flush=True)
-                    yield piece
-
+            for piece in self._llm.stream_response_deltas(
+                user_input, provider_history, extra_info=extra_info, model=model
+            ):
+                collected.append(piece)
+                if self.config.debug:
+                    print(piece, end="", flush=True)
+                yield piece
             stream_completed = True
         finally:
             if self.config.debug:
                 print("", flush=True)
-
-            # Only persist the assistant turn if the stream completed without raising.
-            # This avoids polluting the next prompt with partial output.
             if stream_completed:
-                assistant_content = "".join(collected)
-                self.conversation_history.append(f"{self.config.botname}: " + assistant_content)
+                self.conversation_history.append(
+                    f"{self.config.botname}: " + "".join(collected)
+                )
 
-    @retry_with_backoff(max_attempts=3, initial_delay=1)
+    def transcribe_and_translate(self, model=None, audio_file_path=None):
+        return self._stt.transcribe(audio_file_path=audio_file_path, model=model)
+
     def define_route(self, user_input, model=None, extra_routes=None):
-        try:
-            if not model:
-                model = self.config.gpt_route_model
-            with open(f"{self.config.sandvoice_path}/routes.yaml", 'r') as f:
-                template_str = f.read()
-            template = Template(template_str)
-            rendered_config = template.render(location=self.config.location)
-            system_role = yaml.safe_load(rendered_config)
-            route_role_text = system_role['route_role']
-            if extra_routes:
-                route_role_text = route_role_text.rstrip() + extra_routes
-
-            logger.info("Routing: %r", user_input)
-            completion = self.openai_client.chat.completions.create(
-                model=model,
-                messages=[
-                    {"role": "system", "content": route_role_text},
-                    {"role": "user", "content": user_input},
-                ]
-            )
-            route = json.loads(completion.choices[0].message.content)
-            result = _normalize_route_response(route)
-            logger.info("Route chosen: %s", result)
-            return result
-        except FileNotFoundError as e:
-            error_msg = handle_file_error(e, operation="read", filename="routes.yaml")
-            logger.error("Routes file error: %s", e)
-            print(error_msg)
-            # Return default route as fallback
-            return {"route": DEFAULT_ROUTE_NAME, "reason": "Error loading routes"}
-        except json.JSONDecodeError as e:
-            error_msg = "Error parsing route response from AI. Using default route."
-            logger.error("Route JSON parse error: %s", e)
-            print(error_msg)
-            return {"route": DEFAULT_ROUTE_NAME, "reason": "Parse error"}
-        except Exception as e:
-            error_msg = handle_api_error(e, service_name="OpenAI GPT")
-            logger.error("Route definition error: %s", e)
-            print(error_msg)
-            return {"route": DEFAULT_ROUTE_NAME, "reason": "API error"}
-
-    @retry_with_backoff(max_attempts=3, initial_delay=1)
-    def text_summary(self, user_input, extra_info = None, words = "100", model = None):
-        try:
-            if not model:
-                model = self.config.gpt_summary_model
-            if self.config.debug:
-                print("Summary words: " + words)
-                print("Before: " + user_input)
-            system_role = f"""
-            You're a bot summaries texts in {words} words.
-            If there is a date of the text you are reading, mention the date in the summary.
-            The summary must content the most important information of the text.
-            Your answer will be in json format: {{"title": "some title", "text": "the summary here"}}.
-            The text must be translated to {self.config.language} if required.
-            If one of the texts has no content or has an error, figure something out from the title.
-            You will receive a text and you need to summarize it in {words} words and return the title and the summary.
-            You must be able to answer the user's question with the summary. For example, if the user is asking for a recipe, your answer must have the recipe.
-            The only condition that will allow you bypass the limite of {words} words is if that amount of words is not enough to summarize the text.
-            Do your best to be as close to the limit  of {words} words as possible.
-            """
-
-            if self.config.debug:
-                print(system_role)
-            if extra_info != None:
-                system_role = "Consider that this is the question of the user: {extra_info}" + system_role
-
-            completion = self.openai_client.chat.completions.create(
-            model = model,
-            messages = [
-                {"role": "system", "content": system_role},
-                {"role": "user", "content": user_input}
-            ])
-            if self.config.debug:
-                print("After: " +completion.choices[0].message.content + "\n")
-            return json.loads(completion.choices[0].message.content)
-        except json.JSONDecodeError as e:
-            error_msg = "Error parsing summary response from AI."
-            logger.error("Summary JSON parse error: %s", e)
-            print(error_msg)
-            return {"title": "Error", "text": "Unable to generate summary"}
-        except Exception as e:
-            error_msg = handle_api_error(e, service_name="OpenAI GPT")
-            logger.error("Text summary error: %s", e)
-            print(error_msg)
-            return {"title": "Error", "text": "Unable to generate summary"}
-
-    @retry_with_backoff(max_attempts=3, initial_delay=1)
-    def _generate_tts_files(self, text, model, voice):
-        """Generate TTS audio files. Raises on failure so @retry_with_backoff can retry."""
-        warnings.filterwarnings("ignore", category=DeprecationWarning)
-        chunks = split_text_for_tts(text)
-        if not chunks:
-            return []
-
-        response_id = uuid.uuid4().hex
-        output_files = []
-
-        try:
-            for i, chunk in enumerate(chunks, start=1):
-                speech_file_path = os.path.join(
-                    self.config.tmp_files_path,
-                    f"tts-response-{response_id}-chunk-{i:03d}.mp3",
-                )
-                response = self.openai_client.audio.speech.create(
-                    model=model,
-                    voice=voice,
-                    input=chunk
-                )
-                output_files.append(speech_file_path)
-                response.stream_to_file(speech_file_path)
-                logger.debug(">>> TTS FILE CREATED: thread=%s, file=%s",
-                             threading.current_thread().name, os.path.basename(speech_file_path))
-        except Exception:
-            for f in output_files:
-                try:
-                    if os.path.exists(f):
-                        os.remove(f)
-                except Exception:
-                    pass  # best-effort cleanup
-            raise
-
-        return output_files
+        return self._llm.define_route(user_input, model=model, extra_routes=extra_routes)
 
     def text_to_speech(self, text, model=None, voice=None):
-        logger.debug(">>> TTS GENERATION CALLED from thread %s: text=%s...",
-                     threading.current_thread().name, text[:50] if text else "empty")
-        logger.debug(">>> TTS GENERATION full text length: %d chars", len(text) if text else 0)
-        model = model or self.config.text_to_speech_model
-        voice = voice or self.config.bot_voice_model
-        try:
-            return self._generate_tts_files(text, model, voice)
-        except Exception as e:
-            logger.error("Text-to-speech failed: %s", handle_api_error(e, service_name="OpenAI TTS"))
-            logger.debug("Text-to-speech exception details:", exc_info=True)
-            return []
+        return self._tts.text_to_speech(text, model=model, voice=voice)
+
+    def text_summary(self, user_input, extra_info=None, words="100", model=None):
+        return self._llm.text_summary(user_input, extra_info=extra_info, words=words, model=model)

--- a/common/ai.py
+++ b/common/ai.py
@@ -180,6 +180,26 @@ class ErrorMessage:
         self.content = content
 
 
+_SUPPORTED_PROVIDERS = {"openai"}
+
+
+def _validate_provider_names(config):
+    """Raise ValueError for any unsupported provider name.
+
+    Called by from_config before the API-key check so a misconfigured
+    provider gives an actionable error rather than a misleading missing-key
+    message.  _build_*_provider functions also validate as a safety net for
+    direct callers; both reference _SUPPORTED_PROVIDERS as the single source
+    of truth.
+    """
+    for field in ("llm_provider", "tts_provider", "stt_provider"):
+        name = getattr(config, field, "openai")
+        if name not in _SUPPORTED_PROVIDERS:
+            error_msg = f"Unknown {field}: {name!r}"
+            print(f"Error: {error_msg}")
+            raise ValueError(error_msg)
+
+
 def _build_llm_provider(config, openai_client):
     # Deferred import to avoid circular dependency: openai_llm imports from common.ai
     from common.providers import OpenAILLMProvider
@@ -203,9 +223,6 @@ def _build_stt_provider(config, openai_client):
     if provider == "openai":
         return OpenAISTTProvider(openai_client, config)
     raise ValueError(f"Unknown stt_provider: {provider!r}")
-
-
-_SUPPORTED_PROVIDERS = {"openai"}
 
 
 class AI:
@@ -236,16 +253,7 @@ class AI:
         setup_error_logging(config)
         # Validate provider names before checking the API key so a misconfigured
         # provider gives an actionable error rather than "Missing OPENAI_API_KEY".
-        provider_fields = {
-            "llm_provider": getattr(config, "llm_provider", "openai"),
-            "tts_provider": getattr(config, "tts_provider", "openai"),
-            "stt_provider": getattr(config, "stt_provider", "openai"),
-        }
-        for field, name in provider_fields.items():
-            if name not in _SUPPORTED_PROVIDERS:
-                error_msg = f"Unknown {field}: {name!r}"
-                print(f"Error: {error_msg}")
-                raise ValueError(error_msg)
+        _validate_provider_names(config)
         if not os.environ.get('OPENAI_API_KEY'):
             error_msg = "Missing OPENAI_API_KEY environment variable. Please set it and try again."
             print(f"Error: {error_msg}")

--- a/common/ai.py
+++ b/common/ai.py
@@ -197,7 +197,7 @@ def _validate_provider_names(config):
     """
     for field in ("llm_provider", "tts_provider", "stt_provider"):
         raw = getattr(config, field, None)
-        name = str(raw).strip().lower() if raw else "openai"
+        name = (str(raw).strip().lower() if raw is not None else "") or "openai"
         if name not in _SUPPORTED_PROVIDERS:
             error_msg = f"Unknown {field}: {name!r}"
             print(f"Error: {error_msg}")
@@ -209,7 +209,8 @@ def _build_llm_provider(config, openai_client):
     from common.providers import OpenAILLMProvider
     # Dispatch dict keys must match _SUPPORTED_PROVIDERS.
     _dispatch = {"openai": OpenAILLMProvider}
-    provider = (getattr(config, "llm_provider", None) or "openai").strip().lower()
+    raw = getattr(config, "llm_provider", None)
+    provider = (str(raw).strip().lower() if raw is not None else "") or "openai"
     klass = _dispatch.get(provider)
     if klass is None:
         raise ValueError(f"Unknown llm_provider: {provider!r}")
@@ -219,7 +220,8 @@ def _build_llm_provider(config, openai_client):
 def _build_tts_provider(config, openai_client):
     from common.providers import OpenAITTSProvider
     _dispatch = {"openai": OpenAITTSProvider}
-    provider = (getattr(config, "tts_provider", None) or "openai").strip().lower()
+    raw = getattr(config, "tts_provider", None)
+    provider = (str(raw).strip().lower() if raw is not None else "") or "openai"
     klass = _dispatch.get(provider)
     if klass is None:
         raise ValueError(f"Unknown tts_provider: {provider!r}")
@@ -229,7 +231,8 @@ def _build_tts_provider(config, openai_client):
 def _build_stt_provider(config, openai_client):
     from common.providers import OpenAISTTProvider
     _dispatch = {"openai": OpenAISTTProvider}
-    provider = (getattr(config, "stt_provider", None) or "openai").strip().lower()
+    raw = getattr(config, "stt_provider", None)
+    provider = (str(raw).strip().lower() if raw is not None else "") or "openai"
     klass = _dispatch.get(provider)
     if klass is None:
         raise ValueError(f"Unknown stt_provider: {provider!r}")

--- a/common/ai.py
+++ b/common/ai.py
@@ -213,6 +213,11 @@ class AI:
         self._stt = stt
         self.conversation_history = []
 
+    @property
+    def openai_client(self):
+        """Return the underlying OpenAI client for plugins that use the API directly."""
+        return getattr(self._llm, '_client', None)
+
     @classmethod
     def from_config(cls, config):
         setup_error_logging(config)

--- a/common/ai.py
+++ b/common/ai.py
@@ -205,22 +205,47 @@ def _build_stt_provider(config, openai_client):
     raise ValueError(f"Unknown stt_provider: {provider!r}")
 
 
+_SUPPORTED_PROVIDERS = {"openai"}
+
+
 class AI:
-    def __init__(self, llm, tts, stt, config):
+    def __init__(self, llm, tts, stt, config, openai_client=None):
         self.config = config
         self._llm = llm
         self._tts = tts
         self._stt = stt
+        self._openai_client = openai_client
         self.conversation_history = []
 
     @property
     def openai_client(self):
-        """Return the underlying OpenAI client for plugins that use the API directly."""
-        return getattr(self._llm, '_client', None)
+        """Return the underlying OpenAI client for plugins that use the API directly.
+
+        Raises AttributeError if the AI was not constructed via from_config or the
+        configured provider does not expose an OpenAI client.
+        """
+        if self._openai_client is None:
+            raise AttributeError(
+                "openai_client is not available: AI was not constructed via "
+                "from_config, or the configured provider does not use an OpenAI client."
+            )
+        return self._openai_client
 
     @classmethod
     def from_config(cls, config):
         setup_error_logging(config)
+        # Validate provider names before checking the API key so a misconfigured
+        # provider gives an actionable error rather than "Missing OPENAI_API_KEY".
+        provider_fields = {
+            "llm_provider": getattr(config, "llm_provider", "openai"),
+            "tts_provider": getattr(config, "tts_provider", "openai"),
+            "stt_provider": getattr(config, "stt_provider", "openai"),
+        }
+        for field, name in provider_fields.items():
+            if name not in _SUPPORTED_PROVIDERS:
+                error_msg = f"Unknown {field}: {name!r}"
+                print(f"Error: {error_msg}")
+                raise ValueError(error_msg)
         if not os.environ.get('OPENAI_API_KEY'):
             error_msg = "Missing OPENAI_API_KEY environment variable. Please set it and try again."
             print(f"Error: {error_msg}")
@@ -229,7 +254,7 @@ class AI:
         llm = _build_llm_provider(config, openai_client)
         tts = _build_tts_provider(config, openai_client)
         stt = _build_stt_provider(config, openai_client)
-        return cls(llm, tts, stt, config)
+        return cls(llm, tts, stt, config, openai_client=openai_client)
 
     def generate_response(self, user_input, extra_info=None, model=None):
         # Append user turn first so history is consistent even if the call fails.

--- a/common/ai.py
+++ b/common/ai.py
@@ -186,15 +186,18 @@ _SUPPORTED_PROVIDERS = {"openai"}
 def _validate_provider_names(config):
     """Raise ValueError for any unsupported provider name.
 
-    Called by from_config before the API-key check so a misconfigured
-    provider gives an actionable error rather than a misleading missing-key
-    message.  _SUPPORTED_PROVIDERS is the canonical set; _build_*_provider
-    functions also raise ValueError for unknown names as a defensive safety
-    net for direct callers, but they do not reference _SUPPORTED_PROVIDERS
-    directly — update both when adding a new provider.
+    Normalises each value (strip, lower, None/empty → "openai") before
+    checking against _SUPPORTED_PROVIDERS.  Called by from_config before the
+    API-key check so a misconfigured provider gives an actionable error rather
+    than a misleading missing-key message.
+
+    _build_*_provider helpers use dispatch dicts whose keys correspond to
+    _SUPPORTED_PROVIDERS.  Update _SUPPORTED_PROVIDERS and each dispatch dict
+    together when adding a new provider.
     """
     for field in ("llm_provider", "tts_provider", "stt_provider"):
-        name = getattr(config, field, "openai")
+        raw = getattr(config, field, None)
+        name = str(raw).strip().lower() if raw else "openai"
         if name not in _SUPPORTED_PROVIDERS:
             error_msg = f"Unknown {field}: {name!r}"
             print(f"Error: {error_msg}")
@@ -204,26 +207,33 @@ def _validate_provider_names(config):
 def _build_llm_provider(config, openai_client):
     # Deferred import to avoid circular dependency: openai_llm imports from common.ai
     from common.providers import OpenAILLMProvider
-    provider = getattr(config, "llm_provider", "openai")
-    if provider == "openai":
-        return OpenAILLMProvider(openai_client, config)
-    raise ValueError(f"Unknown llm_provider: {provider!r}")
+    # Dispatch dict keys must match _SUPPORTED_PROVIDERS.
+    _dispatch = {"openai": OpenAILLMProvider}
+    provider = (getattr(config, "llm_provider", None) or "openai").strip().lower()
+    klass = _dispatch.get(provider)
+    if klass is None:
+        raise ValueError(f"Unknown llm_provider: {provider!r}")
+    return klass(openai_client, config)
 
 
 def _build_tts_provider(config, openai_client):
     from common.providers import OpenAITTSProvider
-    provider = getattr(config, "tts_provider", "openai")
-    if provider == "openai":
-        return OpenAITTSProvider(openai_client, config)
-    raise ValueError(f"Unknown tts_provider: {provider!r}")
+    _dispatch = {"openai": OpenAITTSProvider}
+    provider = (getattr(config, "tts_provider", None) or "openai").strip().lower()
+    klass = _dispatch.get(provider)
+    if klass is None:
+        raise ValueError(f"Unknown tts_provider: {provider!r}")
+    return klass(openai_client, config)
 
 
 def _build_stt_provider(config, openai_client):
     from common.providers import OpenAISTTProvider
-    provider = getattr(config, "stt_provider", "openai")
-    if provider == "openai":
-        return OpenAISTTProvider(openai_client, config)
-    raise ValueError(f"Unknown stt_provider: {provider!r}")
+    _dispatch = {"openai": OpenAISTTProvider}
+    provider = (getattr(config, "stt_provider", None) or "openai").strip().lower()
+    klass = _dispatch.get(provider)
+    if klass is None:
+        raise ValueError(f"Unknown stt_provider: {provider!r}")
+    return klass(openai_client, config)
 
 
 class AI:

--- a/common/configuration.py
+++ b/common/configuration.py
@@ -137,6 +137,11 @@ class Config:
             "cache_warmup_retries": 3,       # max attempts per plugin before giving up
             "cache_warmup_retry_delay_s": 2, # seconds between retry attempts
 
+            # Provider selection (Plan 43) — only "openai" is supported for now
+            "llm_provider": "openai",
+            "tts_provider": "openai",
+            "stt_provider": "openai",
+
             # Task Scheduler (Plan 21)
             "scheduler_enabled": "disabled",
             "scheduler_poll_interval": 30,
@@ -207,6 +212,9 @@ class Config:
         self.api_retry_attempts = self.get("api_retry_attempts")
         self.enable_error_logging = self.get("enable_error_logging").lower() == "enabled"
         self.error_log_path = self.get("error_log_path")
+        self.llm_provider = str(self.get("llm_provider") or "openai").strip().lower()
+        self.tts_provider = str(self.get("tts_provider") or "openai").strip().lower()
+        self.stt_provider = str(self.get("stt_provider") or "openai").strip().lower()
 
         # Streaming
         self.stream_responses = self.get("stream_responses").lower() == "enabled"

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -155,6 +155,10 @@ plan/
 **Document**: [completed/42-openai-provider-implementations.md](./completed/42-openai-provider-implementations.md)
 **Description**: Implement `OpenAILLMProvider`, `OpenAITTSProvider`, and `OpenAISTTProvider` in `common/providers/`. Logic extracted from `AI` class; `AI` is unchanged. Requires Plan 41.
 
+### Priority 43: AI Facade Migration
+**Document**: [completed/43-ai-facade-migration.md](./completed/43-ai-facade-migration.md)
+**Description**: Refactor `AI` into a thin facade: owns `conversation_history`, delegates capabilities to provider instances, and exposes `AI.from_config(config)` factory. Adds `llm_provider`, `tts_provider`, `stt_provider` config keys (all default to `openai`). Runtime method call sites (`generate_response`, `text_to_speech`, etc.) remain unchanged; only construction changes to `AI.from_config(config)`. Requires Plans 41 and 42.
+
 ---
 
 ## In Progress 🚧
@@ -197,10 +201,6 @@ plan/
 ### Priority 37: Context-Aware Routing
 **Document**: [backlog/37-context-aware-routing.md](./backlog/37-context-aware-routing.md)
 **Description**: Pass the last N conversation turns to `define_route` so the routing LLM can correctly resolve follow-up utterances. Fixes misrouting of clarifications (e.g. "I mean the FIFA World Cup" after a realtime_websearch query routing to `news`).
-
-### Priority 43: AI Facade Migration
-**Document**: [backlog/43-ai-facade-migration.md](./backlog/43-ai-facade-migration.md)
-**Description**: Refactor `AI` into a thin facade: owns `conversation_history`, delegates capabilities to provider instances, and exposes `AI.from_config(config)` factory. Adds `llm_provider`, `tts_provider`, `stt_provider` config keys (all default to `openai`). Runtime method call sites (`generate_response`, `text_to_speech`, etc.) remain unchanged; only construction changes to `AI.from_config(config)`. Requires Plans 41 and 42.
 
 ### Future Enhancements
 **Document**: [backlog/FUTURE.md](./backlog/FUTURE.md)

--- a/plan/completed/43-ai-facade-migration.md
+++ b/plan/completed/43-ai-facade-migration.md
@@ -1,0 +1,163 @@
+# Plan 43: AI Facade Migration
+
+## Problem
+
+After Plans 41 and 42, three OpenAI provider classes exist alongside the original `AI`
+class, which still owns all the logic directly. This plan completes the migration:
+`AI` becomes a thin facade that owns conversation history, delegates all capability calls
+to provider instances, and exposes a factory (`AI.from_config`) that reads config to
+pick and instantiate the right providers.
+
+Runtime method call sites (`sandvoice.py`, `wake_word.py`, plugins, scheduler) remain
+unchanged — `s.ai.generate_response(...)` still works. The only change to entry points
+is construction: `sandvoice.py` and `wake_word.py` switch from `AI(config)` to
+`AI.from_config(config)`.
+
+## Goal
+
+- `AI` owns `conversation_history` and delegates to `LLMProvider`, `TTSProvider`,
+  `STTProvider`
+- `AI.from_config(config)` is the standard constructor; the bare `AI(config)` constructor
+  is removed or kept only for tests that pass providers directly
+- Three new config keys (`llm_provider`, `tts_provider`, `stt_provider`) select the
+  provider; all default to `openai`
+- Duplicate logic in `ai.py` is deleted once providers own it
+
+## Approach
+
+### `AI` class redesign
+
+```python
+class AI:
+    def __init__(self, llm: LLMProvider, tts: TTSProvider, stt: STTProvider, config):
+        self.config = config
+        self._llm = llm
+        self._tts = tts
+        self._stt = stt
+        self.conversation_history = []
+
+    @classmethod
+    def from_config(cls, config):
+        setup_error_logging(config)
+        _check_api_key(config)  # validates OPENAI_API_KEY (or future provider keys)
+        openai_client = OpenAI(timeout=config.api_timeout)
+        llm = _build_llm_provider(config, openai_client)
+        tts = _build_tts_provider(config, openai_client)
+        stt = _build_stt_provider(config, openai_client)
+        return cls(llm, tts, stt, config)
+```
+
+### Public API — unchanged for all callers
+
+`AI` wraps provider calls and manages history:
+
+```python
+def generate_response(self, user_input, extra_info=None, model=None):
+    user_message = "User: " + user_input
+    if not self.conversation_history or self.conversation_history[-1] != user_message:
+        self.conversation_history.append(user_message)
+    result = self._llm.generate_response(
+        user_input, self.conversation_history, extra_info=extra_info, model=model
+    )
+    self.conversation_history.append(f"{self.config.botname}: " + result.content)
+    return result
+
+def stream_response_deltas(self, user_input, extra_info=None, model=None):
+    user_message = "User: " + user_input
+    if not self.conversation_history or self.conversation_history[-1] != user_message:
+        self.conversation_history.append(user_message)
+    collected = []
+    for piece in self._llm.stream_response_deltas(
+        user_input, self.conversation_history, extra_info=extra_info, model=model
+    ):
+        collected.append(piece)
+        yield piece
+    self.conversation_history.append(f"{self.config.botname}: " + "".join(collected))
+
+def text_to_speech(self, text, model=None, voice=None):
+    return self._tts.text_to_speech(text, model=model, voice=voice)
+
+def transcribe_and_translate(self, model=None, audio_file_path=None):
+    return self._stt.transcribe(audio_file_path=audio_file_path, model=model)
+
+def define_route(self, user_input, model=None, extra_routes=None):
+    return self._llm.define_route(user_input, model=model, extra_routes=extra_routes)
+
+def text_summary(self, user_input, extra_info=None, words="100", model=None):
+    return self._llm.text_summary(user_input, extra_info=extra_info, words=words, model=model)
+```
+
+Note: `transcribe_and_translate` is kept as the public name (callers use this name) but
+delegates to `stt.transcribe`.
+
+### Provider factory helpers
+
+```python
+def _build_llm_provider(config, openai_client):
+    provider = getattr(config, "llm_provider", "openai")
+    if provider == "openai":
+        return OpenAILLMProvider(openai_client, config)
+    raise ValueError(f"Unknown llm_provider: {provider!r}")
+
+def _build_tts_provider(config, openai_client): ...
+def _build_stt_provider(config, openai_client): ...
+```
+
+Raising `ValueError` on unknown provider names fails fast at startup — better than
+silent fallback to a wrong provider.
+
+### New config keys
+
+Add to `configuration.py` defaults and `load_config()`:
+
+```python
+"llm_provider": "openai",
+"tts_provider": "openai",
+"stt_provider": "openai",
+```
+
+No validation beyond the factory raise is needed for now (only `openai` is valid).
+
+### Cleanup in `common/ai.py`
+
+Once providers own all logic, remove from `AI`:
+- Direct `openai.OpenAI` client construction (moves to `from_config`)
+- `OPENAI_API_KEY` check (moves to `from_config`)
+- All method bodies that now delegate to providers
+- `setup_error_logging` call (stays in `from_config`)
+
+Helpers that are not provider-specific remain in `ai.py`:
+- `split_text_for_tts`, `pop_streaming_chunk` — pure text utilities used elsewhere
+- `normalize_route_name`, `_normalize_route_response` — used in `define_route`
+- `ErrorMessage` — used by tests and providers
+
+## Acceptance Criteria
+
+- [ ] `AI.from_config(config)` is the standard construction path; `sandvoice.py` and
+      `wake_word.py` updated to call it
+- [ ] `llm_provider`, `tts_provider`, `stt_provider` config keys added with `openai` default
+- [ ] `conversation_history` lives on `AI`; provider methods do not own or mutate it
+- [ ] Unknown provider name raises `ValueError` at startup (tested)
+- [ ] All existing call sites (`sandvoice.py`, `wake_word.py`, plugins, scheduler,
+      `_SchedulerContext`) work without modification beyond the construction call
+- [ ] All existing tests pass; `test_ai.py` updated to use `AI(llm, tts, stt, config)`
+      direct constructor with mock providers
+- [ ] Coverage >80% for updated `ai.py`
+- [ ] No OpenAI-specific code in `AI` instance methods; `AI.from_config` is the
+      intentional provider wiring point and may contain OpenAI client construction
+      (via `_build_*_provider` helpers) — that is by design, not a violation
+
+## Dependencies
+
+- Plan 41 merged
+- Plan 42 merged
+
+## Notes
+
+- `_SchedulerContext` in `sandvoice.py` creates its own `AI` instance — it should also
+  call `AI.from_config`; verify it still passes an isolated `conversation_history`
+  (it does, because history is now on `AI`, not shared between instances)
+- Keep `transcribe_and_translate` as the public name on `AI` to avoid touching all
+  callers; the rename to `transcribe` is internal to the STT provider
+- Do not add provider config keys for future providers in this plan — add them only
+  when a second provider is implemented

--- a/sandvoice.py
+++ b/sandvoice.py
@@ -121,7 +121,7 @@ class SandVoice:
     def __init__(self):
         self.parse_args()
         self.config = Config()
-        self.ai = AI(self.config)
+        self.ai = AI.from_config(self.config)
         if not os.path.exists(self.config.tmp_files_path):
             os.makedirs(self.config.tmp_files_path)
         self.plugins = {}
@@ -351,7 +351,7 @@ class SandVoice:
         ai = None
         db = None
         try:
-            ai = AI(self.config)
+            ai = AI.from_config(self.config)
             db = SchedulerDB(self.config.scheduler_db_path)
             scheduler = TaskScheduler(
                 db=db,
@@ -461,7 +461,7 @@ class SandVoice:
                                 "cache_auto_refresh warmup: invoking %r (attempt %d)",
                                 pname, attempt + 1,
                             )
-                            thread_ai = AI(self.config)
+                            thread_ai = AI.from_config(self.config)
                             resolved = resolve_plugin_route_name(r['route'], self.plugins)
                             r['route'] = resolved
                             ctx = _SchedulerContext(self, thread_ai)

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,616 +1,370 @@
-import unittest
-import tempfile
 import os
-import json
-from unittest.mock import Mock, patch, mock_open
-from common.ai import AI, ErrorMessage, pop_streaming_chunk
+import unittest
+from unittest.mock import Mock, patch, MagicMock
 
+from common.ai import (
+    AI, ErrorMessage, pop_streaming_chunk,
+    _build_llm_provider, _build_tts_provider, _build_stt_provider,
+)
+from common.providers import OpenAILLMProvider, OpenAITTSProvider, OpenAISTTProvider
+from common.providers.base import LLMProvider, TTSProvider, STTProvider
+
+
+def _make_config(**kwargs):
+    config = Mock()
+    config.botname = "TestBot"
+    config.api_timeout = 10
+    config.api_retry_attempts = 3
+    config.llm_provider = "openai"
+    config.tts_provider = "openai"
+    config.stt_provider = "openai"
+    config.debug = False
+    config.enable_error_logging = False
+    config.error_log_path = "/tmp/test-error.log"
+    for k, v in kwargs.items():
+        setattr(config, k, v)
+    return config
+
+
+def _make_providers():
+    llm = MagicMock(spec=LLMProvider)
+    tts = MagicMock(spec=TTSProvider)
+    stt = MagicMock(spec=STTProvider)
+    return llm, tts, stt
+
+
+# ---------------------------------------------------------------------------
+# ErrorMessage
+# ---------------------------------------------------------------------------
 
 class TestErrorMessage(unittest.TestCase):
-    def test_error_message_creation(self):
-        """Test ErrorMessage object creation"""
+    def test_content_stored(self):
         msg = ErrorMessage("Test error")
         self.assertEqual(msg.content, "Test error")
 
 
-class TestAIInitialization(unittest.TestCase):
-    def setUp(self):
-        """Set up test environment"""
-        self.temp_dir = tempfile.mkdtemp()
-        self.original_home = os.environ.get('HOME')
-        self.original_api_key = os.environ.get('OPENAI_API_KEY')
-        os.environ['HOME'] = self.temp_dir
-        os.environ['OPENAI_API_KEY'] = 'test-api-key'
-        os.makedirs(os.path.join(self.temp_dir, ".sandvoice"), exist_ok=True)
+# ---------------------------------------------------------------------------
+# AI.__init__
+# ---------------------------------------------------------------------------
 
-    def tearDown(self):
-        """Clean up test environment"""
-        if self.original_home is not None:
-            os.environ['HOME'] = self.original_home
-        else:
-            os.environ.pop('HOME', None)
+class TestAIInit(unittest.TestCase):
+    def test_stores_providers_and_config(self):
+        llm, tts, stt = _make_providers()
+        config = _make_config()
+        ai = AI(llm, tts, stt, config)
+        self.assertIs(ai._llm, llm)
+        self.assertIs(ai._tts, tts)
+        self.assertIs(ai._stt, stt)
+        self.assertIs(ai.config, config)
 
-        if self.original_api_key is not None:
-            os.environ['OPENAI_API_KEY'] = self.original_api_key
-        else:
-            os.environ.pop('OPENAI_API_KEY', None)
-
-        import shutil
-        shutil.rmtree(self.temp_dir, ignore_errors=True)
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    def test_init_success(self, mock_setup_logging, mock_openai):
-        """Test successful AI initialization"""
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-
-        ai = AI(mock_config)
-
-        self.assertIsNotNone(ai.openai_client)
+    def test_conversation_history_starts_empty(self):
+        ai = AI(*_make_providers(), _make_config())
         self.assertEqual(ai.conversation_history, [])
-        mock_setup_logging.assert_called_once_with(ai.config)
-        mock_openai.assert_called_once_with(timeout=10)
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    def test_init_missing_api_key(self, mock_setup_logging, mock_openai):
-        """Test initialization fails without API key"""
-        del os.environ['OPENAI_API_KEY']
-        mock_config = Mock()
-        mock_config.enable_error_logging = False
-        mock_config.error_log_path = '/tmp/error.log'
-
-        with self.assertRaises(ValueError) as context:
-            AI(mock_config)
-
-        self.assertIn("OPENAI_API_KEY", str(context.exception))
 
 
-class TestTranscribeAndTranslate(unittest.TestCase):
+# ---------------------------------------------------------------------------
+# AI.from_config
+# ---------------------------------------------------------------------------
+
+class TestAIFromConfig(unittest.TestCase):
     def setUp(self):
-        """Set up test environment"""
-        self.temp_dir = tempfile.mkdtemp()
-        self.original_home = os.environ.get('HOME')
-        self.original_api_key = os.environ.get('OPENAI_API_KEY')
-        os.environ['HOME'] = self.temp_dir
+        self.orig_key = os.environ.get('OPENAI_API_KEY')
         os.environ['OPENAI_API_KEY'] = 'test-key'
 
     def tearDown(self):
-        """Clean up"""
-        import shutil
-        # Restore original environment variables
-        if self.original_home is not None:
-            os.environ['HOME'] = self.original_home
-        elif 'HOME' in os.environ:
-            del os.environ['HOME']
-
-        if self.original_api_key is not None:
-            os.environ['OPENAI_API_KEY'] = self.original_api_key
-        elif 'OPENAI_API_KEY' in os.environ:
-            del os.environ['OPENAI_API_KEY']
-
-        shutil.rmtree(self.temp_dir, ignore_errors=True)
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    @patch('builtins.open', new_callable=mock_open, read_data=b'fake audio data')
-    def test_transcribe_success(self, mock_file, mock_setup, mock_openai_class):
-        """Test successful transcription"""
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.speech_to_text_model = 'whisper-1'
-        mock_config.speech_to_text_task = 'translate'
-        mock_config.speech_to_text_language = ''
-        mock_config.speech_to_text_translate_provider = 'whisper'
-        mock_config.speech_to_text_translate_model = 'gpt-5-mini'
-        mock_config.tmp_recording = '/tmp/recording'
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-
-        mock_transcript = Mock()
-        mock_transcript.text = "Hello world"
-        mock_client.audio.translations.create.return_value = mock_transcript
-
-        ai = AI(mock_config)
-        result = ai.transcribe_and_translate()
-
-        self.assertEqual(result, "Hello world")
-        mock_file.assert_called_once_with('/tmp/recording.mp3', 'rb')
-        mock_client.audio.translations.create.assert_called_once()
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    @patch('builtins.open', new_callable=mock_open, read_data=b'fake audio data')
-    def test_transcribe_task_transcribe_with_language_hint(self, mock_file, mock_setup, mock_openai_class):
-        """Test transcribe task keeps original language"""
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.speech_to_text_model = 'whisper-1'
-        mock_config.speech_to_text_task = 'transcribe'
-        mock_config.speech_to_text_language = 'pt'
-        mock_config.tmp_recording = '/tmp/recording'
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-
-        mock_transcript = Mock()
-        mock_transcript.text = "O que e uma lombriga?"
-        mock_client.audio.transcriptions.create.return_value = mock_transcript
-
-        ai = AI(mock_config)
-        result = ai.transcribe_and_translate()
-
-        self.assertEqual(result, "O que e uma lombriga?")
-        mock_file.assert_called_once_with('/tmp/recording.mp3', 'rb')
-        mock_client.audio.transcriptions.create.assert_called_once()
-        _args, kwargs = mock_client.audio.transcriptions.create.call_args
-        self.assertEqual(kwargs.get('language'), 'pt')
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    @patch('builtins.open', new_callable=mock_open, read_data=b'fake audio data')
-    def test_transcribe_task_transcribe_without_language_hint(self, mock_file, mock_setup, mock_openai_class):
-        """Test transcribe task omits language when not provided"""
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.speech_to_text_model = 'whisper-1'
-        mock_config.speech_to_text_task = 'transcribe'
-        mock_config.speech_to_text_language = ''
-        mock_config.tmp_recording = '/tmp/recording'
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-
-        mock_transcript = Mock()
-        mock_transcript.text = "Hello"
-        mock_client.audio.transcriptions.create.return_value = mock_transcript
-
-        ai = AI(mock_config)
-        result = ai.transcribe_and_translate()
-
-        self.assertEqual(result, "Hello")
-        _args, kwargs = mock_client.audio.transcriptions.create.call_args
-        self.assertNotIn('language', kwargs)
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    @patch('builtins.open', new_callable=mock_open, read_data=b'fake audio data')
-    def test_translate_provider_gpt_transcribe_then_translate(self, mock_file, mock_setup, mock_openai_class):
-        """Test translate via GPT uses transcribe then chat translate"""
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.speech_to_text_model = 'whisper-1'
-        mock_config.speech_to_text_task = 'translate'
-        mock_config.speech_to_text_language = 'pt'
-        mock_config.speech_to_text_translate_provider = 'gpt'
-        mock_config.speech_to_text_translate_model = 'gpt-5-mini'
-        mock_config.tmp_recording = '/tmp/recording'
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-
-        mock_transcript = Mock()
-        mock_transcript.text = "O que e uma lombriga?"
-        mock_client.audio.transcriptions.create.return_value = mock_transcript
-
-        mock_message = Mock()
-        mock_message.content = "What is a worm?"
-        mock_completion = Mock()
-        mock_completion.choices = [Mock(message=mock_message)]
-        mock_client.chat.completions.create.return_value = mock_completion
-
-        ai = AI(mock_config)
-        result = ai.transcribe_and_translate()
-
-        self.assertEqual(result, "What is a worm?")
-        mock_file.assert_called_once_with('/tmp/recording.mp3', 'rb')
-        mock_client.audio.transcriptions.create.assert_called_once()
-        mock_client.chat.completions.create.assert_called_once()
-        mock_client.audio.translations.create.assert_not_called()
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    @patch('builtins.open', new_callable=mock_open, read_data=b'fake audio data')
-    def test_translate_provider_gpt_skips_chat_on_empty_transcript(self, mock_file, mock_setup, mock_openai_class):
-        """Test translate via GPT returns empty and skips chat on empty transcript"""
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.speech_to_text_model = 'whisper-1'
-        mock_config.speech_to_text_task = 'translate'
-        mock_config.speech_to_text_language = 'pt'
-        mock_config.speech_to_text_translate_provider = 'gpt'
-        mock_config.speech_to_text_translate_model = 'gpt-5-mini'
-        mock_config.tmp_recording = '/tmp/recording'
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-
-        mock_transcript = Mock()
-        mock_transcript.text = "   "
-        mock_client.audio.transcriptions.create.return_value = mock_transcript
-
-        ai = AI(mock_config)
-        result = ai.transcribe_and_translate()
-
-        self.assertEqual(result, "")
-        mock_client.chat.completions.create.assert_not_called()
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    def test_transcribe_file_not_found(self, mock_setup, mock_openai_class):
-        """Test transcription with missing file"""
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.tmp_recording = '/nonexistent/recording'
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-
-        ai = AI(mock_config)
-
-        with self.assertRaises(FileNotFoundError):
-            ai.transcribe_and_translate()
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    @patch('builtins.open', new_callable=mock_open, read_data=b'fake audio data')
-    def test_transcribe_generic_exception(self, mock_file, mock_setup, mock_openai_class):
-        """Test transcription with generic API exception"""
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.speech_to_text_model = 'whisper-1'
-        mock_config.speech_to_text_task = 'translate'
-        mock_config.speech_to_text_language = ''
-        mock_config.speech_to_text_translate_provider = 'whisper'
-        mock_config.speech_to_text_translate_model = 'gpt-5-mini'
-        mock_config.tmp_recording = '/tmp/recording'
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-        mock_client.audio.translations.create.side_effect = Exception("API Error")
-
-        ai = AI(mock_config)
-
-        with self.assertRaises(Exception) as context:
-            ai.transcribe_and_translate()
-
-        self.assertIn("API Error", str(context.exception))
-        self.assertEqual(mock_client.audio.translations.create.call_count, 3)
-
-
-class TestGenerateResponse(unittest.TestCase):
-    def setUp(self):
-        """Set up test environment"""
-        self.original_api_key = os.environ.get('OPENAI_API_KEY')
-        os.environ['OPENAI_API_KEY'] = 'test-key'
-
-    def tearDown(self):
-        """Restore environment"""
-        if self.original_api_key is not None:
-            os.environ['OPENAI_API_KEY'] = self.original_api_key
+        if self.orig_key is not None:
+            os.environ['OPENAI_API_KEY'] = self.orig_key
         else:
             os.environ.pop('OPENAI_API_KEY', None)
 
     @patch('common.ai.OpenAI')
     @patch('common.ai.setup_error_logging')
-    def test_generate_response_success(self, mock_setup, mock_openai_class):
-        """Test successful response generation"""
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.gpt_response_model = 'gpt-3.5-turbo'
-        mock_config.botname = 'TestBot'
-        mock_config.language = 'English'
-        mock_config.timezone = 'EST'
-        mock_config.location = 'Test City'
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-
-        mock_message = Mock()
-        mock_message.content = "Hello! How can I help?"
-        mock_completion = Mock()
-        mock_completion.choices = [Mock(message=mock_message)]
-        mock_client.chat.completions.create.return_value = mock_completion
-
-        ai = AI(mock_config)
-        result = ai.generate_response("Hello")
-
-        self.assertEqual(result.content, "Hello! How can I help?")
-        self.assertEqual(len(ai.conversation_history), 2)
-        self.assertIn("User: Hello", ai.conversation_history[0])
-        self.assertIn("TestBot: Hello! How can I help?", ai.conversation_history[1])
+    def test_returns_ai_instance(self, mock_setup, mock_openai):
+        config = _make_config()
+        ai = AI.from_config(config)
+        self.assertIsInstance(ai, AI)
+        self.assertEqual(ai.conversation_history, [])
 
     @patch('common.ai.OpenAI')
     @patch('common.ai.setup_error_logging')
-    def test_generate_response_streaming_success(self, mock_setup, mock_openai_class):
-        """Test streaming response assembly produces final content."""
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.gpt_response_model = 'gpt-3.5-turbo'
-        mock_config.botname = 'TestBot'
-        mock_config.language = 'English'
-        mock_config.timezone = 'EST'
-        mock_config.location = 'Test City'
-        mock_config.debug = False
-        mock_config.stream_responses = True
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-
-        e1 = Mock()
-        e1.choices = [Mock(delta=Mock(content="Hello"))]
-        e2 = Mock()
-        e2.choices = [Mock(delta=Mock(content=" world"))]
-        e3 = Mock()
-        e3.choices = [Mock(delta=Mock(content="!"))]
-
-        mock_client.chat.completions.create.return_value = iter([e1, e2, e3])
-
-        ai = AI(mock_config)
-        result = ai.generate_response("Hello")
-
-        self.assertEqual(result.content, "Hello world!")
-        self.assertEqual(len(ai.conversation_history), 2)
-        self.assertIn("User: Hello", ai.conversation_history[0])
-        self.assertIn("TestBot: Hello world!", ai.conversation_history[1])
-
-        _args, kwargs = mock_client.chat.completions.create.call_args
-        self.assertTrue(kwargs.get('stream'))
+    def test_calls_setup_error_logging(self, mock_setup, mock_openai):
+        config = _make_config()
+        AI.from_config(config)
+        mock_setup.assert_called_once_with(config)
 
     @patch('common.ai.OpenAI')
     @patch('common.ai.setup_error_logging')
-    def test_generate_response_with_extra_info(self, mock_setup, mock_openai_class):
-        """Test response generation with extra context"""
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.gpt_response_model = 'gpt-3.5-turbo'
-        mock_config.botname = 'TestBot'
-        mock_config.language = 'English'
-        mock_config.timezone = 'EST'
-        mock_config.location = 'Test City'
-        mock_config.debug = False
+    def test_creates_openai_client_with_timeout(self, mock_setup, mock_openai):
+        config = _make_config(api_timeout=15)
+        AI.from_config(config)
+        mock_openai.assert_called_once_with(timeout=15)
 
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-
-        mock_message = Mock()
-        mock_message.content = "The weather is sunny"
-        mock_completion = Mock()
-        mock_completion.choices = [Mock(message=mock_message)]
-        mock_client.chat.completions.create.return_value = mock_completion
-
-        ai = AI(mock_config)
-        result = ai.generate_response("What's the weather?", extra_info="Temperature: 72F")
-
-        self.assertEqual(result.content, "The weather is sunny")
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    def test_generate_response_api_error(self, mock_setup, mock_openai_class):
-        """Test response generation with API error returns ErrorMessage"""
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.gpt_response_model = 'gpt-3.5-turbo'
-        mock_config.botname = 'TestBot'
-        mock_config.language = 'English'
-        mock_config.timezone = 'EST'
-        mock_config.location = 'Test City'
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-        mock_client.chat.completions.create.side_effect = Exception("API Error")
-
-        ai = AI(mock_config)
-        result = ai.generate_response("Hello")
-
-        self.assertIsInstance(result, ErrorMessage)
-        self.assertIn("trouble", result.content)
+    def test_raises_on_missing_api_key(self):
+        del os.environ['OPENAI_API_KEY']
+        config = _make_config()
+        with self.assertRaises(ValueError) as ctx:
+            AI.from_config(config)
+        self.assertIn("OPENAI_API_KEY", str(ctx.exception))
 
 
-class TestDefineRoute(unittest.TestCase):
+# ---------------------------------------------------------------------------
+# Provider factory helpers
+# ---------------------------------------------------------------------------
+
+class TestProviderFactories(unittest.TestCase):
     def setUp(self):
-        """Set up test environment"""
-        self.original_api_key = os.environ.get('OPENAI_API_KEY')
-        os.environ['OPENAI_API_KEY'] = 'test-key'
-        self.routes_yaml = """
-route_role: |
-  You are a routing bot.
-"""
+        self.client = Mock()
 
-    def tearDown(self):
-        """Restore original OPENAI_API_KEY environment variable"""
-        if self.original_api_key is not None:
-            os.environ['OPENAI_API_KEY'] = self.original_api_key
-        elif 'OPENAI_API_KEY' in os.environ:
-            del os.environ['OPENAI_API_KEY']
+    def test_build_llm_openai(self):
+        from common.providers import OpenAILLMProvider
+        config = _make_config(llm_provider="openai")
+        provider = _build_llm_provider(config, self.client)
+        self.assertIsInstance(provider, OpenAILLMProvider)
 
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    @patch('builtins.open', new_callable=mock_open)
-    def test_define_route_success(self, mock_file, mock_setup, mock_openai_class):
-        """Test successful route definition"""
-        mock_file.return_value.read.return_value = self.routes_yaml
+    def test_build_tts_openai(self):
+        from common.providers import OpenAITTSProvider
+        config = _make_config(tts_provider="openai")
+        provider = _build_tts_provider(config, self.client)
+        self.assertIsInstance(provider, OpenAITTSProvider)
 
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.gpt_route_model = 'gpt-3.5-turbo'
-        mock_config.location = 'Test City'
-        mock_config.sandvoice_path = '/test/path'
-        mock_config.debug = False
+    def test_build_stt_openai(self):
+        from common.providers import OpenAISTTProvider
+        config = _make_config(stt_provider="openai")
+        provider = _build_stt_provider(config, self.client)
+        self.assertIsInstance(provider, OpenAISTTProvider)
 
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
+    def test_unknown_llm_provider_raises(self):
+        config = _make_config(llm_provider="unknown")
+        with self.assertRaises(ValueError) as ctx:
+            _build_llm_provider(config, self.client)
+        self.assertIn("unknown", str(ctx.exception))
 
-        mock_message = Mock()
-        mock_message.content = '{"route": "weather", "reason": "User asked about weather"}'
-        mock_completion = Mock()
-        mock_completion.choices = [Mock(message=mock_message)]
-        mock_client.chat.completions.create.return_value = mock_completion
+    def test_unknown_tts_provider_raises(self):
+        config = _make_config(tts_provider="unknown")
+        with self.assertRaises(ValueError) as ctx:
+            _build_tts_provider(config, self.client)
+        self.assertIn("unknown", str(ctx.exception))
 
-        ai = AI(mock_config)
-        result = ai.define_route("What's the weather?")
+    def test_unknown_stt_provider_raises(self):
+        config = _make_config(stt_provider="unknown")
+        with self.assertRaises(ValueError) as ctx:
+            _build_stt_provider(config, self.client)
+        self.assertIn("unknown", str(ctx.exception))
 
+
+# ---------------------------------------------------------------------------
+# AI.generate_response — history management
+# ---------------------------------------------------------------------------
+
+class TestAIGenerateResponse(unittest.TestCase):
+    def setUp(self):
+        self.llm, self.tts, self.stt = _make_providers()
+        self.config = _make_config()
+        self.ai = AI(self.llm, self.tts, self.stt, self.config)
+
+    def _mock_result(self, content):
+        msg = Mock()
+        msg.content = content
+        self.llm.generate_response.return_value = msg
+        return msg
+
+    def test_delegates_to_llm(self):
+        self._mock_result("Hello!")
+        result = self.ai.generate_response("hi")
+        self.llm.generate_response.assert_called_once_with(
+            "hi", [], extra_info=None, model=None
+        )
+        self.assertEqual(result.content, "Hello!")
+
+    def test_appends_user_and_assistant_to_history(self):
+        self._mock_result("Hello!")
+        self.ai.generate_response("hi")
+        self.assertEqual(len(self.ai.conversation_history), 2)
+        self.assertEqual(self.ai.conversation_history[0], "User: hi")
+        self.assertEqual(self.ai.conversation_history[1], "TestBot: Hello!")
+
+    def test_passes_prior_history_to_provider(self):
+        self.ai.conversation_history = ["User: prev", "TestBot: ok"]
+        self._mock_result("Good")
+        self.ai.generate_response("next")
+        call_args = self.llm.generate_response.call_args
+        history_passed = call_args[0][1]
+        self.assertEqual(history_passed, ["User: prev", "TestBot: ok"])
+
+    def test_does_not_duplicate_user_turn_on_retry(self):
+        self.ai.conversation_history = ["User: hi"]
+        self._mock_result("Hi again")
+        self.ai.generate_response("hi")
+        user_turns = [m for m in self.ai.conversation_history if m == "User: hi"]
+        self.assertEqual(len(user_turns), 1)
+
+    def test_extra_info_forwarded(self):
+        self._mock_result("Sunny")
+        self.ai.generate_response("weather?", extra_info="72F")
+        call_kwargs = self.llm.generate_response.call_args[1]
+        self.assertEqual(call_kwargs["extra_info"], "72F")
+
+    def test_model_forwarded(self):
+        self._mock_result("ok")
+        self.ai.generate_response("hi", model="gpt-4")
+        call_kwargs = self.llm.generate_response.call_args[1]
+        self.assertEqual(call_kwargs["model"], "gpt-4")
+
+    def test_error_message_still_updates_history(self):
+        error = ErrorMessage("Sorry, having trouble.")
+        self.llm.generate_response.return_value = error
+        result = self.ai.generate_response("hi")
+        self.assertIsInstance(result, ErrorMessage)
+        self.assertEqual(len(self.ai.conversation_history), 2)
+
+
+# ---------------------------------------------------------------------------
+# AI.stream_response_deltas — history management
+# ---------------------------------------------------------------------------
+
+class TestAIStreamResponseDeltas(unittest.TestCase):
+    def setUp(self):
+        self.llm, self.tts, self.stt = _make_providers()
+        self.config = _make_config()
+        self.ai = AI(self.llm, self.tts, self.stt, self.config)
+
+    def test_yields_deltas(self):
+        self.llm.stream_response_deltas.return_value = iter(["Hello", " there", "!"])
+        pieces = list(self.ai.stream_response_deltas("hi"))
+        self.assertEqual(pieces, ["Hello", " there", "!"])
+
+    def test_appends_user_and_assistant_to_history_on_success(self):
+        self.llm.stream_response_deltas.return_value = iter(["Hello", " there"])
+        list(self.ai.stream_response_deltas("hi"))
+        self.assertEqual(len(self.ai.conversation_history), 2)
+        self.assertEqual(self.ai.conversation_history[0], "User: hi")
+        self.assertEqual(self.ai.conversation_history[1], "TestBot: Hello there")
+
+    def test_user_turn_in_history_on_stream_failure(self):
+        def _broken():
+            yield "Hello"
+            raise RuntimeError("boom")
+
+        self.llm.stream_response_deltas.return_value = _broken()
+        gen = self.ai.stream_response_deltas("hi")
+        self.assertEqual(next(gen), "Hello")
+        with self.assertRaises(RuntimeError):
+            list(gen)
+        # User turn present; assistant turn absent.
+        self.assertEqual(len(self.ai.conversation_history), 1)
+        self.assertEqual(self.ai.conversation_history[0], "User: hi")
+
+    def test_provider_receives_history_without_current_user_turn(self):
+        self.ai.conversation_history = ["User: prev", "TestBot: ok"]
+        self.llm.stream_response_deltas.return_value = iter(["hi"])
+        list(self.ai.stream_response_deltas("next"))
+        call_args = self.llm.stream_response_deltas.call_args
+        history_passed = call_args[0][1]
+        # Should be prior turns only — not include "User: next"
+        self.assertEqual(history_passed, ["User: prev", "TestBot: ok"])
+
+    def test_does_not_duplicate_user_turn(self):
+        self.ai.conversation_history = ["User: hi"]
+        self.llm.stream_response_deltas.return_value = iter(["ok"])
+        list(self.ai.stream_response_deltas("hi"))
+        user_turns = [m for m in self.ai.conversation_history if m == "User: hi"]
+        self.assertEqual(len(user_turns), 1)
+
+
+# ---------------------------------------------------------------------------
+# AI.transcribe_and_translate
+# ---------------------------------------------------------------------------
+
+class TestAITranscribeAndTranslate(unittest.TestCase):
+    def test_delegates_to_stt(self):
+        llm, tts, stt = _make_providers()
+        stt.transcribe.return_value = "hello"
+        ai = AI(llm, tts, stt, _make_config())
+        result = ai.transcribe_and_translate(audio_file_path="/tmp/test.mp3")
+        stt.transcribe.assert_called_once_with(audio_file_path="/tmp/test.mp3", model=None)
+        self.assertEqual(result, "hello")
+
+    def test_forwards_model(self):
+        llm, tts, stt = _make_providers()
+        stt.transcribe.return_value = "hello"
+        ai = AI(llm, tts, stt, _make_config())
+        ai.transcribe_and_translate(model="whisper-1", audio_file_path="/tmp/test.mp3")
+        stt.transcribe.assert_called_once_with(audio_file_path="/tmp/test.mp3", model="whisper-1")
+
+
+# ---------------------------------------------------------------------------
+# AI.define_route
+# ---------------------------------------------------------------------------
+
+class TestAIDefineRoute(unittest.TestCase):
+    def test_delegates_to_llm(self):
+        llm, tts, stt = _make_providers()
+        llm.define_route.return_value = {"route": "weather", "reason": "weather query"}
+        ai = AI(llm, tts, stt, _make_config())
+        result = ai.define_route("what is the weather?")
+        llm.define_route.assert_called_once_with(
+            "what is the weather?", model=None, extra_routes=None
+        )
         self.assertEqual(result["route"], "weather")
-        self.assertIn("reason", result)
 
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    @patch('builtins.open', new_callable=mock_open)
-    def test_define_route_normalizes_legacy_default_route_name(self, mock_file, mock_setup, mock_openai_class):
-        """Legacy default-rote output must normalize to default-route."""
-        mock_file.return_value.read.return_value = self.routes_yaml
+    def test_forwards_extra_routes(self):
+        llm, tts, stt = _make_providers()
+        llm.define_route.return_value = {"route": "default-route", "reason": "fallback"}
+        ai = AI(llm, tts, stt, _make_config())
+        ai.define_route("hi", extra_routes="\n- custom-route: do stuff")
+        call_kwargs = llm.define_route.call_args[1]
+        self.assertIn("custom-route", call_kwargs["extra_routes"])
 
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.gpt_route_model = 'gpt-3.5-turbo'
-        mock_config.location = 'Test City'
-        mock_config.sandvoice_path = '/test/path'
-        mock_config.debug = False
 
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
+# ---------------------------------------------------------------------------
+# AI.text_to_speech
+# ---------------------------------------------------------------------------
 
-        mock_message = Mock()
-        mock_message.content = '{"route": "default-rote", "reason": "fallback"}'
-        mock_completion = Mock()
-        mock_completion.choices = [Mock(message=mock_message)]
-        mock_client.chat.completions.create.return_value = mock_completion
+class TestAITextToSpeech(unittest.TestCase):
+    def test_delegates_to_tts(self):
+        llm, tts, stt = _make_providers()
+        tts.text_to_speech.return_value = ["/tmp/tts-001.mp3"]
+        ai = AI(llm, tts, stt, _make_config())
+        result = ai.text_to_speech("hello")
+        tts.text_to_speech.assert_called_once_with("hello", model=None, voice=None)
+        self.assertEqual(result, ["/tmp/tts-001.mp3"])
 
-        ai = AI(mock_config)
-        result = ai.define_route("Hello")
+    def test_forwards_model_and_voice(self):
+        llm, tts, stt = _make_providers()
+        tts.text_to_speech.return_value = []
+        ai = AI(llm, tts, stt, _make_config())
+        ai.text_to_speech("hi", model="tts-1-hd", voice="nova")
+        tts.text_to_speech.assert_called_once_with("hi", model="tts-1-hd", voice="nova")
 
-        self.assertEqual(result["route"], "default-route")
-        self.assertEqual(result["reason"], "fallback")
 
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    @patch('builtins.open', new_callable=mock_open)
-    def test_define_route_invalid_shape_falls_back_to_default_route(self, mock_file, mock_setup, mock_openai_class):
-        """Non-dict JSON route output must fail closed to the default route."""
-        mock_file.return_value.read.return_value = self.routes_yaml
+# ---------------------------------------------------------------------------
+# AI.text_summary
+# ---------------------------------------------------------------------------
 
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.gpt_route_model = 'gpt-3.5-turbo'
-        mock_config.location = 'Test City'
-        mock_config.sandvoice_path = '/test/path'
-        mock_config.debug = False
+class TestAITextSummary(unittest.TestCase):
+    def test_delegates_to_llm(self):
+        llm, tts, stt = _make_providers()
+        llm.text_summary.return_value = {"title": "T", "text": "S"}
+        ai = AI(llm, tts, stt, _make_config())
+        result = ai.text_summary("long article")
+        llm.text_summary.assert_called_once_with(
+            "long article", extra_info=None, words="100", model=None
+        )
+        self.assertEqual(result["title"], "T")
 
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
+    def test_forwards_words_and_extra_info(self):
+        llm, tts, stt = _make_providers()
+        llm.text_summary.return_value = {"title": "T", "text": "S"}
+        ai = AI(llm, tts, stt, _make_config())
+        ai.text_summary("article", extra_info="recipe", words="50")
+        call_kwargs = llm.text_summary.call_args[1]
+        self.assertEqual(call_kwargs["words"], "50")
+        self.assertEqual(call_kwargs["extra_info"], "recipe")
 
-        mock_message = Mock()
-        mock_message.content = '["default-rote", "fallback"]'
-        mock_completion = Mock()
-        mock_completion.choices = [Mock(message=mock_message)]
-        mock_client.chat.completions.create.return_value = mock_completion
 
-        ai = AI(mock_config)
-        result = ai.define_route("Hello")
-
-        self.assertEqual(result["route"], "default-route")
-        self.assertEqual(result["reason"], "Invalid route response")
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    def test_define_route_file_not_found(self, mock_setup, mock_openai_class):
-        """Test route definition with missing routes file"""
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.sandvoice_path = '/nonexistent'
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-
-        ai = AI(mock_config)
-        result = ai.define_route("Hello")
-
-        self.assertEqual(result["route"], "default-route")
-        self.assertIn("Error", result["reason"])
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    @patch('builtins.open', new_callable=mock_open)
-    def test_define_route_json_parse_error(self, mock_file, mock_setup, mock_openai_class):
-        """Test route definition with invalid JSON response"""
-        mock_file.return_value.read.return_value = self.routes_yaml
-
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.gpt_route_model = 'gpt-3.5-turbo'
-        mock_config.location = 'Test City'
-        mock_config.sandvoice_path = '/test/path'
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-
-        mock_message = Mock()
-        mock_message.content = 'invalid json'
-        mock_completion = Mock()
-        mock_completion.choices = [Mock(message=mock_message)]
-        mock_client.chat.completions.create.return_value = mock_completion
-
-        ai = AI(mock_config)
-        result = ai.define_route("Hello")
-
-        self.assertEqual(result["route"], "default-route")
-        self.assertIn("Parse error", result["reason"])
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    @patch('builtins.open', new_callable=mock_open)
-    def test_define_route_api_exception(self, mock_file, mock_setup, mock_openai_class):
-        """Test route definition with API exception"""
-        mock_file.return_value.read.return_value = self.routes_yaml
-
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.gpt_route_model = 'gpt-3.5-turbo'
-        mock_config.location = 'Test City'
-        mock_config.sandvoice_path = '/test/path'
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-        mock_client.chat.completions.create.side_effect = Exception("API Error")
-
-        ai = AI(mock_config)
-        result = ai.define_route("Hello")
-
-        self.assertEqual(result["route"], "default-route")
-        self.assertIn("API error", result["reason"])
-
+# ---------------------------------------------------------------------------
+# pop_streaming_chunk (unchanged utility)
+# ---------------------------------------------------------------------------
 
 class TestStreamingHelpers(unittest.TestCase):
     def test_pop_streaming_chunk_sentence_boundary(self):
@@ -650,170 +404,6 @@ class TestStreamingHelpers(unittest.TestCase):
         chunk = chunk or ""
         self.assertLessEqual(len(chunk), max_chars)
         self.assertEqual((chunk + rest), buf)
-
-
-class TestStreamResponseDeltas(unittest.TestCase):
-    def setUp(self):
-        self.original_api_key = os.environ.get('OPENAI_API_KEY')
-        os.environ['OPENAI_API_KEY'] = 'test-key'
-
-    def tearDown(self):
-        if self.original_api_key is not None:
-            os.environ['OPENAI_API_KEY'] = self.original_api_key
-        else:
-            os.environ.pop('OPENAI_API_KEY', None)
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    def test_stream_response_deltas_assembles_and_updates_history(self, mock_setup, mock_openai_class):
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.gpt_response_model = 'gpt-3.5-turbo'
-        mock_config.botname = 'TestBot'
-        mock_config.language = 'English'
-        mock_config.timezone = 'EST'
-        mock_config.location = 'Test City'
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-
-        e1 = Mock()
-        e1.choices = [Mock(delta=Mock(content="Hello"))]
-        e2 = Mock()
-        e2.choices = [Mock(delta=Mock(content=" there"))]
-        e3 = Mock()
-        e3.choices = [Mock(delta=Mock(content="!"))]
-        mock_client.chat.completions.create.return_value = iter([e1, e2, e3])
-
-        ai = AI(mock_config)
-        pieces = list(ai.stream_response_deltas("Hi"))
-        self.assertEqual("".join(pieces), "Hello there!")
-        self.assertEqual(len(ai.conversation_history), 2)
-        self.assertIn("User: Hi", ai.conversation_history[0])
-        self.assertIn("TestBot: Hello there!", ai.conversation_history[1])
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    def test_stream_response_deltas_does_not_append_partial_assistant_on_failure(self, mock_setup, mock_openai_class):
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.gpt_response_model = 'gpt-3.5-turbo'
-        mock_config.botname = 'TestBot'
-        mock_config.language = 'English'
-        mock_config.timezone = 'EST'
-        mock_config.location = 'Test City'
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-
-        def _broken_stream():
-            e1 = Mock()
-            e1.choices = [Mock(delta=Mock(content="Hello"))]
-            yield e1
-            raise RuntimeError("boom")
-
-        mock_client.chat.completions.create.return_value = _broken_stream()
-
-        ai = AI(mock_config)
-        gen = ai.stream_response_deltas("Hi")
-        self.assertEqual(next(gen), "Hello")
-        with self.assertRaises(RuntimeError):
-            list(gen)
-
-        # Only the user turn should be present; assistant turn should not be persisted.
-        self.assertEqual(len(ai.conversation_history), 1)
-        self.assertIn("User: Hi", ai.conversation_history[0])
-
-
-class TestTextSummary(unittest.TestCase):
-    def setUp(self):
-        """Set up test environment"""
-        self.original_api_key = os.environ.get('OPENAI_API_KEY')
-        os.environ['OPENAI_API_KEY'] = 'test-key'
-
-    def tearDown(self):
-        """Restore environment"""
-        if self.original_api_key is not None:
-            os.environ['OPENAI_API_KEY'] = self.original_api_key
-        else:
-            os.environ.pop('OPENAI_API_KEY', None)
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    def test_text_summary_success(self, mock_setup, mock_openai_class):
-        """Test successful text summarization"""
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.gpt_summary_model = 'gpt-3.5-turbo'
-        mock_config.language = 'English'
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-
-        mock_message = Mock()
-        mock_message.content = '{"title": "Test Article", "text": "This is a summary"}'
-        mock_completion = Mock()
-        mock_completion.choices = [Mock(message=mock_message)]
-        mock_client.chat.completions.create.return_value = mock_completion
-
-        ai = AI(mock_config)
-        result = ai.text_summary("Long text to summarize", words="50")
-
-        self.assertEqual(result["title"], "Test Article")
-        self.assertEqual(result["text"], "This is a summary")
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    def test_text_summary_json_error(self, mock_setup, mock_openai_class):
-        """Test summary with JSON parse error"""
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.gpt_summary_model = 'gpt-3.5-turbo'
-        mock_config.language = 'English'
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-
-        mock_message = Mock()
-        mock_message.content = 'invalid json'
-        mock_completion = Mock()
-        mock_completion.choices = [Mock(message=mock_message)]
-        mock_client.chat.completions.create.return_value = mock_completion
-
-        ai = AI(mock_config)
-        result = ai.text_summary("Long text")
-
-        self.assertEqual(result["title"], "Error")
-        self.assertIn("Unable", result["text"])
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    def test_text_summary_api_exception(self, mock_setup, mock_openai_class):
-        """Test summary with API exception"""
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 3
-        mock_config.gpt_summary_model = 'gpt-3.5-turbo'
-        mock_config.language = 'English'
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-        mock_client.chat.completions.create.side_effect = Exception("API Error")
-
-        ai = AI(mock_config)
-        result = ai.text_summary("Long text")
-
-        self.assertEqual(result["title"], "Error")
-        self.assertIn("Unable", result["text"])
 
 
 if __name__ == '__main__':

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -119,6 +119,15 @@ class TestAIFromConfig(unittest.TestCase):
 
     @patch('common.ai.OpenAI')
     @patch('common.ai.setup_error_logging')
+    def test_whitespace_only_provider_defaults_to_openai(self, mock_setup, mock_openai):
+        # Whitespace-only provider values must normalize to "openai", not raise
+        # Unknown provider: '' — same as None/empty.
+        config = _make_config(llm_provider="   ", tts_provider="   ", stt_provider="   ")
+        ai = AI.from_config(config)
+        self.assertIsInstance(ai, AI)
+
+    @patch('common.ai.OpenAI')
+    @patch('common.ai.setup_error_logging')
     def test_openai_client_accessible_after_from_config(self, mock_setup, mock_openai):
         config = _make_config()
         ai = AI.from_config(config)

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -106,6 +106,32 @@ class TestAIFromConfig(unittest.TestCase):
             AI.from_config(config)
         self.assertIn("OPENAI_API_KEY", str(ctx.exception))
 
+    def test_unknown_provider_raises_before_api_key_check(self):
+        # Provider validation must happen before the API key check so a
+        # misconfigured provider name gives the actionable error, not a
+        # misleading "Missing OPENAI_API_KEY" message.
+        del os.environ['OPENAI_API_KEY']
+        config = _make_config(llm_provider="mistral")
+        with self.assertRaises(ValueError) as ctx:
+            AI.from_config(config)
+        self.assertIn("llm_provider", str(ctx.exception))
+        self.assertNotIn("OPENAI_API_KEY", str(ctx.exception))
+
+    @patch('common.ai.OpenAI')
+    @patch('common.ai.setup_error_logging')
+    def test_openai_client_accessible_after_from_config(self, mock_setup, mock_openai):
+        config = _make_config()
+        ai = AI.from_config(config)
+        # from_config stores the client; the property must return it.
+        self.assertIs(ai.openai_client, mock_openai.return_value)
+
+    def test_openai_client_raises_when_not_set(self):
+        llm, tts, stt = _make_providers()
+        ai = AI(llm, tts, stt, _make_config())
+        with self.assertRaises(AttributeError) as ctx:
+            _ = ai.openai_client
+        self.assertIn("from_config", str(ctx.exception))
+
 
 # ---------------------------------------------------------------------------
 # Provider factory helpers

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -142,19 +142,16 @@ class TestProviderFactories(unittest.TestCase):
         self.client = Mock()
 
     def test_build_llm_openai(self):
-        from common.providers import OpenAILLMProvider
         config = _make_config(llm_provider="openai")
         provider = _build_llm_provider(config, self.client)
         self.assertIsInstance(provider, OpenAILLMProvider)
 
     def test_build_tts_openai(self):
-        from common.providers import OpenAITTSProvider
         config = _make_config(tts_provider="openai")
         provider = _build_tts_provider(config, self.client)
         self.assertIsInstance(provider, OpenAITTSProvider)
 
     def test_build_stt_openai(self):
-        from common.providers import OpenAISTTProvider
         config = _make_config(stt_provider="openai")
         provider = _build_stt_provider(config, self.client)
         self.assertIsInstance(provider, OpenAISTTProvider)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1600,9 +1600,8 @@ class TestWarmupCache(unittest.TestCase):
              patch("sandvoice._SchedulerContext"), \
              patch("sandvoice.threading.Thread", side_effect=real_thread):
             sv._warmup_cache()
-
-        for t in threads:
-            t.join(timeout=5)
+            for t in threads:
+                t.join(timeout=5)
 
         self.assertEqual(len(call_count), 2)
 

--- a/tests/test_tts_chunking.py
+++ b/tests/test_tts_chunking.py
@@ -50,7 +50,7 @@ class TestSplitTextForTTS(unittest.TestCase):
         self.assertTrue(chunks[0].endswith("."))
 
 
-class TestTextToSpeechChunking(unittest.TestCase):
+class TestTextToSpeechDelegation(unittest.TestCase):
     """Tests that AI.text_to_speech delegates correctly to the TTS provider.
 
     Detailed chunking, file naming, and cleanup behaviour is tested in

--- a/tests/test_tts_chunking.py
+++ b/tests/test_tts_chunking.py
@@ -76,11 +76,13 @@ class TestTextToSpeechChunking(unittest.TestCase):
         ai, tts = self._make_ai(["/tmp/chunk-001.mp3", "/tmp/chunk-002.mp3"])
         files = ai.text_to_speech("long text")
         self.assertEqual(len(files), 2)
+        tts.text_to_speech.assert_called_once_with("long text", model=None, voice=None)
 
     def test_text_to_speech_returns_empty_on_failure(self):
         ai, tts = self._make_ai([])
         result = ai.text_to_speech("hello")
         self.assertEqual(result, [])
+        tts.text_to_speech.assert_called_once_with("hello", model=None, voice=None)
 
 
 

--- a/tests/test_tts_chunking.py
+++ b/tests/test_tts_chunking.py
@@ -1,11 +1,8 @@
-import os
-import shutil
-import logging
 import unittest
-import tempfile
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock
 
 from common.ai import AI, split_text_for_tts
+from common.providers.base import LLMProvider, TTSProvider, STTProvider
 
 
 class TestSplitTextForTTS(unittest.TestCase):
@@ -54,125 +51,36 @@ class TestSplitTextForTTS(unittest.TestCase):
 
 
 class TestTextToSpeechChunking(unittest.TestCase):
-    def setUp(self):
-        self.temp_dir = tempfile.mkdtemp()
-        self.original_api_key = os.environ.get('OPENAI_API_KEY')
-        os.environ['OPENAI_API_KEY'] = 'test-key'
+    """Tests that AI.text_to_speech delegates correctly to the TTS provider.
 
-        # Keep unit test output clean (text_to_speech logs errors on failure paths).
-        logging.disable(logging.CRITICAL)
+    Detailed chunking, file naming, and cleanup behaviour is tested in
+    tests/test_openai_providers.py::TestOpenAITTSProviderTextToSpeech.
+    """
 
-    def tearDown(self):
-        logging.disable(logging.NOTSET)
+    def _make_ai(self, tts_return_value):
+        config = MagicMock()
+        config.debug = False
+        llm = MagicMock(spec=LLMProvider)
+        tts = MagicMock(spec=TTSProvider)
+        stt = MagicMock(spec=STTProvider)
+        tts.text_to_speech.return_value = tts_return_value
+        return AI(llm, tts, stt, config), tts
 
-        if self.original_api_key is not None:
-            os.environ['OPENAI_API_KEY'] = self.original_api_key
-        else:
-            del os.environ['OPENAI_API_KEY']
-
-        shutil.rmtree(self.temp_dir, ignore_errors=True)
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    @patch('common.ai.uuid.uuid4')
-    def test_text_to_speech_returns_file_list(self, mock_uuid4, mock_setup, mock_openai_class):
-        mock_uuid4.return_value = Mock(hex='abc123')
-
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 1
-        mock_config.text_to_speech_model = 'tts-1'
-        mock_config.bot_voice_model = 'nova'
-        mock_config.tmp_files_path = self.temp_dir
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-
-        mock_response = Mock()
-        mock_response.stream_to_file = Mock()
-        mock_client.audio.speech.create.return_value = mock_response
-
-        ai = AI(mock_config)
+    def test_text_to_speech_returns_file_list(self):
+        ai, tts = self._make_ai(["/tmp/tts-001.mp3"])
         files = ai.text_to_speech("Hello world")
+        self.assertEqual(files, ["/tmp/tts-001.mp3"])
+        tts.text_to_speech.assert_called_once_with("Hello world", model=None, voice=None)
 
-        self.assertEqual(len(files), 1)
-        expected_path = os.path.join(self.temp_dir, 'tts-response-abc123-chunk-001.mp3')
-        self.assertEqual(files[0], expected_path)
-        mock_response.stream_to_file.assert_called_once_with(expected_path)
+    def test_text_to_speech_multi_chunk(self):
+        ai, tts = self._make_ai(["/tmp/chunk-001.mp3", "/tmp/chunk-002.mp3"])
+        files = ai.text_to_speech("long text")
+        self.assertEqual(len(files), 2)
 
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    @patch('common.ai.uuid.uuid4')
-    @patch('common.ai.split_text_for_tts')
-    def test_text_to_speech_multi_chunk(self, mock_split, mock_uuid4, mock_setup, mock_openai_class):
-        mock_split.return_value = ["chunk1", "chunk2"]
-        mock_uuid4.return_value = Mock(hex='abc123')
-
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 1
-        mock_config.text_to_speech_model = 'tts-1'
-        mock_config.bot_voice_model = 'nova'
-        mock_config.tmp_files_path = self.temp_dir
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-
-        mock_response = Mock()
-        mock_response.stream_to_file = Mock()
-        mock_client.audio.speech.create.return_value = mock_response
-
-        ai = AI(mock_config)
-        files = ai.text_to_speech("ignored")
-
-        mock_split.assert_called_once_with("ignored")
-
-        self.assertEqual(files, [
-            os.path.join(self.temp_dir, 'tts-response-abc123-chunk-001.mp3'),
-            os.path.join(self.temp_dir, 'tts-response-abc123-chunk-002.mp3'),
-        ])
-        self.assertEqual(mock_client.audio.speech.create.call_count, 2)
-        self.assertEqual(mock_response.stream_to_file.call_count, 2)
-
-    @patch('common.ai.OpenAI')
-    @patch('common.ai.setup_error_logging')
-    @patch('common.ai.uuid.uuid4')
-    @patch('common.ai.split_text_for_tts')
-    def test_text_to_speech_cleanup_on_chunk_failure(self, mock_split, mock_uuid4, mock_setup, mock_openai_class):
-        mock_split.return_value = ["chunk1", "chunk2"]
-        mock_uuid4.return_value = Mock(hex='abc123')
-
-        mock_config = Mock()
-        mock_config.api_timeout = 10
-        mock_config.api_retry_attempts = 1
-        mock_config.text_to_speech_model = 'tts-1'
-        mock_config.bot_voice_model = 'nova'
-        mock_config.tmp_files_path = self.temp_dir
-        mock_config.debug = False
-
-        mock_client = Mock()
-        mock_openai_class.return_value = mock_client
-
-        speech_response = Mock()
-
-        def write_file(path):
-            with open(path, 'wb') as f:
-                f.write(b'fake mp3')
-
-        speech_response.stream_to_file.side_effect = write_file
-
-        # First chunk succeeds, second chunk raises before writing.
-        mock_client.audio.speech.create.side_effect = [speech_response, Exception("boom")]
-
-        ai = AI(mock_config)
-        result = ai.text_to_speech("ignored")
-
+    def test_text_to_speech_returns_empty_on_failure(self):
+        ai, tts = self._make_ai([])
+        result = ai.text_to_speech("hello")
         self.assertEqual(result, [])
-
-        first_path = os.path.join(self.temp_dir, 'tts-response-abc123-chunk-001.mp3')
-        self.assertFalse(os.path.exists(first_path))
 
 
 


### PR DESCRIPTION
## Summary

- `AI.__init__` now takes `(llm, tts, stt, config)` — all capability calls delegate to provider instances
- `AI.from_config(config)` is the standard construction path; `sandvoice.py` updated at all three call sites
- `_build_llm/tts/stt_provider()` factory helpers raise `ValueError` on unknown provider name (fast startup fail)
- `llm_provider`, `tts_provider`, `stt_provider` config keys added (all default to `"openai"`)
- `AI` owns `conversation_history`; providers receive snapshots and never mutate it
- Deferred imports in `_build_*_provider` helpers break the `ai.py` ↔ `openai_llm.py` circular dependency

## Planning Document
Implements plan/completed/43-ai-facade-migration.md

## Changes
- `common/ai.py` — rewritten: `AI` is now a facade; all OpenAI logic removed from instance methods
- `common/configuration.py` — three new provider config keys added to defaults and `load_config()`
- `sandvoice.py` — three `AI(self.config)` calls replaced with `AI.from_config(self.config)`
- `tests/test_ai.py` — rewritten to use mock providers; tests `from_config`, provider factories, delegation, and history management
- `tests/test_tts_chunking.py` — `TestTextToSpeechChunking` replaced with delegation-contract tests; detailed chunking tests live in `test_openai_providers.py`

## Testing
- [x] All tests pass: 924 passing
- [x] Coverage >80%
- [x] Tested on Mac M1
- [ ] Tested on Pi 3B

## Configuration Changes
```yaml
llm_provider: openai   # LLM provider (only "openai" supported)
tts_provider: openai   # TTS provider (only "openai" supported)
stt_provider: openai   # STT provider (only "openai" supported)
```