### PR TITLE
Add plans 44, 45, 46: complete provider interface coverage

### DIFF
--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -204,7 +204,7 @@ plan/
 
 ### Priority 44: LLMProvider one_shot Method
 **Document**: [backlog/44-llm-provider-one-shot.md](./backlog/44-llm-provider-one-shot.md)
-**Description**: Add `one_shot(prompt, model=None)` to `LLMProvider` ABC, implement in `OpenAILLMProvider` (delegates to `generate_response` with empty history), and expose on `AI`. Enables single-turn LLM calls that do not affect conversation history. Foundation for Plan 46.
+**Description**: Add `one_shot(prompt, model=None)` to `LLMProvider` ABC, implement in `OpenAILLMProvider` as a direct single-turn, system-role-free call (not delegated to `generate_response`), and expose on `AI`. Enables single-turn LLM calls that do not affect conversation history. Foundation for Plan 46.
 
 ### Priority 45: LLMProvider web_search Method
 **Document**: [backlog/45-llm-provider-web-search.md](./backlog/45-llm-provider-web-search.md)

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -202,6 +202,18 @@ plan/
 **Document**: [backlog/37-context-aware-routing.md](./backlog/37-context-aware-routing.md)
 **Description**: Pass the last N conversation turns to `define_route` so the routing LLM can correctly resolve follow-up utterances. Fixes misrouting of clarifications (e.g. "I mean the FIFA World Cup" after a realtime_websearch query routing to `news`).
 
+### Priority 44: LLMProvider one_shot Method
+**Document**: [backlog/44-llm-provider-one-shot.md](./backlog/44-llm-provider-one-shot.md)
+**Description**: Add `one_shot(prompt, model=None)` to `LLMProvider` ABC, implement in `OpenAILLMProvider` (delegates to `generate_response` with empty history), and expose on `AI`. Enables single-turn LLM calls that do not affect conversation history. Foundation for Plan 46.
+
+### Priority 45: LLMProvider web_search Method
+**Document**: [backlog/45-llm-provider-web-search.md](./backlog/45-llm-provider-web-search.md)
+**Description**: Add `web_search(query, instructions, model=None, include=None)` to `LLMProvider` ABC, implement in `OpenAILLMProvider` using the Responses API with `retry_with_backoff` and consistent error result, and expose on `AI`. Foundation for Plan 46.
+
+### Priority 46: Remove openai_client Escape Hatch
+**Document**: [backlog/46-remove-openai-client-escape-hatch.md](./backlog/46-remove-openai-client-escape-hatch.md)
+**Description**: Migrate `voice_filler.py` to `ai.one_shot()` and `realtime_websearch/plugin.py` to `ai.web_search()`, then remove the `openai_client` property and `_openai_client` attribute from `AI` entirely. After this plan, no plugin or instance method touches the OpenAI SDK directly. Requires Plans 44 and 45.
+
 ### Future Enhancements
 **Document**: [backlog/FUTURE.md](./backlog/FUTURE.md)
 **Description**: Long-term feature ideas including API Cost Management, Conversation History Management, Code Deduplication, Timers & Reminders, Music Control, Smart Home Integration, Calendar Integration, Todo List Management, Multi-User Support, and Conversation Memory.

--- a/plan/backlog/44-llm-provider-one-shot.md
+++ b/plan/backlog/44-llm-provider-one-shot.md
@@ -41,15 +41,32 @@ def one_shot(self, prompt, model=None):
 
 ### `OpenAILLMProvider` (`common/providers/openai_llm.py`)
 
-Implement by delegating to the existing `generate_response` with an empty history:
+Implement as a direct, minimal API call — **do not** delegate to `generate_response`.
+`generate_response` injects the full SandVoice system role (including the
+`"answer in {config.language}"` instruction) and wraps the user prompt as
+`"User: {prompt}"`. These are the wrong semantics for a raw single-turn call: callers
+like `voice_filler` supply a self-contained prompt that must not be overridden by the
+SandVoice persona.
 
 ```python
-def one_shot(self, prompt, model=None):
-    return self.generate_response(prompt, [], model=model)
-```
+@retry_with_backoff(max_attempts=3, initial_delay=1)
+def _call_one_shot(self, prompt, model=None):
+    if not model:
+        model = self.config.gpt_response_model
+    completion = self._client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return completion.choices[0].message
 
-`generate_response` already handles an empty history correctly — it builds a messages
-list with no prior turns and returns an `ErrorMessage`-compatible result on failure.
+def one_shot(self, prompt, model=None):
+    try:
+        return self._call_one_shot(prompt, model=model)
+    except Exception as e:
+        error_msg = handle_api_error(e, service_name="OpenAI GPT")
+        logger.error("one_shot error: %s", e)
+        return ErrorMessage(error_msg)
+```
 
 ### `AI` facade (`common/ai.py`)
 
@@ -64,7 +81,7 @@ No history reads or writes. Return value is passed straight through to the calle
 ## Acceptance Criteria
 
 - [ ] `LLMProvider.one_shot(prompt, model=None)` abstract method added
-- [ ] `OpenAILLMProvider.one_shot` implemented; delegates to `generate_response(prompt, [])`
+- [ ] `OpenAILLMProvider.one_shot` implemented as a direct, system-role-free API call (via `_call_one_shot` with `retry_with_backoff`); does **not** delegate to `generate_response`
 - [ ] `AI.one_shot(prompt, model=None)` delegates to `self._llm.one_shot`
 - [ ] Unit tests cover: successful call, API failure returns `ErrorMessage`-like result
 - [ ] Coverage >80% for changed files

--- a/plan/backlog/44-llm-provider-one-shot.md
+++ b/plan/backlog/44-llm-provider-one-shot.md
@@ -1,0 +1,81 @@
+# Plan 44: LLMProvider one_shot Method
+
+## Problem
+
+`VoiceFillerCache._translate_phrases()` needs a single-turn LLM call that does not
+touch `AI.conversation_history`. Currently it bypasses the provider interface entirely:
+
+```python
+completion = self._ai.openai_client.chat.completions.create(
+    model=self._config.gpt_response_model,
+    messages=[{"role": "user", "content": prompt}],
+)
+```
+
+This couples the module to the OpenAI SDK directly, which defeats the purpose of the
+provider facade introduced in Plans 41–43.
+
+`AI.generate_response()` cannot be used here because it appends both the user turn and
+the assistant reply to `conversation_history`, contaminating the interactive session
+with warmup data.
+
+## Goal
+
+Add a `one_shot(prompt, model=None)` method to `LLMProvider`, implement it in
+`OpenAILLMProvider`, and expose it on `AI` — so callers can make a single-turn LLM
+call without affecting conversation history.
+
+## Approach
+
+### `LLMProvider` ABC (`common/providers/base.py`)
+
+```python
+@abstractmethod
+def one_shot(self, prompt, model=None):
+    """Single-turn LLM call with no conversation history.
+
+    Returns a response object with a `.content` attribute (str).
+    Does not read or mutate any conversation state.
+    """
+```
+
+### `OpenAILLMProvider` (`common/providers/openai_llm.py`)
+
+Implement by delegating to the existing `generate_response` with an empty history:
+
+```python
+def one_shot(self, prompt, model=None):
+    return self.generate_response(prompt, [], model=model)
+```
+
+`generate_response` already handles an empty history correctly — it builds a messages
+list with no prior turns and returns an `ErrorMessage`-compatible result on failure.
+
+### `AI` facade (`common/ai.py`)
+
+```python
+def one_shot(self, prompt, model=None):
+    """Single-turn LLM call that does not affect conversation history."""
+    return self._llm.one_shot(prompt, model=model)
+```
+
+No history reads or writes. Return value is passed straight through to the caller.
+
+## Acceptance Criteria
+
+- [ ] `LLMProvider.one_shot(prompt, model=None)` abstract method added
+- [ ] `OpenAILLMProvider.one_shot` implemented; delegates to `generate_response(prompt, [])`
+- [ ] `AI.one_shot(prompt, model=None)` delegates to `self._llm.one_shot`
+- [ ] Unit tests cover: successful call, API failure returns `ErrorMessage`-like result
+- [ ] Coverage >80% for changed files
+
+## Dependencies
+
+- Plan 43 merged
+
+## Notes
+
+- `one_shot` intentionally has no `extra_info` parameter — it is for simple
+  single-prompt calls. If a caller needs system context, pass it in the prompt string.
+- The method name `one_shot` is preferred over `prompt` or `query` to make it clear
+  that no history is involved.

--- a/plan/backlog/45-llm-provider-web-search.md
+++ b/plan/backlog/45-llm-provider-web-search.md
@@ -74,12 +74,19 @@ def web_search(self, query, instructions, model=None, include=None):
         logger.error("Web search error: %s", e)
         print(error_msg)
         return _WebSearchErrorResult(
-            "I encountered an error while searching the web. Please try again."
+            output_text="I encountered an error while searching the web. Please try again."
         )
 ```
 
-A minimal `_WebSearchErrorResult` namedtuple (or dataclass) with an `output_text`
-attribute keeps the return type consistent whether the call succeeds or fails.
+`_WebSearchErrorResult` is a namedtuple defined at module level in `openai_llm.py`:
+
+```python
+from collections import namedtuple
+_WebSearchErrorResult = namedtuple("_WebSearchErrorResult", ["output_text"])
+```
+
+Using the named field (`output_text=...`) in the constructor makes the `.output_text`
+contract explicit and avoids positional-argument ambiguity.
 
 ### `AI` facade (`common/ai.py`)
 

--- a/plan/backlog/45-llm-provider-web-search.md
+++ b/plan/backlog/45-llm-provider-web-search.md
@@ -101,7 +101,7 @@ def web_search(self, query, instructions, model=None, include=None):
 ## Acceptance Criteria
 
 - [ ] `LLMProvider.web_search(query, instructions, model=None, include=None)` abstract method added
-- [ ] `OpenAILLMProvider.web_search` implemented with `retry_with_backoff`, error handling, and consistent return type
+- [ ] `OpenAILLMProvider.web_search` implemented with `retry_with_backoff`, error handling, and consistent return interface (both success and failure paths expose `.output_text`)
 - [ ] `_WebSearchErrorResult` (or equivalent) returns a user-friendly `.output_text` on failure
 - [ ] `AI.web_search(...)` delegates to `self._llm.web_search`
 - [ ] Unit tests cover: successful call, API failure returns error result with `.output_text`

--- a/plan/backlog/45-llm-provider-web-search.md
+++ b/plan/backlog/45-llm-provider-web-search.md
@@ -1,0 +1,114 @@
+# Plan 45: LLMProvider web_search Method
+
+## Problem
+
+`plugins/realtime_websearch/plugin.py` calls the OpenAI Responses API directly:
+
+```python
+resp = s.ai.openai_client.responses.create(
+    model=...,
+    instructions=system_instructions,
+    tools=[{"type": "web_search"}],
+    tool_choice="auto",
+    input=query,
+    include=include_params,
+)
+```
+
+This bypasses the provider interface, couples the plugin to the OpenAI SDK, and relies
+on the `openai_client` escape hatch on `AI` that should be removed (Plan 46).
+
+## Goal
+
+Add `web_search(query, instructions, model=None, include=None)` to `LLMProvider`,
+implement it in `OpenAILLMProvider` using the Responses API, and expose it on `AI` —
+so plugins call `s.ai.web_search(...)` with no knowledge of the underlying SDK.
+
+## Approach
+
+### `LLMProvider` ABC (`common/providers/base.py`)
+
+```python
+@abstractmethod
+def web_search(self, query, instructions, model=None, include=None):
+    """Answer a query using a web-search-augmented LLM call.
+
+    Args:
+        query: The user question to search for.
+        instructions: System-level instructions for the response style.
+        model: Override the default model. Provider picks a default when None.
+        include: Optional list of provider-specific include flags
+                 (e.g. ["web_search_call.action.sources"] for debugging).
+
+    Returns:
+        A result object with at minimum an `.output_text` attribute (str).
+        Returns a fallback result with a user-friendly error message on failure.
+    """
+```
+
+### `OpenAILLMProvider` (`common/providers/openai_llm.py`)
+
+Move the `responses.create` call from the plugin into the provider:
+
+```python
+@retry_with_backoff(max_attempts=3, initial_delay=1)
+def _call_web_search(self, query, instructions, model=None, include=None):
+    if not model:
+        model = self.config.gpt_response_model
+    return self._client.responses.create(
+        model=model,
+        instructions=instructions,
+        tools=[{"type": "web_search"}],
+        tool_choice="auto",
+        input=query,
+        include=include or [],
+    )
+
+def web_search(self, query, instructions, model=None, include=None):
+    try:
+        return self._call_web_search(
+            query, instructions, model=model, include=include
+        )
+    except Exception as e:
+        error_msg = handle_api_error(e, service_name="OpenAI web search")
+        logger.error("Web search error: %s", e)
+        print(error_msg)
+        return _WebSearchErrorResult(
+            "I encountered an error while searching the web. Please try again."
+        )
+```
+
+A minimal `_WebSearchErrorResult` namedtuple (or dataclass) with an `output_text`
+attribute keeps the return type consistent whether the call succeeds or fails.
+
+### `AI` facade (`common/ai.py`)
+
+```python
+def web_search(self, query, instructions, model=None, include=None):
+    """Web-search-augmented LLM call. Does not affect conversation history."""
+    return self._llm.web_search(
+        query, instructions, model=model, include=include
+    )
+```
+
+## Acceptance Criteria
+
+- [ ] `LLMProvider.web_search(query, instructions, model=None, include=None)` abstract method added
+- [ ] `OpenAILLMProvider.web_search` implemented with `retry_with_backoff`, error handling, and consistent return type
+- [ ] `_WebSearchErrorResult` (or equivalent) returns a user-friendly `.output_text` on failure
+- [ ] `AI.web_search(...)` delegates to `self._llm.web_search`
+- [ ] Unit tests cover: successful call, API failure returns error result with `.output_text`
+- [ ] Coverage >80% for changed files
+
+## Dependencies
+
+- Plan 43 merged
+
+## Notes
+
+- `web_search` does not append to `conversation_history` — the plugin is responsible
+  for deciding what (if anything) to include in the response returned to the user.
+- The `include` parameter is intentionally generic; callers pass provider-specific
+  values and the provider uses them as-is. This avoids over-abstracting a debug feature.
+- When a second search provider is added, the return type contract (`output_text`)
+  should be formalised into a `SearchResult` dataclass shared across providers.

--- a/plan/backlog/46-remove-openai-client-escape-hatch.md
+++ b/plan/backlog/46-remove-openai-client-escape-hatch.md
@@ -1,0 +1,123 @@
+# Plan 46: Remove openai_client Escape Hatch
+
+## Problem
+
+`AI` exposes a public `openai_client` property that lets callers bypass the provider
+interface entirely:
+
+```python
+@property
+def openai_client(self):
+    return self._openai_client  # raises AttributeError if not from_config
+```
+
+Two callers depend on it:
+
+| Caller | What it does |
+|--------|-------------|
+| `common/voice_filler.py` | Single-turn LLM call for phrase translation |
+| `plugins/realtime_websearch/plugin.py` | Responses API web search call |
+
+Both have proper provider-level solutions in Plans 44 and 45. Once those are in place,
+the escape hatch serves no purpose and should be removed.
+
+## Goal
+
+Migrate both callers to use the new provider methods, then delete `openai_client` from
+`AI` and `_openai_client` from `AI.__init__`. No caller should reference the OpenAI
+SDK directly outside of `common/providers/`.
+
+## Approach
+
+### `common/voice_filler.py`
+
+Replace:
+```python
+completion = self._ai.openai_client.chat.completions.create(
+    model=self._config.gpt_response_model,
+    messages=[{"role": "user", "content": prompt}],
+)
+raw = completion.choices[0].message.content.strip()
+```
+
+With:
+```python
+result = self._ai.one_shot(prompt, model=self._config.gpt_response_model)
+raw = result.content.strip()
+```
+
+### `plugins/realtime_websearch/plugin.py`
+
+Replace:
+```python
+resp = s.ai.openai_client.responses.create(
+    model=...,
+    instructions=system_instructions,
+    tools=[{"type": "web_search"}],
+    tool_choice="auto",
+    input=query,
+    include=include_params,
+)
+text = resp.output_text or "..."
+```
+
+With:
+```python
+resp = s.ai.web_search(
+    query,
+    instructions=system_instructions,
+    model=getattr(s.config, 'gpt_response_model', None) or "gpt-5-mini",
+    include=include_params,
+)
+text = resp.output_text or "..."
+```
+
+The debug source-printing block that inspects `resp.output` stays in the plugin —
+it is presentation logic, not provider logic.
+
+### `common/ai.py`
+
+Remove:
+- `self._openai_client = openai_client` from `AI.__init__`
+- `openai_client` keyword-only parameter from `AI.__init__`
+- `openai_client` property
+- `openai_client=openai_client` kwarg from `cls(...)` call in `from_config`
+
+`from_config` still constructs the client locally and passes it to the three
+`_build_*_provider` helpers — that is an implementation detail of the factory, not
+part of the public AI interface.
+
+### Tests
+
+- Update `tests/test_ai.py`: remove `test_openai_client_accessible_after_from_config`
+  and `test_openai_client_raises_when_not_set` (the property no longer exists).
+- Update `tests/test_tts_chunking.py` and any other test that passes `openai_client=`
+  to `AI(...)`.
+- Add / update `tests/test_voice_filler.py` to mock `ai.one_shot` instead of
+  `ai.openai_client.chat.completions.create`.
+- Add / update `tests/plugins/test_realtime_websearch.py` to mock `s.ai.web_search`
+  instead of `s.ai.openai_client.responses.create`.
+
+## Acceptance Criteria
+
+- [ ] `voice_filler.py` uses `ai.one_shot(prompt, model=...)` — no `openai_client` reference
+- [ ] `realtime_websearch/plugin.py` uses `s.ai.web_search(...)` — no `openai_client` reference
+- [ ] `AI.openai_client` property removed
+- [ ] `AI._openai_client` attribute removed
+- [ ] No `openai_client` keyword in `AI.__init__` or `AI.from_config`
+- [ ] No import of `openai` SDK outside `common/providers/` in production code
+- [ ] All tests pass; removed tests replaced with ones targeting the new interface
+- [ ] Coverage >80% for changed files
+
+## Dependencies
+
+- Plan 44 merged
+- Plan 45 merged
+
+## Notes
+
+- `from openai import OpenAI` remains in `common/ai.py` inside `from_config` — this
+  is the intentional provider wiring point. The constraint is that no *instance method*
+  of `AI` and no *plugin* touches the SDK directly.
+- After this plan, adding a non-OpenAI provider requires only implementing the
+  `LLMProvider` ABC — no plugins or `voice_filler.py` need changes.

--- a/plan/backlog/46-remove-openai-client-escape-hatch.md
+++ b/plan/backlog/46-remove-openai-client-escape-hatch.md
@@ -105,7 +105,8 @@ part of the public AI interface.
 - [ ] `AI.openai_client` property removed
 - [ ] `AI._openai_client` attribute removed
 - [ ] No `openai_client` keyword in `AI.__init__` or `AI.from_config`
-- [ ] No import of `openai` SDK outside `common/providers/` in production code
+- [ ] No plugin or `AI` instance method imports or references the `openai` SDK directly;
+      `AI.from_config` (the provider wiring point) may retain `from openai import OpenAI`
 - [ ] All tests pass; removed tests replaced with ones targeting the new interface
 - [ ] Coverage >80% for changed files
 

--- a/plan/backlog/46-remove-openai-client-escape-hatch.md
+++ b/plan/backlog/46-remove-openai-client-escape-hatch.md
@@ -121,8 +121,9 @@ part of the public AI interface.
 
 ## Notes
 
-- `from openai import OpenAI` remains in `common/ai.py` inside `from_config` — this
-  is the intentional provider wiring point. The constraint is that no *instance method*
-  of `AI` and no *plugin* touches the SDK directly.
+- `from openai import OpenAI` remains in `common/ai.py` at module scope (the provider
+  wiring point). The constraint is that no *instance method* of `AI` and no *plugin*
+  touches the SDK directly. Whether the import stays at module scope or moves inside
+  `from_config` is an implementation detail outside the scope of this plan.
 - After this plan, adding a non-OpenAI provider requires only implementing the
   `LLMProvider` ABC — no plugins or `voice_filler.py` need changes.

--- a/plan/backlog/46-remove-openai-client-escape-hatch.md
+++ b/plan/backlog/46-remove-openai-client-escape-hatch.md
@@ -71,7 +71,6 @@ With:
 resp = s.ai.web_search(
     query,
     instructions=system_instructions,
-    model=getattr(s.config, 'gpt_response_model', None) or "gpt-5-mini",
     include=include_params,
 )
 text = resp.output_text or "..."

--- a/plan/backlog/46-remove-openai-client-escape-hatch.md
+++ b/plan/backlog/46-remove-openai-client-escape-hatch.md
@@ -8,7 +8,12 @@ interface entirely:
 ```python
 @property
 def openai_client(self):
-    return self._openai_client  # raises AttributeError if not from_config
+    if self._openai_client is None:
+        raise AttributeError(
+            "openai_client is not available: AI was not constructed via "
+            "from_config, or the configured provider does not use an OpenAI client."
+        )
+    return self._openai_client
 ```
 
 Two callers depend on it:

--- a/plan/backlog/46-remove-openai-client-escape-hatch.md
+++ b/plan/backlog/46-remove-openai-client-escape-hatch.md
@@ -96,12 +96,12 @@ part of the public AI interface.
 
 - Update `tests/test_ai.py`: remove `test_openai_client_accessible_after_from_config`
   and `test_openai_client_raises_when_not_set` (the property no longer exists).
-- Update `tests/test_tts_chunking.py` and any other test that passes `openai_client=`
-  to `AI(...)`.
-- Add / update `tests/test_voice_filler.py` to mock `ai.one_shot` instead of
-  `ai.openai_client.chat.completions.create`.
-- Add / update `tests/plugins/test_realtime_websearch.py` to mock `s.ai.web_search`
-  instead of `s.ai.openai_client.responses.create`.
+- Update any tests that directly access or mock `ai.openai_client` to use the
+  provider-backed interface instead: `tests/test_ai.py` (remove the two
+  `openai_client` property tests), `tests/test_voice_filler.py` (mock `ai.one_shot`
+  instead of `ai.openai_client.chat.completions.create`).
+- Update `tests/test_realtime_websearch_plugin.py` to mock `s.ai.web_search`
+  instead of `sv.ai.openai_client.responses.create`.
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary

Three planning documents for fully closing the `openai_client` escape hatch on `AI`:

- **Plan 44** — `LLMProvider.one_shot(prompt, model=None)`: single-turn LLM call with no history mutation. Fixes `voice_filler.py` which calls `chat.completions.create` directly.
- **Plan 45** — `LLMProvider.web_search(query, instructions, model=None, include=None)`: Responses API web search wrapped behind the provider interface. Fixes `realtime_websearch/plugin.py` which calls `responses.create` directly.
- **Plan 46** — Remove `AI.openai_client` property and `_openai_client` attribute entirely once 44+45 land. Migrates both callers. After this plan, no plugin or AI instance method touches the OpenAI SDK directly.

## Motivation

Plans 41–43 built the provider facade but left two escape hatches using `openai_client` directly. These plans complete the migration so the abstraction is consistent end-to-end. After Plan 46 merges, adding a non-OpenAI provider requires only implementing the `LLMProvider` ABC — no plugins need changes.

## No code changes

This PR adds plan documents only. Implementation follows in separate PRs (44 → 45 → 46).