### PR TITLE
Add Plan 50 and Plan 51: custom prompt injection

### DIFF
--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -223,6 +223,14 @@ plan/
 **Description**: Move `OpenAILLMProvider._build_system_role()` logic into a standalone `build_system_role(config, extra_info=None)` function in `common/prompt.py`. The SandVoice bot identity, language, timezone/location context, verbosity instructions, and the formatting constraint not to reply as a chat are application-level concerns — not OpenAI-specific. Any future provider imports and calls the shared function directly.
 
 
+### Priority 50: system_prompt_extra — User-Defined Standing Instructions
+**Document**: [backlog/50-system-prompt-extra.md](./backlog/50-system-prompt-extra.md)
+**Description**: Add optional `system_prompt_extra` config key (YAML block scalar string) that appends user-defined standing instructions to the system prompt on every request. Appended between the core persona and per-request `extra_info`. Implemented in `common/prompt.py` and `common/configuration.py`.
+
+### Priority 51: Greeting Plugin — Extra Instructions
+**Document**: [backlog/51-greeting-extra-instructions.md](./backlog/51-greeting-extra-instructions.md)
+**Description**: Add optional `greeting_extra` config key that appends user-defined instructions to the greeting plugin's generation prompt (e.g. "end the greeting with a short proverb"). Separate from `system_prompt_extra` — affects only the greeting plugin's live generation.
+
 ### Future Enhancements
 **Document**: [backlog/FUTURE.md](./backlog/FUTURE.md)
 **Description**: Long-term feature ideas: alternative providers (Anthropic, Ollama, Piper), local offline mode, conversation history truncation, user-triggered timers, conversation memory, export, plugin hot-reload, API cost tracking, music control, smart home, calendar, todo lists, multi-user support.

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -225,7 +225,7 @@ plan/
 
 ### Priority 50: system_prompt_extra — User-Defined Standing Instructions
 **Document**: [backlog/50-system-prompt-extra.md](./backlog/50-system-prompt-extra.md)
-**Description**: Add optional `system_prompt_extra` config key (YAML block scalar string) that appends user-defined standing instructions to the system prompt on every request. Appended between the core persona and per-request `extra_info`. Implemented in `common/prompt.py` and `common/configuration.py`.
+**Description**: Add optional `system_prompt_extra` config key (YAML block scalar string) that appends user-defined standing instructions to the shared system prompt used by response generation/streaming. Appended between the core persona and per-request `extra_info`. Implemented in `common/prompt.py` and `common/configuration.py`.
 
 ### Priority 51: Greeting Plugin — Extra Instructions
 **Document**: [backlog/51-greeting-extra-instructions.md](./backlog/51-greeting-extra-instructions.md)

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -225,7 +225,7 @@ plan/
 
 ### Priority 50: system_prompt_extra — User-Defined Standing Instructions
 **Document**: [backlog/50-system-prompt-extra.md](./backlog/50-system-prompt-extra.md)
-**Description**: Add optional `system_prompt_extra` config key (YAML block scalar string) that appends user-defined standing instructions to the shared system prompt used by response generation/streaming. Appended between the core persona and per-request `extra_info`. Implemented in `common/prompt.py` and `common/configuration.py`.
+**Description**: Add optional `system_prompt_extra` config key (YAML block scalar string) that appends user-defined standing instructions to the shared system prompt used by response generation/streaming. Appended between the core persona and per-request `extra_info`. To be implemented in `common/prompt.py` and `common/configuration.py`.
 
 ### Priority 51: Greeting Plugin — Extra Instructions
 **Document**: [backlog/51-greeting-extra-instructions.md](./backlog/51-greeting-extra-instructions.md)

--- a/plan/backlog/50-system-prompt-extra.md
+++ b/plan/backlog/50-system-prompt-extra.md
@@ -1,0 +1,81 @@
+# Plan 50: system_prompt_extra — User-Defined Standing Instructions
+
+## Problem
+
+The SandVoice persona is entirely defined in `common/prompt.py`. Users who want
+to customise it (e.g. "always respond formally", "you are a cooking expert",
+"never recommend products by brand name") currently have no way to do so without
+editing source code.
+
+## Goal
+
+Add an optional `system_prompt_extra` config key that appends a block of
+user-defined text to the system prompt on every request. The existing persona is
+never replaced — the extra text is purely additive.
+
+## Config
+
+```yaml
+# Optional: append custom standing instructions to every system prompt.
+# Supports YAML block scalar for multi-line text.
+# system_prompt_extra: |
+#   Always respond in a formal tone.
+#   You are an expert in Brazilian cuisine.
+#   Never recommend products by brand name.
+```
+
+Default: absent / `None` (no injection).
+
+## Implementation
+
+### `common/configuration.py`
+
+Add `system_prompt_extra` to the defaults dict (`None`) and expose it as a
+config property. Validate: if present, must be a non-empty string after
+stripping whitespace; log a warning and treat as absent if the value is
+blank or not a string.
+
+### `common/prompt.py` — `build_system_role`
+
+Append `system_prompt_extra` between the base persona block and `extra_info`:
+
+```python
+if getattr(config, "system_prompt_extra", None):
+    system_role = system_role + config.system_prompt_extra.strip() + "\n"
+if extra_info is not None:
+    system_role = system_role + "Consider the following to answer your question: " + extra_info
+```
+
+Prompt hierarchy (bottom of the system role, top to bottom):
+
+1. Core persona (botname, language, timezone, location, verbosity)
+2. `system_prompt_extra` — standing user customisation
+3. `extra_info` — per-request runtime context (weather, news, etc.)
+
+Log at DEBUG when active:
+
+```python
+logger.debug("system_prompt_extra active (%d chars)", len(config.system_prompt_extra.strip()))
+```
+
+### `config.yaml`
+
+Add the commented-out example above so users can discover the option.
+
+## Acceptance Criteria
+
+- [ ] `system_prompt_extra` absent → prompt unchanged
+- [ ] `system_prompt_extra` set → text appended between persona and `extra_info`
+- [ ] Blank / whitespace-only value treated as absent (warning logged)
+- [ ] Non-string value treated as absent (warning logged)
+- [ ] Both `system_prompt_extra` and `extra_info` present → both appended in order
+- [ ] `tests/test_prompt.py` updated with cases for the above
+- [ ] `tests/test_configuration.py` updated: valid value, blank value, non-string value
+- [ ] `config.yaml` updated with commented-out example
+
+## Notes
+
+- `system_prompt_extra` is a standing configuration — it applies to every
+  request. Per-request context remains in `extra_info` (passed by plugins).
+- No changes to `OpenAILLMProvider` or call sites — `build_system_role` is the
+  only place to update.

--- a/plan/backlog/50-system-prompt-extra.md
+++ b/plan/backlog/50-system-prompt-extra.md
@@ -45,8 +45,9 @@ a string. `validate_config()` should not hard-fail on an invalid optional value.
 Append `system_prompt_extra` between the base persona block and `extra_info`:
 
 ```python
-if getattr(config, "system_prompt_extra", None):
-    system_role = system_role + config.system_prompt_extra.strip() + "\n"
+extra = getattr(config, "system_prompt_extra", None)
+if isinstance(extra, str) and extra.strip():
+    system_role = system_role + extra.strip() + "\n"
 if extra_info is not None:
     system_role = system_role + "Consider the following to answer your question: " + extra_info
 ```

--- a/plan/backlog/50-system-prompt-extra.md
+++ b/plan/backlog/50-system-prompt-extra.md
@@ -85,3 +85,9 @@ Add the commented-out example above so users can discover the option.
   request. Per-request context remains in `extra_info` (passed by plugins).
 - No changes to `OpenAILLMProvider` or call sites — `build_system_role` is the
   only place to update.
+- Do not put secrets, API keys, or personally identifiable information (PII) in
+  `system_prompt_extra`. The value is sent to the LLM provider verbatim with every
+  request and will appear in API logs.
+- Custom instructions can compete with or partially override the default persona
+  (e.g. a tone instruction like "always respond formally" overrides the natural-tone
+  instruction). This is intentional; users take responsibility for the interaction.

--- a/plan/backlog/50-system-prompt-extra.md
+++ b/plan/backlog/50-system-prompt-extra.md
@@ -58,10 +58,13 @@ System role content order (first → last, as concatenated):
 2. `system_prompt_extra` — standing user customisation
 3. `extra_info` — per-request runtime context (weather, news, etc.)
 
-Log at DEBUG when active:
+Log at DEBUG when active (inside the same `if` guard, using the already-defined `extra` variable):
 
 ```python
-logger.debug("system_prompt_extra active (%d chars)", len(config.system_prompt_extra.strip()))
+extra = getattr(config, "system_prompt_extra", None)
+if isinstance(extra, str) and extra.strip():
+    system_role = system_role + extra.strip() + "\n"
+    logger.debug("system_prompt_extra active (%d chars)", len(extra.strip()))
 ```
 
 ### `config.yaml`

--- a/plan/backlog/50-system-prompt-extra.md
+++ b/plan/backlog/50-system-prompt-extra.md
@@ -10,8 +10,12 @@ editing source code.
 ## Goal
 
 Add an optional `system_prompt_extra` config key that appends a block of
-user-defined text to the system prompt on every request. The existing persona is
-never replaced — the extra text is purely additive.
+user-defined text to the system prompt used for response generation and streaming.
+The existing persona is never replaced — the extra text is purely additive.
+
+Note: `build_system_role()` is used for response generation and streaming only.
+Routing (`define_route`) and summarization (`text_summary`) build their own
+system roles and are not affected by this setting.
 
 ## Config
 
@@ -30,10 +34,11 @@ Default: absent / `None` (no injection).
 
 ### `common/configuration.py`
 
-Add `system_prompt_extra` to the defaults dict (`None`) and expose it as a
-config property. Validate: if present, must be a non-empty string after
-stripping whitespace; log a warning and treat as absent if the value is
-blank or not a string.
+Add `system_prompt_extra` to the defaults dict (`None`) and parse it in
+`load_config()` following the existing `Config` pattern (read raw value, set
+attribute). Validate: if present, must be a non-empty string after stripping
+whitespace; log a warning and normalise to `None` if the value is blank or not
+a string. `validate_config()` should not hard-fail on an invalid optional value.
 
 ### `common/prompt.py` — `build_system_role`
 

--- a/plan/backlog/50-system-prompt-extra.md
+++ b/plan/backlog/50-system-prompt-extra.md
@@ -46,7 +46,7 @@ if extra_info is not None:
     system_role = system_role + "Consider the following to answer your question: " + extra_info
 ```
 
-Prompt hierarchy (bottom of the system role, top to bottom):
+System role content order (first → last, as concatenated):
 
 1. Core persona (botname, language, timezone, location, verbosity)
 2. `system_prompt_extra` — standing user customisation

--- a/plan/backlog/51-greeting-extra-instructions.md
+++ b/plan/backlog/51-greeting-extra-instructions.md
@@ -10,8 +10,9 @@ without editing the plugin source.
 ## Goal
 
 Add an optional `greeting_extra` config key that appends user-defined instructions
-to the greeting generation prompt. The existing greeting structure is unchanged;
-the extra text is purely additive.
+to the greeting generation prompt. The base greeting structure instructions remain
+in the prompt, but `greeting_extra` may influence the generated content or
+formatting.
 
 ## Config
 
@@ -29,9 +30,12 @@ Default: absent / `None` (no injection).
 
 ### `common/configuration.py`
 
-Add `greeting_extra` to the defaults dict (`None`) and expose it as a config
-property. Same validation as `system_prompt_extra`: non-empty string after strip,
-otherwise log a warning and treat as absent.
+Add `greeting_extra` to the defaults dict (`None`) and parse it in `load_config()`
+following the existing `Config` pattern: read the raw value, accept only strings
+that remain non-empty after `strip()`, and store the stripped value on the config
+object. For blank or non-string values, log a warning and normalise to `None`.
+`validate_config()` should not hard-fail on an invalid optional `greeting_extra`
+value.
 
 ### `plugins/greeting/plugin.py`
 

--- a/plan/backlog/51-greeting-extra-instructions.md
+++ b/plan/backlog/51-greeting-extra-instructions.md
@@ -1,0 +1,82 @@
+# Plan 51: Greeting Plugin — Extra Instructions
+
+## Problem
+
+The greeting plugin generates a fixed-structure greeting (time-of-day salutation,
+weather comment, fun fact). Users have no way to customise it — for example,
+adding a proverb, a motivational quote, a joke, or any other standing element —
+without editing the plugin source.
+
+## Goal
+
+Add an optional `greeting_extra` config key that appends user-defined instructions
+to the greeting generation prompt. The existing greeting structure is unchanged;
+the extra text is purely additive.
+
+## Config
+
+```yaml
+# Optional: append custom instructions to every generated greeting.
+# Supports YAML block scalar for multi-line text.
+# greeting_extra: |
+#   End the greeting with a short, relevant proverb.
+# greeting_extra: "Include a motivational quote to start the day."
+```
+
+Default: absent / `None` (no injection).
+
+## Implementation
+
+### `common/configuration.py`
+
+Add `greeting_extra` to the defaults dict (`None`) and expose it as a config
+property. Same validation as `system_prompt_extra`: non-empty string after strip,
+otherwise log a warning and treat as absent.
+
+### `plugins/greeting/plugin.py`
+
+Append `greeting_extra` to `extra_system` before the `generate_response` call:
+
+```python
+greeting_extra = getattr(s.config, "greeting_extra", None)
+if greeting_extra and isinstance(greeting_extra, str) and greeting_extra.strip():
+    extra_system = extra_system + greeting_extra.strip() + "\n"
+    logger.debug("greeting_extra active (%d chars)", len(greeting_extra.strip()))
+```
+
+The `extra_system` string already contains the weather info and time-of-day
+instructions; `greeting_extra` is appended at the end so it has the highest
+priority in the prompt.
+
+### Cache interaction
+
+`greeting_extra` is part of the generated text. If the user changes
+`greeting_extra`, the existing cache entry will be stale (it was generated with
+the old instructions). The cache TTL will eventually expire it naturally.
+A future improvement could invalidate the cache on config change, but this is out
+of scope here.
+
+### `config.yaml`
+
+Add the commented-out example above so users can discover the option.
+
+## Acceptance Criteria
+
+- [ ] `greeting_extra` absent → greeting prompt unchanged
+- [ ] `greeting_extra` set → text appended to `extra_system` before LLM call
+- [ ] Blank / whitespace-only value treated as absent (warning logged in config)
+- [ ] Non-string value treated as absent (warning logged in config)
+- [ ] `tests/test_greeting_plugin.py` updated: extra instruction appended to
+      prompt, absent when not configured, blank value skipped
+- [ ] `tests/test_configuration.py` updated: valid value, blank value,
+      non-string value
+- [ ] `config.yaml` updated with commented-out example
+
+## Notes
+
+- `greeting_extra` affects only the greeting plugin's live generation prompt.
+  It is separate from `system_prompt_extra` (which affects every request).
+  Users can set both simultaneously.
+- Cache invalidation on config change is a known limitation; users can manually
+  clear the cache if they want the new instructions to apply immediately. This
+  could be addressed in a future plan.

--- a/plan/backlog/51-greeting-extra-instructions.md
+++ b/plan/backlog/51-greeting-extra-instructions.md
@@ -44,7 +44,7 @@ Append `greeting_extra` to `extra_system` before the `generate_response` call:
 ```python
 greeting_extra = getattr(s.config, "greeting_extra", None)
 if greeting_extra and isinstance(greeting_extra, str) and greeting_extra.strip():
-    extra_system = extra_system + greeting_extra.strip() + "\n"
+    extra_system = extra_system.rstrip() + "\n" + greeting_extra.strip() + "\n"
     logger.debug("greeting_extra active (%d chars)", len(greeting_extra.strip()))
 ```
 

--- a/plan/backlog/51-greeting-extra-instructions.md
+++ b/plan/backlog/51-greeting-extra-instructions.md
@@ -84,3 +84,8 @@ Add the commented-out example above so users can discover the option.
 - Cache invalidation on config change is a known limitation; users can manually
   clear the cache if they want the new instructions to apply immediately. This
   could be addressed in a future plan.
+- Do not put secrets, API keys, or personally identifiable information (PII) in
+  `greeting_extra`. The value is appended to the greeting prompt and sent to the
+  LLM provider verbatim, where it will appear in API logs.
+- Custom instructions can compete with or partially override the default greeting
+  structure. This is intentional; users take responsibility for the interaction.


### PR DESCRIPTION
## Summary
- **Plan 50**: `system_prompt_extra` config key — appends user-defined standing instructions to the system prompt on every request (implemented in `common/prompt.py`)
- **Plan 51**: `greeting_extra` config key — appends custom instructions to the greeting plugin's generation prompt (e.g. "include a proverb")

## Changes
- New: `plan/backlog/50-system-prompt-extra.md`
- New: `plan/backlog/51-greeting-extra-instructions.md`
- Updated: `plan/INDEX.md`

## No code changes — plan docs only