### PR TITLE
Add CLAUDE.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 plugins/__pycache__/
 .claude/
+CLAUDE.md


### PR DESCRIPTION
CLAUDE.md is a local agent instructions file — should not be tracked in the repo.