### PR TITLE
Implement Plan 51: greeting_extra config key

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ voice_filler_phrases:                # set to [] to disable
   - "Let me check that."
   - "Sure, one moment."
 
+# greeting_extra: |             # optional: append custom instructions to the greeting prompt
+#   End the greeting with a short, relevant proverb.
+
 # Scheduler (see Scheduled Tasks section)
 scheduler_enabled: disabled
 scheduler_poll_interval: 30

--- a/common/configuration.py
+++ b/common/configuration.py
@@ -368,10 +368,16 @@ class Config:
         raw_ge = self.get("greeting_extra")
         if raw_ge is None:
             self.greeting_extra = None
-        elif not isinstance(raw_ge, str) or not raw_ge.strip():
+        elif not isinstance(raw_ge, str):
             logger.warning(
                 "greeting_extra must be a non-empty string; ignoring value of type %s",
                 type(raw_ge).__name__,
+            )
+            self.greeting_extra = None
+        elif not raw_ge.strip():
+            logger.warning(
+                "greeting_extra is blank or whitespace-only (length=%d); ignoring",
+                len(raw_ge),
             )
             self.greeting_extra = None
         else:

--- a/common/configuration.py
+++ b/common/configuration.py
@@ -126,6 +126,12 @@ class Config:
                 "Mm-hmm.",
             ],
 
+            # Optional: append custom instructions to the greeting plugin's generation prompt.
+            # Supports YAML block scalar for multi-line text.
+            # greeting_extra: |
+            #   End the greeting with a short, relevant proverb.
+            "greeting_extra": None,
+
             # Background Cache (Plan 20)
             "cache_enabled": "disabled",
             "cache_weather_ttl_s": 10800,    # 3 hours — refresh window
@@ -357,6 +363,19 @@ class Config:
             self.system_prompt_extra = None
         else:
             self.system_prompt_extra = raw_spe.strip()
+
+        # Greeting extra (Plan 51)
+        raw_ge = self.get("greeting_extra")
+        if raw_ge is None:
+            self.greeting_extra = None
+        elif not isinstance(raw_ge, str) or not raw_ge.strip():
+            logger.warning(
+                "greeting_extra must be a non-empty string; ignoring value of type %s",
+                type(raw_ge).__name__,
+            )
+            self.greeting_extra = None
+        else:
+            self.greeting_extra = raw_ge.strip()
 
         # Auto-detect channels if not explicitly configured
         if self.channels is None:

--- a/plugins/greeting/plugin.py
+++ b/plugins/greeting/plugin.py
@@ -87,6 +87,10 @@ def process(user_input, route, s):
     Casually make a friendly and short comment on the weather. Weather info to consider the answer: {weather_response}
     Considering the current day and time, make a fun fact comment about today or this month.
     """
+        greeting_extra = getattr(s.config, "greeting_extra", None)
+        if isinstance(greeting_extra, str) and greeting_extra.strip():
+            extra_system = extra_system.rstrip() + "\n" + greeting_extra.strip() + "\n"
+            logger.debug("greeting_extra active (%d chars)", len(greeting_extra.strip()))
         response_text = s.ai.generate_response(user_input, extra_system).content
 
         if cache is not None:

--- a/plugins/greeting/plugin.py
+++ b/plugins/greeting/plugin.py
@@ -89,8 +89,9 @@ def process(user_input, route, s):
     """
         greeting_extra = getattr(s.config, "greeting_extra", None)
         if isinstance(greeting_extra, str) and greeting_extra.strip():
-            extra_system = extra_system.rstrip() + "\n" + greeting_extra.strip() + "\n"
-            logger.debug("greeting_extra active (%d chars)", len(greeting_extra.strip()))
+            greeting_extra_stripped = greeting_extra.strip()
+            extra_system = extra_system.rstrip() + "\n" + greeting_extra_stripped + "\n"
+            logger.debug("greeting_extra active (%d chars)", len(greeting_extra_stripped))
         response_text = s.ai.generate_response(user_input, extra_system).content
 
         if cache is not None:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1266,25 +1266,7 @@ class TestSystemPromptExtraConfig(_TempHomeBase):
         self.assertTrue(any("system_prompt_extra" in msg and "blank" in msg for msg in cm.output))
 
 
-class TestGreetingExtraConfig(unittest.TestCase):
-    def setUp(self):
-        self.temp_dir = tempfile.mkdtemp()
-        self.original_home = os.environ.get('HOME')
-        os.environ['HOME'] = self.temp_dir
-        os.makedirs(os.path.join(self.temp_dir, ".sandvoice"), exist_ok=True)
-
-    def tearDown(self):
-        if self.original_home:
-            os.environ['HOME'] = self.original_home
-        else:
-            del os.environ['HOME']
-        shutil.rmtree(self.temp_dir, ignore_errors=True)
-
-    def write_config(self, config_dict):
-        config_path = os.path.join(self.temp_dir, ".sandvoice", "config.yaml")
-        with open(config_path, 'w') as f:
-            yaml.dump(config_dict, f)
-
+class TestGreetingExtraConfig(_TempHomeBase):
     def test_absent_defaults_to_none(self):
         config = Config()
         self.assertIsNone(config.greeting_extra)
@@ -1314,6 +1296,12 @@ class TestGreetingExtraConfig(unittest.TestCase):
         with self.assertLogs("common.configuration", level="WARNING") as cm:
             Config()
         self.assertTrue(any("greeting_extra" in msg for msg in cm.output))
+
+    def test_blank_string_logs_warning(self):
+        self.write_config({"greeting_extra": "   "})
+        with self.assertLogs("common.configuration", level="WARNING") as cm:
+            Config()
+        self.assertTrue(any("greeting_extra" in msg and "blank" in msg for msg in cm.output))
 
 
 if __name__ == '__main__':

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1266,5 +1266,55 @@ class TestSystemPromptExtraConfig(_TempHomeBase):
         self.assertTrue(any("system_prompt_extra" in msg and "blank" in msg for msg in cm.output))
 
 
+class TestGreetingExtraConfig(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_home = os.environ.get('HOME')
+        os.environ['HOME'] = self.temp_dir
+        os.makedirs(os.path.join(self.temp_dir, ".sandvoice"), exist_ok=True)
+
+    def tearDown(self):
+        if self.original_home:
+            os.environ['HOME'] = self.original_home
+        else:
+            del os.environ['HOME']
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def write_config(self, config_dict):
+        config_path = os.path.join(self.temp_dir, ".sandvoice", "config.yaml")
+        with open(config_path, 'w') as f:
+            yaml.dump(config_dict, f)
+
+    def test_absent_defaults_to_none(self):
+        config = Config()
+        self.assertIsNone(config.greeting_extra)
+
+    def test_valid_string_stored(self):
+        self.write_config({"greeting_extra": "End with a proverb."})
+        config = Config()
+        self.assertEqual(config.greeting_extra, "End with a proverb.")
+
+    def test_value_is_stripped(self):
+        self.write_config({"greeting_extra": "  Add a joke.  "})
+        config = Config()
+        self.assertEqual(config.greeting_extra, "Add a joke.")
+
+    def test_blank_string_normalised_to_none(self):
+        self.write_config({"greeting_extra": "   "})
+        config = Config()
+        self.assertIsNone(config.greeting_extra)
+
+    def test_non_string_normalised_to_none(self):
+        self.write_config({"greeting_extra": 99})
+        config = Config()
+        self.assertIsNone(config.greeting_extra)
+
+    def test_non_string_logs_warning(self):
+        self.write_config({"greeting_extra": 99})
+        with self.assertLogs("common.configuration", level="WARNING") as cm:
+            Config()
+        self.assertTrue(any("greeting_extra" in msg for msg in cm.output))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_greeting_plugin.py
+++ b/tests/test_greeting_plugin.py
@@ -338,5 +338,79 @@ class TestGreetingNoCacheConfigured(unittest.TestCase):
         self.assertEqual(result, "Boa noite!")
 
 
+class TestGreetingExtra(unittest.TestCase):
+    def test_greeting_extra_appended_to_prompt(self):
+        """When greeting_extra is set, it is appended to the extra_system prompt."""
+        from plugins.greeting.plugin import process
+
+        s = _make_s(cache=None)
+        s.config.greeting_extra = "End the greeting with a short proverb."
+        s.ai.define_route.return_value = {"route": "weather"}
+        s.route_message.return_value = "15°C"
+        s.ai.generate_response.return_value.content = "Good morning! Here's a proverb."
+
+        captured = []
+        def capture_response(user_input, extra_system):
+            captured.append(extra_system)
+            return s.ai.generate_response.return_value
+
+        s.ai.generate_response.side_effect = capture_response
+
+        with patch("plugins.greeting.plugin._cache_key", return_value="greeting:morning"), \
+             patch("plugins.greeting.plugin.build_extra_routes_text", return_value=""):
+            process("good morning", {}, s)
+
+        self.assertEqual(len(captured), 1)
+        self.assertIn("End the greeting with a short proverb.", captured[0])
+
+    def test_greeting_extra_absent_prompt_unchanged(self):
+        """When greeting_extra is not set, extra_system is unmodified."""
+        from plugins.greeting.plugin import process
+
+        s = _make_s(cache=None)
+        s.config.greeting_extra = None
+        s.ai.define_route.return_value = {"route": "weather"}
+        s.route_message.return_value = "15°C"
+        s.ai.generate_response.return_value.content = "Good morning!"
+
+        captured = []
+        def capture_response(user_input, extra_system):
+            captured.append(extra_system)
+            return s.ai.generate_response.return_value
+
+        s.ai.generate_response.side_effect = capture_response
+
+        with patch("plugins.greeting.plugin._cache_key", return_value="greeting:morning"), \
+             patch("plugins.greeting.plugin.build_extra_routes_text", return_value=""):
+            process("good morning", {}, s)
+
+        self.assertEqual(len(captured), 1)
+        self.assertNotIn("proverb", captured[0])
+
+    def test_greeting_extra_blank_value_skipped(self):
+        """When greeting_extra is blank whitespace, extra_system is unmodified."""
+        from plugins.greeting.plugin import process
+
+        s = _make_s(cache=None)
+        s.config.greeting_extra = "   "
+        s.ai.define_route.return_value = {"route": "weather"}
+        s.route_message.return_value = "15°C"
+        s.ai.generate_response.return_value.content = "Good morning!"
+
+        captured = []
+        def capture_response(user_input, extra_system):
+            captured.append(extra_system)
+            return s.ai.generate_response.return_value
+
+        s.ai.generate_response.side_effect = capture_response
+
+        with patch("plugins.greeting.plugin._cache_key", return_value="greeting:morning"), \
+             patch("plugins.greeting.plugin.build_extra_routes_text", return_value=""):
+            process("good morning", {}, s)
+
+        self.assertEqual(len(captured), 1)
+        self.assertFalse(captured[0].endswith("   \n"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_greeting_plugin.py
+++ b/tests/test_greeting_plugin.py
@@ -364,7 +364,7 @@ class TestGreetingExtra(unittest.TestCase):
         self.assertIn("End the greeting with a short proverb.", captured[0])
 
     def test_greeting_extra_absent_prompt_unchanged(self):
-        """When greeting_extra is not set, extra_system is unmodified."""
+        """When greeting_extra is not set, the specific greeting_extra content is not injected."""
         from plugins.greeting.plugin import process
 
         s = _make_s(cache=None)
@@ -385,31 +385,31 @@ class TestGreetingExtra(unittest.TestCase):
             process("good morning", {}, s)
 
         self.assertEqual(len(captured), 1)
-        self.assertNotIn("proverb", captured[0])
+        self.assertNotIn("End the greeting with a short proverb.", captured[0])
 
     def test_greeting_extra_blank_value_skipped(self):
-        """When greeting_extra is blank whitespace, extra_system is unmodified."""
+        """When greeting_extra is blank whitespace, extra_system is identical to the baseline."""
         from plugins.greeting.plugin import process
 
-        s = _make_s(cache=None)
-        s.config.greeting_extra = "   "
-        s.ai.define_route.return_value = {"route": "weather"}
-        s.route_message.return_value = "15°C"
-        s.ai.generate_response.return_value.content = "Good morning!"
+        def _capture(greeting_extra_value):
+            s = _make_s(cache=None)
+            s.config.greeting_extra = greeting_extra_value
+            s.ai.define_route.return_value = {"route": "weather"}
+            s.route_message.return_value = "15°C"
+            s.ai.generate_response.return_value.content = "Good morning!"
+            captured = []
+            def capture_response(user_input, extra_system):
+                captured.append(extra_system)
+                return s.ai.generate_response.return_value
+            s.ai.generate_response.side_effect = capture_response
+            with patch("plugins.greeting.plugin._cache_key", return_value="greeting:morning"), \
+                 patch("plugins.greeting.plugin.build_extra_routes_text", return_value=""):
+                process("good morning", {}, s)
+            return captured[0]
 
-        captured = []
-        def capture_response(user_input, extra_system):
-            captured.append(extra_system)
-            return s.ai.generate_response.return_value
-
-        s.ai.generate_response.side_effect = capture_response
-
-        with patch("plugins.greeting.plugin._cache_key", return_value="greeting:morning"), \
-             patch("plugins.greeting.plugin.build_extra_routes_text", return_value=""):
-            process("good morning", {}, s)
-
-        self.assertEqual(len(captured), 1)
-        self.assertFalse(captured[0].endswith("   \n"))
+        baseline = _capture(None)
+        blank_result = _capture("   ")
+        self.assertEqual(blank_result, baseline)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add optional `greeting_extra` config key that appends user-defined instructions to the greeting plugin's generation prompt (e.g. "end the greeting with a short proverb")
- Appended to `extra_system` after `.rstrip()` so the injected text always starts on a clean line
- Blank/whitespace-only or non-string values normalised to `None` with a warning logged

## Planning Document
Implements plan/backlog/51-greeting-extra-instructions.md

## Changes
- `common/configuration.py`: add `greeting_extra` to defaults; parse/validate in `load_config()`
- `plugins/greeting/plugin.py`: inject `greeting_extra` into `extra_system` before LLM call
- `README.md`: add commented-out example in config section
- `tests/test_greeting_plugin.py`: `TestGreetingExtra` (3 cases)
- `tests/test_configuration.py`: `TestGreetingExtraConfig` (6 cases)

## Testing
- [x] All tests pass (978 passed)
- [x] Coverage 88%
- [x] Tested on Mac M1