### PR TITLE
Instruct LLM to spell out symbols for TTS compatibility

### DIFF
--- a/common/providers/openai_llm.py
+++ b/common/providers/openai_llm.py
@@ -47,6 +47,7 @@ class OpenAILLMProvider(LLMProvider):
             Current date and time to be considered when answering the message: {now}.
             Never answer as a chat, for example reading your name in a conversation.
             DO NOT reply to messages with the format "{self.config.botname}": <message here>.
+            Never use symbols, always spell it out. For example say degrees instead of using the symbol. Don't say km/h, but kilometers per hour, and so on.
             Reply in a natural and human way.
             {verbosity_instruction}
             """


### PR DESCRIPTION
## Summary

Adds one instruction to the system prompt in `OpenAILLMProvider._build_system_role()`:

> Never use symbols, always spell it out. For example say degrees instead of using the symbol. Don't say km/h, but kilometers per hour, and so on.

## Motivation

TTS engines read symbols literally or skip them entirely, producing unnatural speech. For example:
- `°C` → silence or "degree sign C" instead of "degrees Celsius"
- `km/h` → "k m slash h" instead of "kilometers per hour"
- `%` → skipped or "percent sign" instead of "percent"

This instruction nudges the LLM to spell everything out before the text reaches TTS, which noticeably improves voice output quality — especially for weather, news, and search responses that tend to include units and symbols.

## Testing

- [ ] All tests pass (928 passing)
- [ ] Tested on Mac M1