### PR TITLE
Add plan 47: extract system prompt to common/prompt.py

### DIFF
--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -214,6 +214,10 @@ plan/
 **Document**: [backlog/46-remove-openai-client-escape-hatch.md](./backlog/46-remove-openai-client-escape-hatch.md)
 **Description**: Migrate `voice_filler.py` to `ai.one_shot()` and `realtime_websearch/plugin.py` to `ai.web_search()`, then remove the `openai_client` property and `_openai_client` attribute from `AI` entirely. After this plan, no plugin or instance method touches the OpenAI SDK directly. Requires Plans 44 and 45.
 
+### Priority 47: Extract System Prompt to common/prompt.py
+**Document**: [backlog/47-system-prompt-extraction.md](./backlog/47-system-prompt-extraction.md)
+**Description**: Move `OpenAILLMProvider._build_system_role()` logic into a standalone `build_system_role(config, extra_info=None)` function in `common/prompt.py`. The SandVoice bot identity, language, timezone/location context, verbosity instructions, and the formatting constraint not to reply as a chat are application-level concerns — not OpenAI-specific. Any future provider imports and calls the shared function directly.
+
 ### Future Enhancements
 **Document**: [backlog/FUTURE.md](./backlog/FUTURE.md)
 **Description**: Long-term feature ideas including API Cost Management, Conversation History Management, Code Deduplication, Timers & Reminders, Music Control, Smart Home Integration, Calendar Integration, Todo List Management, Multi-User Support, and Conversation Memory.

--- a/plan/backlog/47-system-prompt-extraction.md
+++ b/plan/backlog/47-system-prompt-extraction.md
@@ -1,0 +1,130 @@
+# Plan 47: Extract System Prompt to common/prompt.py
+
+## Problem
+
+`OpenAILLMProvider._build_system_role()` contains the core SandVoice persona and
+conversation instructions:
+
+```python
+system_role = f"""
+    Your name is {self.config.botname}.
+    You are an assistant written in Python by Breno Brand.
+    You must answer in {self.config.language}.
+    The person that is talking to you is in the {self.config.timezone} time zone.
+    ...
+    Never use symbols, always spell it out...
+    Reply in a natural and human way.
+    {verbosity_instruction}
+"""
+```
+
+None of this is OpenAI-specific. It is the application-level identity of SandVoice —
+persona, language, timezone, TTS formatting rules, verbosity. Any future provider
+(Gemini, Anthropic, etc.) would need the identical prompt, forcing either duplication
+or inheritance from `OpenAILLMProvider`.
+
+## Goal
+
+Move `_build_system_role` logic into a standalone `build_system_role(config,
+extra_info=None)` function in `common/prompt.py`. Each provider that needs a system
+role calls this shared function. `OpenAILLMProvider` becomes a thin caller.
+
+## Approach
+
+### New file: `common/prompt.py`
+
+```python
+import datetime
+
+def build_system_role(config, extra_info=None):
+    """Build the SandVoice system prompt from config.
+
+    Returns a string suitable for use as the system role in any LLM API call.
+    Provider-agnostic — contains only application-level instructions.
+    """
+    now = datetime.datetime.now()
+    verbosity = getattr(config, "verbosity", "brief")
+
+    if verbosity == "detailed":
+        verbosity_instruction = (
+            "Verbosity: detailed. Provide thorough, structured answers by default. "
+            "Include steps/examples when helpful. If the user asks for a short answer, comply."
+        )
+    elif verbosity == "normal":
+        verbosity_instruction = (
+            "Verbosity: normal. Be concise but complete. "
+            "Expand when the user explicitly asks for more detail."
+        )
+    else:
+        verbosity_instruction = (
+            "Verbosity: brief. Keep answers short by default (1-3 sentences). "
+            "Avoid long lists and excessive detail unless the user explicitly asks to expand, "
+            "asks for details, or says they want a longer answer."
+        )
+
+    system_role = f"""
+        Your name is {config.botname}.
+        You are an assistant written in Python by Breno Brand.
+        You must answer in {config.language}.
+        The person that is talking to you is in the {config.timezone} time zone.
+        The person that is talking to you is located in {config.location}.
+        Current date and time to be considered when answering the message: {now}.
+        Never answer as a chat, for example reading your name in a conversation.
+        DO NOT reply to messages with the format "{config.botname}": <message here>.
+        Never use symbols, always spell it out. For example say degrees instead of
+        using the symbol. Don't say km/h, but kilometers per hour, and so on.
+        Reply in a natural and human way.
+        {verbosity_instruction}
+        """
+
+    if extra_info is not None:
+        system_role = system_role + "Consider the following to answer your question: " + extra_info
+
+    return system_role
+```
+
+### `OpenAILLMProvider` (`common/providers/openai_llm.py`)
+
+Replace `_build_system_role` with a one-line delegation:
+
+```python
+from common.prompt import build_system_role
+
+class OpenAILLMProvider(LLMProvider):
+    def _build_system_role(self, extra_info=None):
+        return build_system_role(self.config, extra_info=extra_info)
+```
+
+The private method is kept as a thin wrapper so the call sites inside
+`OpenAILLMProvider` (`generate_response`, `stream_response_deltas`,
+`text_summary`) don't need to change.
+
+### Future providers
+
+Any future `GeminiLLMProvider`, `AnthropicLLMProvider`, etc. imports and calls
+`build_system_role(self.config, extra_info=extra_info)` directly — no inheritance
+from `OpenAILLMProvider` required.
+
+## Acceptance Criteria
+
+- [ ] `common/prompt.py` created with `build_system_role(config, extra_info=None)`
+- [ ] `OpenAILLMProvider._build_system_role` delegates to `build_system_role`; no
+      prompt logic remains in `openai_llm.py`
+- [ ] All existing tests pass unchanged (the output of `_build_system_role` is identical)
+- [ ] `tests/test_prompt.py` added: covers verbosity variants (brief/normal/detailed),
+      `extra_info` appended correctly, `None` extra_info omitted
+- [ ] Coverage >80% for `common/prompt.py`
+
+## Dependencies
+
+- None (purely additive refactor, no plan dependencies)
+
+## Notes
+
+- `build_system_role` is a pure function — it reads config values and returns a string.
+  No side effects, easy to test in isolation.
+- The `text_summary` system role in `OpenAILLMProvider` ("You are a bot that summarizes
+  texts in N words.") is intentionally NOT moved — it is a task-specific prompt, not
+  the SandVoice persona.
+- The routing system role (from `routes.yaml`) is also NOT moved — it is routing
+  configuration, not persona.

--- a/plan/backlog/47-system-prompt-extraction.md
+++ b/plan/backlog/47-system-prompt-extraction.md
@@ -29,55 +29,10 @@ function with only the minimal `self.config` → `config` substitution needed fo
 the extraction; otherwise preserve the logic and prompt text exactly — including
 the leading/trailing whitespace inside the triple-quoted `system_role` f-string,
 which is part of the prompt text and must not be "cleaned up" during the move.
-Tests must assert exact string equality to catch any accidental whitespace changes.
 
-```python
-import datetime
-
-def build_system_role(config, extra_info=None):
-    """Build the SandVoice system prompt from config.
-
-    Returns a string suitable for use as the system role in any LLM API call.
-    Provider-agnostic — contains only application-level instructions.
-    """
-    now = datetime.datetime.now()
-    verbosity = getattr(config, "verbosity", "brief")
-
-    if verbosity == "detailed":
-        verbosity_instruction = (
-            "Verbosity: detailed. Provide thorough, structured answers by default. "
-            "Include steps/examples when helpful. If the user asks for a short answer, comply."
-        )
-    elif verbosity == "normal":
-        verbosity_instruction = (
-            "Verbosity: normal. Be concise but complete. "
-            "Expand when the user explicitly asks for more detail."
-        )
-    else:
-        verbosity_instruction = (
-            "Verbosity: brief. Keep answers short by default (1-3 sentences). "
-            "Avoid long lists and excessive detail unless the user explicitly asks to expand, "
-            "asks for details, or says they want a longer answer."
-        )
-
-    system_role = f"""
-        Your name is {config.botname}.
-        You are an assistant written in Python by Breno Brand.
-        You must answer in {config.language}.
-        The person that is talking to you is in the {config.timezone} time zone.
-        The person that is talking to you is located in {config.location}.
-        Current date and time to be considered when answering the message: {now}.
-        Never answer as a chat, for example reading your name in a conversation.
-        DO NOT reply to messages with the format "{config.botname}": <message here>.
-        Reply in a natural and human way.
-        {verbosity_instruction}
-        """
-
-    if extra_info is not None:
-        system_role = system_role + "Consider the following to answer your question: " + extra_info
-
-    return system_role
-```
+**Do not rely on the snippet below for exact indentation or content.** The snippet
+is illustrative only. The source of truth is `common/providers/openai_llm.py` at
+implementation time — copy/paste the f-string directly from that file.
 
 The prompt text must match `openai_llm.py` exactly at the time of implementation —
 check for any instructions added by later PRs (e.g. PR #127) and include them.
@@ -113,7 +68,8 @@ from `OpenAILLMProvider` required.
       including leading/trailing whitespace in the f-string)
 - [ ] `tests/test_prompt.py` added: covers verbosity variants (brief/normal/detailed),
       `extra_info` appended correctly, `None` extra_info omitted; assertions use exact
-      string equality (not `assertIn`) to catch accidental whitespace changes
+      string equality (not `assertIn`) to catch accidental whitespace changes; patch
+      `datetime.datetime.now` to a fixed value so assertions are deterministic
 - [ ] Coverage >80% for `common/prompt.py`
 
 ## Dependencies
@@ -122,8 +78,10 @@ from `OpenAILLMProvider` required.
 
 ## Notes
 
-- `build_system_role` is a pure function — it reads config values and returns a string.
-  No side effects, easy to test in isolation.
+- `build_system_role` reads config values and returns a string. It calls
+  `datetime.datetime.now()` internally, so it is time-dependent (not strictly pure),
+  but it has no other side effects. Tests must patch `datetime.datetime.now` to a
+  fixed value to get deterministic output.
 - The `text_summary` system role in `OpenAILLMProvider` ("You are a bot that summarizes
   texts in N words.") is intentionally NOT moved — it is a task-specific prompt, not
   the SandVoice persona.

--- a/plan/backlog/47-system-prompt-extraction.md
+++ b/plan/backlog/47-system-prompt-extraction.md
@@ -3,25 +3,16 @@
 ## Problem
 
 `OpenAILLMProvider._build_system_role()` contains the core SandVoice persona and
-conversation instructions:
-
-```python
-system_role = f"""
-    Your name is {self.config.botname}.
-    You are an assistant written in Python by Breno Brand.
-    You must answer in {self.config.language}.
-    The person that is talking to you is in the {self.config.timezone} time zone.
-    ...
-    Never use symbols, always spell it out...
-    Reply in a natural and human way.
-    {verbosity_instruction}
-"""
-```
+conversation instructions assembled from configuration values (bot identity, language,
+timezone/location, verbosity, and a formatting constraint not to reply as a chat).
 
 None of this is OpenAI-specific. It is the application-level identity of SandVoice —
-persona, language, timezone, TTS formatting rules, verbosity. Any future provider
-(Gemini, Anthropic, etc.) would need the identical prompt, forcing either duplication
-or inheritance from `OpenAILLMProvider`.
+persona, language, timezone, verbosity. Any future provider (Gemini, Anthropic, etc.)
+would need the identical prompt, forcing either duplication or inheritance from
+`OpenAILLMProvider`.
+
+The implementation in `common/providers/openai_llm.py` is the source of truth for the
+exact prompt text. This plan must preserve it exactly.
 
 ## Goal
 
@@ -32,6 +23,9 @@ role calls this shared function. `OpenAILLMProvider` becomes a thin caller.
 ## Approach
 
 ### New file: `common/prompt.py`
+
+Copy the body of `OpenAILLMProvider._build_system_role()` verbatim into a module-level
+function, replacing `self.config` with `config`:
 
 ```python
 import datetime
@@ -71,8 +65,6 @@ def build_system_role(config, extra_info=None):
         Current date and time to be considered when answering the message: {now}.
         Never answer as a chat, for example reading your name in a conversation.
         DO NOT reply to messages with the format "{config.botname}": <message here>.
-        Never use symbols, always spell it out. For example say degrees instead of
-        using the symbol. Don't say km/h, but kilometers per hour, and so on.
         Reply in a natural and human way.
         {verbosity_instruction}
         """
@@ -82,6 +74,9 @@ def build_system_role(config, extra_info=None):
 
     return system_role
 ```
+
+The prompt text must match `openai_llm.py` exactly at the time of implementation —
+check for any instructions added by later PRs (e.g. PR #127) and include them.
 
 ### `OpenAILLMProvider` (`common/providers/openai_llm.py`)
 
@@ -96,8 +91,8 @@ class OpenAILLMProvider(LLMProvider):
 ```
 
 The private method is kept as a thin wrapper so the call sites inside
-`OpenAILLMProvider` (`generate_response`, `stream_response_deltas`,
-`text_summary`) don't need to change.
+`OpenAILLMProvider` (`generate_response`, `stream_response_deltas`) don't need to
+change.
 
 ### Future providers
 

--- a/plan/backlog/47-system-prompt-extraction.md
+++ b/plan/backlog/47-system-prompt-extraction.md
@@ -24,8 +24,12 @@ role calls this shared function. `OpenAILLMProvider` becomes a thin caller.
 
 ### New file: `common/prompt.py`
 
-Copy the body of `OpenAILLMProvider._build_system_role()` verbatim into a module-level
-function, replacing `self.config` with `config`:
+Copy the body of `OpenAILLMProvider._build_system_role()` into a module-level
+function with only the minimal `self.config` → `config` substitution needed for
+the extraction; otherwise preserve the logic and prompt text exactly — including
+the leading/trailing whitespace inside the triple-quoted `system_role` f-string,
+which is part of the prompt text and must not be "cleaned up" during the move.
+Tests must assert exact string equality to catch any accidental whitespace changes.
 
 ```python
 import datetime
@@ -105,9 +109,11 @@ from `OpenAILLMProvider` required.
 - [ ] `common/prompt.py` created with `build_system_role(config, extra_info=None)`
 - [ ] `OpenAILLMProvider._build_system_role` delegates to `build_system_role`; no
       prompt logic remains in `openai_llm.py`
-- [ ] All existing tests pass unchanged (the output of `_build_system_role` is identical)
+- [ ] All existing tests pass unchanged (the output of `_build_system_role` is identical,
+      including leading/trailing whitespace in the f-string)
 - [ ] `tests/test_prompt.py` added: covers verbosity variants (brief/normal/detailed),
-      `extra_info` appended correctly, `None` extra_info omitted
+      `extra_info` appended correctly, `None` extra_info omitted; assertions use exact
+      string equality (not `assertIn`) to catch accidental whitespace changes
 - [ ] Coverage >80% for `common/prompt.py`
 
 ## Dependencies

--- a/plan/backlog/47-system-prompt-extraction.md
+++ b/plan/backlog/47-system-prompt-extraction.md
@@ -4,9 +4,8 @@
 
 `OpenAILLMProvider._build_system_role()` contains the core SandVoice persona and
 conversation instructions assembled from configuration values (bot identity, language,
-timezone/location, current date/time, verbosity, a formatting constraint not to reply
-as a chat, and a TTS formatting instruction to spell out symbols rather than emit them
-directly).
+timezone/location, current date/time, verbosity, and output constraints such as never
+answering as a chat).
 
 None of this is OpenAI-specific. It is the application-level identity of SandVoice —
 persona, language, timezone, verbosity, output style. Any future provider (Gemini,

--- a/plan/backlog/47-system-prompt-extraction.md
+++ b/plan/backlog/47-system-prompt-extraction.md
@@ -4,12 +4,14 @@
 
 `OpenAILLMProvider._build_system_role()` contains the core SandVoice persona and
 conversation instructions assembled from configuration values (bot identity, language,
-timezone/location, verbosity, and a formatting constraint not to reply as a chat).
+timezone/location, current date/time, verbosity, a formatting constraint not to reply
+as a chat, and a TTS formatting instruction to spell out symbols rather than emit them
+directly).
 
 None of this is OpenAI-specific. It is the application-level identity of SandVoice —
-persona, language, timezone, verbosity. Any future provider (Gemini, Anthropic, etc.)
-would need the identical prompt, forcing either duplication or inheritance from
-`OpenAILLMProvider`.
+persona, language, timezone, verbosity, output style. Any future provider (Gemini,
+Anthropic, etc.) would need the identical prompt, forcing either duplication or
+inheritance from `OpenAILLMProvider`.
 
 The implementation in `common/providers/openai_llm.py` is the source of truth for the
 exact prompt text. This plan must preserve it exactly.


### PR DESCRIPTION
## Summary

Adds Plan 47 to the backlog: extract the SandVoice system prompt out of `OpenAILLMProvider` and into a shared `common/prompt.py` utility function.

## Motivation

`OpenAILLMProvider._build_system_role()` contains the core SandVoice persona — botname, language, timezone, TTS formatting rules, verbosity — none of which is OpenAI-specific. Any future provider (Gemini, Anthropic, etc.) would need the same prompt, forcing duplication.

Extracting it to `build_system_role(config, extra_info=None)` in `common/prompt.py` gives every provider a single import with no inheritance required.

## No code changes

Plan document only. Implementation follows in a separate PR.