### PR TITLE
Add Plan 58: weather forecast for future date queries

### DIFF
--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -231,9 +231,9 @@ plan/
 **Document**: [backlog/51-greeting-extra-instructions.md](./backlog/51-greeting-extra-instructions.md)
 **Description**: Add optional `greeting_extra` config key that appends user-defined instructions to the greeting plugin's generation prompt (e.g. "end the greeting with a short proverb"). Separate from `system_prompt_extra` — affects only the greeting plugin's live generation.
 
-### Priority 52: Weather Forecast — 7-Day / Future Date Queries
+### Priority 52: Weather Forecast — 5-Day / Future Date Queries
 **Document**: [backlog/52-weather-forecast.md](./backlog/52-weather-forecast.md)
-**Description**: Extend the weather plugin to handle future-date queries ("will it rain tomorrow?", "what's the weather on Saturday?") by routing to the OpenWeatherMap 5-day/3-hour forecast endpoint. Adds `days_ahead` route parameter, separate cache keys and TTL config for forecast entries.
+**Description**: Extend the weather plugin to handle future-date queries ("will it rain tomorrow?", "what's the weather on Saturday?") by routing to the OpenWeatherMap 5-day/3-hour forecast endpoint. Adds `days_ahead` route parameter (0–5), separate cache keys and TTL config for forecast entries. Days beyond 5 return a graceful degradation message.
 
 ### Future Enhancements
 **Document**: [backlog/FUTURE.md](./backlog/FUTURE.md)

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -231,6 +231,10 @@ plan/
 **Document**: [backlog/51-greeting-extra-instructions.md](./backlog/51-greeting-extra-instructions.md)
 **Description**: Add optional `greeting_extra` config key that appends user-defined instructions to the greeting plugin's generation prompt (e.g. "end the greeting with a short proverb"). Separate from `system_prompt_extra` — affects only the greeting plugin's live generation.
 
+### Priority 52: Weather Forecast — 7-Day / Future Date Queries
+**Document**: [backlog/52-weather-forecast.md](./backlog/52-weather-forecast.md)
+**Description**: Extend the weather plugin to handle future-date queries ("will it rain tomorrow?", "what's the weather on Saturday?") by routing to the OpenWeatherMap 5-day/3-hour forecast endpoint. Adds `days_ahead` route parameter, separate cache keys and TTL config for forecast entries.
+
 ### Future Enhancements
 **Document**: [backlog/FUTURE.md](./backlog/FUTURE.md)
 **Description**: Long-term feature ideas: alternative providers (Anthropic, Ollama, Piper), local offline mode, conversation history truncation, user-triggered timers, conversation memory, export, plugin hot-reload, API cost tracking, music control, smart home, calendar, todo lists, multi-user support.

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -256,7 +256,7 @@ plan/
 **Description**: Add an always-on Telegram channel as a background thread within the SandVoice process. Text messages from whitelisted user IDs are routed through the same AI, plugins, and conversation history as wake-word mode. Adds `telegram_enabled`, `telegram_bot_token`, and `telegram_allowed_user_ids` config keys. Phase 1 is text only; Phase 2 adds voice message support.
 
 ### Priority 58: Weather Forecast — 5-Day / Future Date Queries
-**Document**: [backlog/52-weather-forecast.md](./backlog/52-weather-forecast.md)
+**Document**: [backlog/58-weather-forecast.md](./backlog/58-weather-forecast.md)
 **Description**: Extend the weather plugin to handle future-date queries ("will it rain tomorrow?", "what's the weather on Saturday?") by routing to the OpenWeatherMap 5-day/3-hour forecast endpoint. Adds `days_ahead` route parameter (0–5), separate cache keys and TTL config for forecast entries. Days beyond 5 return a graceful degradation message.
 
 ### Future Enhancements

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -255,6 +255,10 @@ plan/
 **Document**: [backlog/55-telegram-channel.md](./backlog/55-telegram-channel.md)
 **Description**: Add an always-on Telegram channel as a background thread within the SandVoice process. Text messages from whitelisted user IDs are routed through the same AI, plugins, and conversation history as wake-word mode. Adds `telegram_enabled`, `telegram_bot_token`, and `telegram_allowed_user_ids` config keys. Phase 1 is text only; Phase 2 adds voice message support.
 
+### Priority 58: Weather Forecast — 5-Day / Future Date Queries
+**Document**: [backlog/52-weather-forecast.md](./backlog/52-weather-forecast.md)
+**Description**: Extend the weather plugin to handle future-date queries ("will it rain tomorrow?", "what's the weather on Saturday?") by routing to the OpenWeatherMap 5-day/3-hour forecast endpoint. Adds `days_ahead` route parameter (0–5), separate cache keys and TTL config for forecast entries. Days beyond 5 return a graceful degradation message.
+
 ### Future Enhancements
 **Document**: [backlog/FUTURE.md](./backlog/FUTURE.md)
 **Description**: Long-term feature ideas: alternative providers (Anthropic, Ollama, Piper), local offline mode, conversation history truncation, user-triggered timers, conversation memory, export, plugin hot-reload, API cost tracking, music control, smart home, calendar, todo lists, multi-user support.

--- a/plan/backlog/52-weather-forecast.md
+++ b/plan/backlog/52-weather-forecast.md
@@ -1,0 +1,79 @@
+# Plan 52: Weather Forecast — 7-Day / Future Date Queries
+
+## Status
+📋 Backlog
+
+## Problem
+The weather plugin (`plugins/weather/plugin.py`) only queries the OpenWeatherMap **current weather** endpoint (`/data/2.5/weather`). When a user asks "what will the weather be like on Thursday?" or "will it rain this weekend?", the plugin returns today's conditions — which is misleading.
+
+## Goal
+Extend the weather plugin to route future-date questions to the OpenWeatherMap **5-day / 3-hour forecast** endpoint (`/data/2.5/forecast`), so users can ask about weather up to 7 days ahead and get accurate answers.
+
+## Approach
+
+### Routing changes (`routes.yaml`)
+Add a `days_ahead` parameter to the weather route so the AI can signal that a future date was requested:
+
+```yaml
+- name: weather
+  description: "Answer questions about current or future weather conditions"
+  parameters:
+    location: string (optional, defaults to configured location)
+    unit: string (optional, defaults to configured unit)
+    days_ahead: integer (optional, 0 = today/current, 1–7 = forecast N days from now)
+```
+
+The AI sets `days_ahead` to `0` (or omits it) for present-tense queries, and to a positive integer for future queries.
+
+### Plugin logic (`plugins/weather/plugin.py`)
+1. Read `route.get('days_ahead', 0)` after existing location/unit defaults.
+2. If `days_ahead == 0`: use existing `OpenWeatherReader.get_current_weather()` path unchanged.
+3. If `days_ahead >= 1`: call a new `OpenWeatherReader.get_forecast(days_ahead)` method:
+   - Hits `/data/2.5/forecast?q=<location>&appid=<key>&units=<unit>&cnt=<slots>` where `cnt = min(days_ahead * 8, 40)` (8 three-hour slots per day, API max 40).
+   - Filters the returned `list` to entries whose `dt_txt` date matches `today + days_ahead`.
+   - Returns the filtered list (or the full list if filtering produces nothing — graceful fallback).
+4. Cache key includes `days_ahead` to avoid collisions between current and forecast entries: `weather:<JSON([loc,unit,days_ahead])>`.
+5. TTL for forecast entries is shorter (configurable, default 1 h) because forecasts change faster than current-conditions summaries.
+6. The LLM prompt for forecast queries asks the model to summarise the day's expected conditions rather than giving a point-in-time reading.
+
+### New config keys (`config.yaml` / `configuration.py`)
+| Key | Default | Description |
+|-----|---------|-------------|
+| `cache_weather_forecast_ttl_s` | `3600` (1 h) | TTL for forecast cache entries |
+| `cache_weather_forecast_max_stale_s` | `7200` (2 h) | Max-stale window for forecast cache entries |
+
+Both follow the existing 4-step config pattern (defaults dict → `load_config()` assignment → validation → documented in `config.yaml`).
+
+### Cache key helper
+Update `_cache_key(location, unit, days_ahead=0)` to encode all three values:
+```python
+def _cache_key(location, unit, days_ahead=0):
+    encoded = json.dumps([location, unit, days_ahead], separators=(",", ":"))
+    return f"weather:{encoded}"
+```
+Legacy entries (encoded without `days_ahead`) are automatically separate — no migration needed.
+
+## Acceptance Criteria
+- [ ] "What's the weather today?" routes to current endpoint (unchanged behavior)
+- [ ] "What will the weather be like tomorrow?" returns next-day forecast data
+- [ ] "Will it rain on Saturday?" returns forecast for the correct day (up to 7 days out)
+- [ ] Forecast responses are cached separately from current-weather responses
+- [ ] Cache TTL/max-stale for forecast entries is independently configurable
+- [ ] Graceful degradation: if `days_ahead > 5` (API limit) or forecast fetch fails, return a friendly message
+- [ ] All new code paths covered by unit tests (>80% coverage)
+- [ ] No regression in existing current-weather tests
+
+## Testing Strategy
+- Unit-test `get_forecast()` with mocked `requests.get` returning a realistic 40-slot forecast payload.
+- Unit-test `_cache_key()` with `days_ahead` variants to confirm key separation.
+- Unit-test the `days_ahead >= 1` branch in `process()` end-to-end with mocked `OpenWeatherReader`.
+- Verify that `days_ahead=0` still exercises the original code path (no regression).
+
+## Out of Scope
+- Hourly forecasts (user asks "what time will the rain start?") — separate plan if needed.
+- Weather alerts / severe weather warnings.
+- Caching warm-up for forecast entries (scheduler would need a per-day-ahead variant).
+
+## Dependencies
+- Existing `VoiceCache` infrastructure (Plan 20) — already in production.
+- OpenWeatherMap free tier includes the 5-day/3-hour forecast endpoint.

--- a/plan/backlog/52-weather-forecast.md
+++ b/plan/backlog/52-weather-forecast.md
@@ -1,4 +1,4 @@
-# Plan 52: Weather Forecast — 7-Day / Future Date Queries
+# Plan 52: Weather Forecast — 5-Day / Future Date Queries
 
 ## Status
 📋 Backlog
@@ -7,7 +7,7 @@
 The weather plugin (`plugins/weather/plugin.py`) only queries the OpenWeatherMap **current weather** endpoint (`/data/2.5/weather`). When a user asks "what will the weather be like on Thursday?" or "will it rain this weekend?", the plugin returns today's conditions — which is misleading.
 
 ## Goal
-Extend the weather plugin to route future-date questions to the OpenWeatherMap **5-day / 3-hour forecast** endpoint (`/data/2.5/forecast`), so users can ask about weather up to 7 days ahead and get accurate answers.
+Extend the weather plugin to route future-date questions to the OpenWeatherMap **5-day / 3-hour forecast** endpoint (`/data/2.5/forecast`), so users can ask about weather up to 5 days ahead and get accurate answers.
 
 ## Approach
 
@@ -20,21 +20,22 @@ Add a `days_ahead` parameter to the weather route so the AI can signal that a fu
   parameters:
     location: string (optional, defaults to configured location)
     unit: string (optional, defaults to configured unit)
-    days_ahead: integer (optional, 0 = today/current, 1–7 = forecast N days from now)
+    days_ahead: integer (optional, 0 = today/current, 1–5 = forecast N days from now)
 ```
 
-The AI sets `days_ahead` to `0` (or omits it) for present-tense queries, and to a positive integer for future queries.
+The AI sets `days_ahead` to `0` (or omits it) for present-tense queries, and to a positive integer for future queries. Values above 5 are outside the API's range and will receive a graceful degradation message (see Acceptance Criteria).
 
 ### Plugin logic (`plugins/weather/plugin.py`)
 1. Read `route.get('days_ahead', 0)` after existing location/unit defaults.
 2. If `days_ahead == 0`: use existing `OpenWeatherReader.get_current_weather()` path unchanged.
-3. If `days_ahead >= 1`: call a new `OpenWeatherReader.get_forecast(days_ahead)` method:
+3. If `1 <= days_ahead <= 5`: call a new `OpenWeatherReader.get_forecast(days_ahead)` method:
    - Hits `/data/2.5/forecast?q=<location>&appid=<key>&units=<unit>&cnt=<slots>` where `cnt = min(days_ahead * 8, 40)` (8 three-hour slots per day, API max 40).
-   - Filters the returned `list` to entries whose `dt_txt` date matches `today + days_ahead`.
-   - Returns the filtered list (or the full list if filtering produces nothing — graceful fallback).
-4. Cache key includes `days_ahead` to avoid collisions between current and forecast entries: `weather:<JSON([loc,unit,days_ahead])>`.
-5. TTL for forecast entries is shorter (configurable, default 1 h) because forecasts change faster than current-conditions summaries.
-6. The LLM prompt for forecast queries asks the model to summarise the day's expected conditions rather than giving a point-in-time reading.
+   - Filters the returned `list` to entries whose forecast date matches `today + days_ahead` in the location's timezone. Use the `city.timezone` offset from the payload (seconds east of UTC) to derive both the target date and to interpret each slot's `dt` field, avoiding off-by-one-day errors around midnight.
+   - Returns the filtered list (or the full list if timezone-based filtering produces nothing — graceful fallback).
+4. If `days_ahead > 5`: return a friendly message without calling the API (e.g. "I can only forecast up to 5 days ahead.").
+5. Cache key includes `days_ahead` to avoid collisions between current and forecast entries: `weather:<JSON([loc,unit,days_ahead])>`.
+6. TTL for forecast entries is shorter (configurable, default 1 h) because forecasts change faster than current-conditions summaries.
+7. The LLM prompt for forecast queries asks the model to summarise the day's expected conditions rather than giving a point-in-time reading.
 
 ### New config keys (`config.yaml` / `configuration.py`)
 | Key | Default | Description |
@@ -56,10 +57,11 @@ Legacy entries (encoded without `days_ahead`) are automatically separate — no 
 ## Acceptance Criteria
 - [ ] "What's the weather today?" routes to current endpoint (unchanged behavior)
 - [ ] "What will the weather be like tomorrow?" returns next-day forecast data
-- [ ] "Will it rain on Saturday?" returns forecast for the correct day (up to 7 days out)
+- [ ] "Will it rain on Saturday?" returns forecast for the correct day (up to 5 days out)
 - [ ] Forecast responses are cached separately from current-weather responses
 - [ ] Cache TTL/max-stale for forecast entries is independently configurable
-- [ ] Graceful degradation: if `days_ahead > 5` (API limit) or forecast fetch fails, return a friendly message
+- [ ] Graceful degradation: if `days_ahead > 5` (beyond API limit), return a friendly message without calling the API
+- [ ] Graceful degradation: if forecast fetch fails for any reason, return a friendly error message
 - [ ] All new code paths covered by unit tests (>80% coverage)
 - [ ] No regression in existing current-weather tests
 
@@ -67,12 +69,15 @@ Legacy entries (encoded without `days_ahead`) are automatically separate — no 
 - Unit-test `get_forecast()` with mocked `requests.get` returning a realistic 40-slot forecast payload.
 - Unit-test `_cache_key()` with `days_ahead` variants to confirm key separation.
 - Unit-test the `days_ahead >= 1` branch in `process()` end-to-end with mocked `OpenWeatherReader`.
+- Unit-test timezone-aware date filtering with a payload whose `city.timezone` offset places the target date differently than UTC.
+- Unit-test `days_ahead > 5` returns the friendly degradation message without making an API call.
 - Verify that `days_ahead=0` still exercises the original code path (no regression).
 
 ## Out of Scope
 - Hourly forecasts (user asks "what time will the rain start?") — separate plan if needed.
 - Weather alerts / severe weather warnings.
 - Caching warm-up for forecast entries (scheduler would need a per-day-ahead variant).
+- Forecasts beyond 5 days (would require a different API tier or provider).
 
 ## Dependencies
 - Existing `VoiceCache` infrastructure (Plan 20) — already in production.

--- a/plan/backlog/52-weather-forecast.md
+++ b/plan/backlog/52-weather-forecast.md
@@ -26,7 +26,7 @@ The AI sets `days_ahead` to `0` (or omits it) for present-tense queries, and to 
 1. Read `route.get('days_ahead', 0)` after existing location/unit defaults.
 2. If `days_ahead == 0`: use existing `OpenWeatherReader.get_current_weather()` path unchanged.
 3. If `1 <= days_ahead <= 5`: call a new `OpenWeatherReader.get_forecast(days_ahead)` method:
-   - Hits `/data/2.5/forecast?q=<location>&appid=<key>&units=<unit>&cnt=<slots>` where `cnt = min(days_ahead * 8, 40)` (8 three-hour slots per day, API max 40).
+   - Hits `/data/2.5/forecast?q=<location>&appid=<key>&units=<unit>&cnt=40` — always fetch all 40 slots (the API maximum). Using `cnt = days_ahead * 8` risks missing the target date when the request is made late in the day, since `cnt` counts slots from "now" rather than calendar days. Fetching 40 slots ensures the target date is always covered.
    - Filters the returned `list` to entries whose forecast date matches `today + days_ahead` in the location's timezone. Use the `city.timezone` offset from the payload (seconds east of UTC) to derive both the target date and to interpret each slot's `dt` field, avoiding off-by-one-day errors around midnight.
    - Returns the filtered list (or the full list if timezone-based filtering produces nothing — graceful fallback).
 4. If `days_ahead > 5`: return a friendly message without calling the API (e.g. "I can only forecast up to 5 days ahead.").

--- a/plan/backlog/52-weather-forecast.md
+++ b/plan/backlog/52-weather-forecast.md
@@ -11,17 +11,14 @@ Extend the weather plugin to route future-date questions to the OpenWeatherMap *
 
 ## Approach
 
-### Routing changes (`routes.yaml`)
-Add a `days_ahead` parameter to the weather route so the AI can signal that a future date was requested:
+### Routing changes (`plugins/weather/plugin.yaml`)
+The weather plugin's routing metadata lives in `plugins/weather/plugin.yaml`, not `routes.yaml`. Update it to support `days_ahead`:
 
-```yaml
-- name: weather
-  description: "Answer questions about current or future weather conditions"
-  parameters:
-    location: string (optional, defaults to configured location)
-    unit: string (optional, defaults to configured unit)
-    days_ahead: integer (optional, 0 = today/current, 1–5 = forecast N days from now)
-```
+- Add `days_ahead` to `route_extra_keys` so the router includes it in the JSON output.
+- Update `route_description` to cover both current and future weather questions, instructing the model to:
+  - Omit `days_ahead` (or set it to `0`) for present-tense queries.
+  - Set `days_ahead` to an integer from `1` to `5` for future-date queries.
+  - Values above `5` are outside the API range — the plugin returns a graceful degradation message.
 
 The AI sets `days_ahead` to `0` (or omits it) for present-tense queries, and to a positive integer for future queries. Values above 5 are outside the API's range and will receive a graceful degradation message (see Acceptance Criteria).
 

--- a/plan/backlog/58-weather-forecast.md
+++ b/plan/backlog/58-weather-forecast.md
@@ -32,7 +32,7 @@ The AI sets `days_ahead` to `0` (or omits it) for present-tense queries, and to 
 4. If `days_ahead > 5`: return a friendly message without calling the API (e.g. "I can only forecast up to 5 days ahead.").
 5. Cache key includes `days_ahead` to avoid collisions between current and forecast entries: `weather:<JSON([loc,unit,days_ahead])>`.
 6. TTL for forecast entries is shorter (configurable, default 1 h) because forecasts change faster than current-conditions summaries.
-7. The LLM prompt for forecast queries asks the model to summarise the day's expected conditions rather than giving a point-in-time reading.
+7. The LLM prompt for forecast queries asks the model to summarize the day's expected conditions rather than giving a point-in-time reading.
 
 ### New config keys (`config.yaml` / `configuration.py`)
 | Key | Default | Description |

--- a/plan/backlog/58-weather-forecast.md
+++ b/plan/backlog/58-weather-forecast.md
@@ -49,7 +49,13 @@ def _cache_key(location, unit, days_ahead=0):
     encoded = json.dumps([location, unit, days_ahead], separators=(",", ":"))
     return f"weather:{encoded}"
 ```
-Legacy entries (encoded without `days_ahead`) are automatically separate — no migration needed.
+
+**Cache key migration note**: Adding `days_ahead=0` to the key changes the shape for
+current-weather entries (`["loc","unit",0]` vs the legacy `["loc","unit"]`), so existing
+cached current-weather entries will not be reused after the upgrade — a one-time cold
+start. This is intentional and acceptable: the weather cache TTL is short (default 3 h)
+so entries expire quickly regardless. No read-through fallback to the legacy key format
+is needed.
 
 ## Acceptance Criteria
 - [ ] "What's the weather today?" routes to current endpoint (unchanged behavior)

--- a/plan/backlog/58-weather-forecast.md
+++ b/plan/backlog/58-weather-forecast.md
@@ -1,4 +1,4 @@
-# Plan 52: Weather Forecast — 5-Day / Future Date Queries
+# Plan 58: Weather Forecast — 5-Day / Future Date Queries
 
 ## Status
 📋 Backlog


### PR DESCRIPTION
## Summary
Adds `plan/backlog/58-weather-forecast.md` — design doc for extending the weather plugin to handle future-date queries using the OpenWeatherMap 5-day/3-hour forecast endpoint.

## Planning Document
Implements plan/backlog/58-weather-forecast.md

## Changes
- Added `plan/backlog/58-weather-forecast.md` with full design: routing changes, plugin logic, cache key strategy, timezone-aware filtering, new config keys
- Updated `plan/INDEX.md` to add Priority 58 backlog entry

## Testing
- [x] All tests pass
- [x] Documentation only — no code changes