### PR TITLE
Add Plan 53: audio response cache for TTS-generated MP3s

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ speech_to_text_translate_model: gpt-5-mini
 text_to_speech_model: tts-1
 bot_voice_model: nova
 
+# Context-aware routing
+route_history_depth: 4       # recent conversation turns passed to the router (0 = stateless)
+
 # Response streaming
 stream_responses: disabled   # enabled = stream LLM deltas (required in --wake-word)
 stream_tts: disabled         # enabled = play TTS while response generates (required in --wake-word)

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -231,6 +231,14 @@ plan/
 **Document**: [backlog/51-greeting-extra-instructions.md](./backlog/51-greeting-extra-instructions.md)
 **Description**: Add optional `greeting_extra` config key that appends user-defined instructions to the greeting plugin's generation prompt (e.g. "end the greeting with a short proverb"). Separate from `system_prompt_extra` — affects only the greeting plugin's live generation.
 
+### Priority 52: Weather Forecast — 5-Day / Future Date Queries
+**Document**: [backlog/52-weather-forecast.md](./backlog/52-weather-forecast.md)
+**Description**: Extend the weather plugin to handle future-date queries ("will it rain tomorrow?", "what's the weather on Saturday?") by routing to the OpenWeatherMap 5-day/3-hour forecast endpoint. Adds `days_ahead` route parameter (0–5), separate cache keys and TTL config for forecast entries. Days beyond 5 return a graceful degradation message.
+
+### Priority 53: Audio Response Cache
+**Document**: [backlog/53-audio-response-cache.md](./backlog/53-audio-response-cache.md)
+**Description**: Cache TTS-generated MP3 files alongside text cache entries. On a cache hit, if a valid audio file exists (validated by SHA-256 hash of text+voice+model), play it directly and skip the TTS API call. Adds `audio_cache_enabled`, `audio_cache_dir`, and `audio_cache_max_files` config keys. Streaming TTS path excluded.
+
 ### Future Enhancements
 **Document**: [backlog/FUTURE.md](./backlog/FUTURE.md)
 **Description**: Long-term feature ideas: alternative providers (Anthropic, Ollama, Piper), local offline mode, conversation history truncation, user-triggered timers, conversation memory, export, plugin hot-reload, API cost tracking, music control, smart home, calendar, todo lists, multi-user support.

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -231,10 +231,6 @@ plan/
 **Document**: [backlog/51-greeting-extra-instructions.md](./backlog/51-greeting-extra-instructions.md)
 **Description**: Add optional `greeting_extra` config key that appends user-defined instructions to the greeting plugin's generation prompt (e.g. "end the greeting with a short proverb"). Separate from `system_prompt_extra` — affects only the greeting plugin's live generation.
 
-### Priority 52: Weather Forecast — 5-Day / Future Date Queries
-**Document**: [backlog/52-weather-forecast.md](./backlog/52-weather-forecast.md)
-**Description**: Extend the weather plugin to handle future-date queries ("will it rain tomorrow?", "what's the weather on Saturday?") by routing to the OpenWeatherMap 5-day/3-hour forecast endpoint. Adds `days_ahead` route parameter (0–5), separate cache keys and TTL config for forecast entries. Days beyond 5 return a graceful degradation message.
-
 ### Priority 53: Audio Response Cache
 **Document**: [backlog/53-audio-response-cache.md](./backlog/53-audio-response-cache.md)
 **Description**: Cache TTS-generated MP3 files alongside text cache entries. On a cache hit, if a valid audio file exists (validated by SHA-256 hash of text+voice+model), play it directly and skip the TTS API call. Adds `audio_cache_enabled`, `audio_cache_dir`, and `audio_cache_max_files` config keys. Streaming TTS path excluded.

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -233,7 +233,7 @@ plan/
 
 ### Priority 53: Audio Response Cache
 **Document**: [backlog/53-audio-response-cache.md](./backlog/53-audio-response-cache.md)
-**Description**: Cache TTS-generated MP3 files alongside text cache entries. On a cache hit, if a valid audio file exists (validated by SHA-256 hash of text+voice+model), play it directly and skip the TTS API call. Adds `audio_cache_enabled`, `audio_cache_dir`, and `audio_cache_max_files` config keys. Streaming TTS path excluded.
+**Description**: Cache TTS-generated MP3 files alongside text cache entries. On a cache hit, if a valid audio file exists (keyed by SHA-256 hash of text+voice+tts_model+tts_provider), play it directly and skip the TTS API call. Adds `audio_cache_enabled`, `audio_cache_dir`, and `audio_cache_max_files` config keys. Streaming TTS path excluded.
 
 ### Future Enhancements
 **Document**: [backlog/FUTURE.md](./backlog/FUTURE.md)

--- a/plan/backlog/53-audio-response-cache.md
+++ b/plan/backlog/53-audio-response-cache.md
@@ -1,0 +1,111 @@
+# Plan 53: Audio Response Cache
+
+## Status
+📋 Backlog
+
+## Problem
+Every text cache hit (weather, greeting) still makes a full TTS API call. The text is
+identical across hits within the same TTL window, so the resulting audio is also identical.
+There is no reason to call TTS more than once per unique (text, voice, model) combination.
+
+## Goal
+Cache the generated MP3 alongside the text response. On a cache hit, if a valid audio
+file already exists, play it directly and skip the TTS call entirely. Audio files are
+stored in a configurable directory and validated by a content hash before use.
+
+## Scope
+
+**In scope:**
+- Non-streaming playback path only (CLI mode and wake-word mode when `stream_responses` is
+  disabled). Streaming TTS pipelines LLM deltas directly into audio; that path is excluded.
+- Plugins that already use `VoiceCache` for text: `weather` and `greeting` today; any
+  future plugin that opts in.
+
+**Out of scope:**
+- Streaming TTS path (`stream_tts`) — deferred.
+- Conversational (non-cached) responses — no value; those are unique per request.
+
+## Design
+
+### Hash function
+A SHA-256 digest of `text + "|" + voice + "|" + tts_model` uniquely identifies an
+audio file. If any of the three change, the hash changes and the old file is ignored.
+
+```python
+import hashlib
+
+def _audio_hash(text, voice, tts_model):
+    payload = f"{text}|{voice}|{tts_model}"
+    return hashlib.sha256(payload.encode()).hexdigest()
+```
+
+The audio file is stored as `<audio_cache_dir>/<hash>.mp3`. The filename is the hash,
+so no separate index is needed to verify freshness — if the file exists at the expected
+path, it is valid by construction.
+
+### VoiceCache changes (`common/cache.py`)
+Add an optional `audio_hash` column to the `voice_cache` SQLite table:
+
+```sql
+ALTER TABLE voice_cache ADD COLUMN audio_hash TEXT;
+```
+
+`VoiceCache.set()` accepts an optional `audio_hash` argument and persists it alongside
+the text value. `VoiceCache.get()` returns the `audio_hash` field in `CacheEntry` so
+callers can verify the file.
+
+### Playback path (`common/audio.py` or call site)
+After a text cache hit:
+
+1. Retrieve `entry.audio_hash` from the cache.
+2. Compute expected hash: `_audio_hash(entry.value, config.bot_voice_model_voice, config.bot_voice_model)`.
+3. Build path: `os.path.join(config.audio_cache_dir, f"{expected_hash}.mp3")`.
+4. If the file exists and `entry.audio_hash == expected_hash`: play the file, skip TTS.
+5. Otherwise: call TTS normally, save the resulting MP3 to the path, call `cache.set()`
+   again with the new `audio_hash`.
+
+Hash mismatch means the cached text was refreshed with new content since the audio was
+generated. The old file is not deleted — it will be orphaned until a cleanup sweep
+(see below). The new audio replaces it under a new hash filename.
+
+### New config keys (`config.yaml` / `configuration.py`)
+| Key | Default | Description |
+|-----|---------|-------------|
+| `audio_cache_enabled` | `"disabled"` | Enable/disable audio caching (`"enabled"`/`"disabled"`) |
+| `audio_cache_dir` | `~/.sandvoice/audio_cache` | Directory for cached MP3 files |
+| `audio_cache_max_files` | `50` | Maximum number of files to keep; oldest by mtime pruned on startup |
+
+All follow the 4-step config pattern (defaults dict → `load_config()` → validation →
+documented in `config.yaml`).
+
+`audio_cache_dir` is created on startup if it does not exist (same pattern as the DB
+directory).
+
+### Orphan cleanup
+On startup (when `audio_cache_enabled` is `"enabled"`), prune files in `audio_cache_dir`
+by mtime until the count is ≤ `audio_cache_max_files`. This is the only cleanup
+mechanism — no background thread, no per-file expiry.
+
+## Acceptance Criteria
+- [ ] On a text cache hit with a valid audio file: TTS API is not called, file is played
+- [ ] On a text cache hit with no audio file: TTS is called, result saved, hash stored
+- [ ] On a text cache hit where `audio_hash` does not match (text was refreshed): TTS
+      called, new file saved under new hash, old file left as orphan
+- [ ] `audio_cache_dir` is created on first use if missing
+- [ ] Orphan files pruned to `audio_cache_max_files` on startup
+- [ ] Audio caching is completely disabled when `audio_cache_enabled: disabled`
+- [ ] Streaming TTS path is unaffected
+- [ ] All new code paths covered by unit tests (>80% coverage)
+
+## Testing Strategy
+- Unit-test `_audio_hash()` for determinism and collision resistance (different text →
+  different hash; same text+voice+model → same hash).
+- Unit-test cache hit with valid file: mock file existence, assert TTS not called.
+- Unit-test cache hit with missing file: assert TTS called, file written, hash stored.
+- Unit-test hash mismatch: assert TTS called even though a file exists at a different path.
+- Unit-test orphan cleanup: assert oldest files removed when count exceeds limit.
+
+## Dependencies
+- `VoiceCache` (Plan 20) — text cache must be enabled for audio cache to apply.
+- `audio_cache_enabled` is independent of `cache_enabled`; both must be on for audio
+  caching to activate.

--- a/plan/backlog/53-audio-response-cache.md
+++ b/plan/backlog/53-audio-response-cache.md
@@ -74,14 +74,17 @@ After a text cache hit, before any TTS call (streaming or non-streaming):
 1. Retrieve `entry.audio_hash` from the cache.
 2. Compute expected hash: `_audio_hash(entry.value, config.bot_voice_model, config.text_to_speech_model, config.tts_provider)`.
 3. Build path: `os.path.join(config.audio_cache_dir, f"{expected_hash}.mp3")`.
-4. If the file exists and `entry.audio_hash == expected_hash`: play the file directly,
-   skip TTS entirely (works in all modes including wake-word).
+4. If the file exists, passes a minimal validation check (non-zero size), and
+   `entry.audio_hash == expected_hash`: play the file directly, skip TTS entirely
+   (works in all modes including wake-word).
 5. Otherwise — **non-streaming path**: call TTS, write MP3 bytes to a temp path,
    atomically rename into place, call `cache.set()` with the new `audio_hash`.
 6. Otherwise — **streaming path**: open a temp file before the stream starts; for each
    audio chunk, play it and append the bytes to the temp file; after the final chunk,
    atomically rename into place, call `cache.set()` with the new `audio_hash`.
    MP3 frames can be appended directly — the resulting file is a valid MP3.
+   If the stream is interrupted (e.g. barge-in), skip the rename; the temp file
+   is left as an orphan and pruned by the startup cleanup.
 
 Hash mismatch means the cached text was refreshed with new content since the audio was
 generated. The old file is not deleted — it will be orphaned until a cleanup sweep

--- a/plan/backlog/53-audio-response-cache.md
+++ b/plan/backlog/53-audio-response-cache.md
@@ -11,7 +11,7 @@ There is no reason to call TTS more than once per unique (text, voice, model) co
 ## Goal
 Cache the generated MP3 alongside the text response. On a cache hit, if a valid audio
 file already exists, play it directly and skip the TTS call entirely. Audio files are
-stored in a configurable directory and validated by a content hash before use.
+stored in a configurable directory and keyed by a hash of (text, voice, tts_model).
 
 ## Scope
 
@@ -33,9 +33,10 @@ audio file. If any of the three change, the hash changes and the old file is ign
 
 ```python
 import hashlib
+import json
 
 def _audio_hash(text, voice, tts_model):
-    payload = f"{text}|{voice}|{tts_model}"
+    payload = json.dumps([text, voice, tts_model], ensure_ascii=False, separators=(",", ":"))
     return hashlib.sha256(payload.encode()).hexdigest()
 ```
 
@@ -47,6 +48,8 @@ path, it is valid by construction.
 Add an optional `audio_hash` column to the `voice_cache` SQLite table:
 
 ```sql
+-- Only run if the column does not already exist (idempotent migration):
+-- check via PRAGMA table_info(voice_cache) and skip if audio_hash is present.
 ALTER TABLE voice_cache ADD COLUMN audio_hash TEXT;
 ```
 
@@ -58,7 +61,7 @@ callers can verify the file.
 After a text cache hit:
 
 1. Retrieve `entry.audio_hash` from the cache.
-2. Compute expected hash: `_audio_hash(entry.value, config.bot_voice_model_voice, config.bot_voice_model)`.
+2. Compute expected hash: `_audio_hash(entry.value, config.bot_voice_model, config.text_to_speech_model)`.
 3. Build path: `os.path.join(config.audio_cache_dir, f"{expected_hash}.mp3")`.
 4. If the file exists and `entry.audio_hash == expected_hash`: play the file, skip TTS.
 5. Otherwise: call TTS normally, save the resulting MP3 to the path, call `cache.set()`

--- a/plan/backlog/53-audio-response-cache.md
+++ b/plan/backlog/53-audio-response-cache.md
@@ -16,8 +16,9 @@ stored in a configurable directory and keyed by a hash of (text, voice, tts_mode
 ## Scope
 
 **In scope:**
-- Non-streaming playback path only (CLI mode and wake-word mode when `stream_responses` is
-  disabled). Streaming TTS pipelines LLM deltas directly into audio; that path is excluded.
+- Non-streaming playback path only (CLI mode and default interactive mode). Wake-word mode
+  requires `stream_responses` and `stream_tts` to be enabled and is therefore excluded.
+  Streaming TTS pipelines LLM deltas directly into audio; that path is excluded.
 - Plugins that already use `VoiceCache` for text: `weather` and `greeting` today; any
   future plugin that opts in.
 

--- a/plan/backlog/53-audio-response-cache.md
+++ b/plan/backlog/53-audio-response-cache.md
@@ -16,14 +16,16 @@ stored in a configurable directory and keyed by a hash of (text, voice, tts_mode
 ## Scope
 
 **In scope:**
-- Non-streaming playback path only (CLI mode and default interactive mode). Wake-word mode
-  requires `stream_responses` and `stream_tts` to be enabled and is therefore excluded.
-  Streaming TTS pipelines LLM deltas directly into audio; that path is excluded.
+- All playback modes: CLI, default interactive, and wake-word mode.
+- On a text cache hit, the audio hash is checked **before** any TTS call. If a valid MP3
+  exists, it is played directly regardless of whether the mode uses streaming or not.
+- On a cache miss in streaming mode, audio chunks are teed to a temp file while playing;
+  the file is atomically renamed into place after playback completes so future hits skip
+  the stream entirely.
 - Plugins that already use `VoiceCache` for text: `weather` and `greeting` today; any
   future plugin that opts in.
 
 **Out of scope:**
-- Streaming TTS path (`stream_tts`) — deferred.
 - Conversational (non-cached) responses — no value; those are unique per request.
 
 ## Design
@@ -67,14 +69,18 @@ the text value. `VoiceCache.get()` returns the `audio_hash` field in `CacheEntry
 callers can verify the file.
 
 ### Playback path (`common/audio.py` or call site)
-After a text cache hit:
+After a text cache hit, before any TTS call (streaming or non-streaming):
 
 1. Retrieve `entry.audio_hash` from the cache.
 2. Compute expected hash: `_audio_hash(entry.value, config.bot_voice_model, config.text_to_speech_model, config.tts_provider)`.
 3. Build path: `os.path.join(config.audio_cache_dir, f"{expected_hash}.mp3")`.
-4. If the file exists and `entry.audio_hash == expected_hash`: play the file, skip TTS.
-5. Otherwise: call TTS normally, save the resulting MP3 to the path, call `cache.set()`
-   again with the new `audio_hash`.
+4. If the file exists and `entry.audio_hash == expected_hash`: play the file directly,
+   skip TTS entirely (works in all modes including wake-word).
+5. Otherwise — **non-streaming path**: call TTS, save MP3 to a temp path, atomically
+   rename into place, call `cache.set()` with the new `audio_hash`.
+6. Otherwise — **streaming path**: proceed with `stream_tts` as normal, simultaneously
+   writing audio chunks to a temp file; atomically rename into place after playback
+   completes, then call `cache.set()` with the new `audio_hash`.
 
 Hash mismatch means the cached text was refreshed with new content since the audio was
 generated. The old file is not deleted — it will be orphaned until a cleanup sweep
@@ -106,14 +112,17 @@ mechanism — no background thread, no per-file expiry.
 - [ ] `audio_cache_dir` is created on first use if missing
 - [ ] Orphan files pruned to `audio_cache_max_files` on startup
 - [ ] Audio caching is completely disabled when `audio_cache_enabled: disabled`
-- [ ] Streaming TTS path is unaffected
+- [ ] Wake-word mode: cache hit plays MP3 directly, skipping the streaming TTS pipeline
+- [ ] Wake-word mode: cache miss streams and writes audio to file; subsequent hit plays from file
 - [ ] All new code paths covered by unit tests (>80% coverage)
 
 ## Testing Strategy
 - Unit-test `_audio_hash()` for determinism, stability, and input separation (same
   text+voice+model+provider → same hash; different text/voice/model/provider → different hash).
 - Unit-test cache hit with valid file: mock file existence, assert TTS not called.
-- Unit-test cache hit with missing file: assert TTS called, file written, hash stored.
+- Unit-test cache miss on non-streaming path: assert TTS called, file written, hash stored.
+- Unit-test cache miss on streaming path: assert stream runs, chunks written to temp file,
+  atomically renamed, hash stored.
 - Unit-test hash mismatch: assert TTS called even though a file exists at a different path.
 - Unit-test orphan cleanup: assert oldest files removed when count exceeds limit.
 

--- a/plan/backlog/53-audio-response-cache.md
+++ b/plan/backlog/53-audio-response-cache.md
@@ -6,12 +6,12 @@
 ## Problem
 Every text cache hit (weather, greeting) still makes a full TTS API call. The text is
 identical across hits within the same TTL window, so the resulting audio is also identical.
-There is no reason to call TTS more than once per unique (text, voice, model) combination.
+There is no reason to call TTS more than once per unique (text, voice, tts_model, tts_provider) combination.
 
 ## Goal
 Cache the generated MP3 alongside the text response. On a cache hit, if a valid audio
 file already exists, play it directly and skip the TTS call entirely. Audio files are
-stored in a configurable directory and keyed by a hash of (text, voice, tts_model).
+stored in a configurable directory and keyed by a hash of (text, voice, tts_model, tts_provider).
 
 ## Scope
 
@@ -54,12 +54,12 @@ Readers should treat a cached file as a hit only if the expected file exists and
 a minimal validation check (non-zero size and/or a decodable MP3 header).
 
 ### VoiceCache changes (`common/cache.py`)
-Add an optional `audio_hash` column to the `voice_cache` SQLite table:
+Add an optional `audio_hash` column to the `cache_entries` SQLite table:
 
 ```sql
 -- Only run if the column does not already exist (idempotent migration):
--- check via PRAGMA table_info(voice_cache) and skip if audio_hash is present.
-ALTER TABLE voice_cache ADD COLUMN audio_hash TEXT;
+-- check via PRAGMA table_info(cache_entries) and skip if audio_hash is present.
+ALTER TABLE cache_entries ADD COLUMN audio_hash TEXT;
 ```
 
 `VoiceCache.set()` accepts an optional `audio_hash` argument and persists it alongside

--- a/plan/backlog/53-audio-response-cache.md
+++ b/plan/backlog/53-audio-response-cache.md
@@ -28,21 +28,29 @@ stored in a configurable directory and keyed by a hash of (text, voice, tts_mode
 ## Design
 
 ### Hash function
-A SHA-256 digest of `text + "|" + voice + "|" + tts_model` uniquely identifies an
-audio file. If any of the three change, the hash changes and the old file is ignored.
+A SHA-256 digest of a canonical JSON serialization of `(text, voice, tts_model, tts_provider)`
+uniquely identifies an audio file. Including the provider prevents cross-provider collisions
+when the same `(voice, model)` strings are used with different TTS backends. If any of the
+four inputs change, the hash changes and the old file is ignored.
 
 ```python
 import hashlib
 import json
 
-def _audio_hash(text, voice, tts_model):
-    payload = json.dumps([text, voice, tts_model], ensure_ascii=False, separators=(",", ":"))
-    return hashlib.sha256(payload.encode()).hexdigest()
+def _audio_hash(text, voice, tts_model, tts_provider):
+    payload = json.dumps(
+        {"text": text, "voice": voice, "tts_model": tts_model, "tts_provider": tts_provider},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 ```
 
 The audio file is stored as `<audio_cache_dir>/<hash>.mp3`. The filename is the hash,
-so no separate index is needed to verify freshness — if the file exists at the expected
-path, it is valid by construction.
+so no separate index is needed to track freshness. Writers must generate the MP3 at a
+temporary path in the same directory and atomically rename it into place once complete.
+Readers should treat a cached file as a hit only if the expected file exists and passes
+a minimal validation check (non-zero size and/or a decodable MP3 header).
 
 ### VoiceCache changes (`common/cache.py`)
 Add an optional `audio_hash` column to the `voice_cache` SQLite table:
@@ -61,7 +69,7 @@ callers can verify the file.
 After a text cache hit:
 
 1. Retrieve `entry.audio_hash` from the cache.
-2. Compute expected hash: `_audio_hash(entry.value, config.bot_voice_model, config.text_to_speech_model)`.
+2. Compute expected hash: `_audio_hash(entry.value, config.bot_voice_model, config.text_to_speech_model, config.tts_provider)`.
 3. Build path: `os.path.join(config.audio_cache_dir, f"{expected_hash}.mp3")`.
 4. If the file exists and `entry.audio_hash == expected_hash`: play the file, skip TTS.
 5. Otherwise: call TTS normally, save the resulting MP3 to the path, call `cache.set()`
@@ -101,8 +109,8 @@ mechanism — no background thread, no per-file expiry.
 - [ ] All new code paths covered by unit tests (>80% coverage)
 
 ## Testing Strategy
-- Unit-test `_audio_hash()` for determinism and collision resistance (different text →
-  different hash; same text+voice+model → same hash).
+- Unit-test `_audio_hash()` for determinism, stability, and input separation (same
+  text+voice+model+provider → same hash; different text/voice/model/provider → different hash).
 - Unit-test cache hit with valid file: mock file existence, assert TTS not called.
 - Unit-test cache hit with missing file: assert TTS called, file written, hash stored.
 - Unit-test hash mismatch: assert TTS called even though a file exists at a different path.

--- a/plan/backlog/53-audio-response-cache.md
+++ b/plan/backlog/53-audio-response-cache.md
@@ -76,11 +76,12 @@ After a text cache hit, before any TTS call (streaming or non-streaming):
 3. Build path: `os.path.join(config.audio_cache_dir, f"{expected_hash}.mp3")`.
 4. If the file exists and `entry.audio_hash == expected_hash`: play the file directly,
    skip TTS entirely (works in all modes including wake-word).
-5. Otherwise — **non-streaming path**: call TTS, save MP3 to a temp path, atomically
-   rename into place, call `cache.set()` with the new `audio_hash`.
-6. Otherwise — **streaming path**: proceed with `stream_tts` as normal, simultaneously
-   writing audio chunks to a temp file; atomically rename into place after playback
-   completes, then call `cache.set()` with the new `audio_hash`.
+5. Otherwise — **non-streaming path**: call TTS, write MP3 bytes to a temp path,
+   atomically rename into place, call `cache.set()` with the new `audio_hash`.
+6. Otherwise — **streaming path**: open a temp file before the stream starts; for each
+   audio chunk, play it and append the bytes to the temp file; after the final chunk,
+   atomically rename into place, call `cache.set()` with the new `audio_hash`.
+   MP3 frames can be appended directly — the resulting file is a valid MP3.
 
 Hash mismatch means the cached text was refreshed with new content since the audio was
 generated. The old file is not deleted — it will be orphaned until a cleanup sweep


### PR DESCRIPTION
## Summary
- Documents Plan 53: cache TTS-generated MP3 files alongside text cache entries to eliminate redundant TTS API calls on cache hits
- Audio files keyed by SHA-256 hash of `(text, voice, tts_model, tts_provider)` — stale audio from refreshed text entries is automatically bypassed
- Streaming TTS path excluded from scope (deferred)

## Planning Documents
- `plan/backlog/53-audio-response-cache.md`
- `plan/INDEX.md`: adds Priority 53 entry
- `README.md`: documents missing `route_history_depth` config option (Plan 37, merged in #139)

## Testing
N/A — docs-only PR