### PR TITLE
Add Plan 54 and 55: conversation history SQLite + Telegram channel

### DIFF
--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -247,6 +247,14 @@ plan/
 **Document**: [backlog/55-vad-pre-speech-grace-period.md](./backlog/55-vad-pre-speech-grace-period.md)
 **Description**: Only start the VAD silence countdown after at least one speech frame has been detected. Prevents the 1.5 s silence window from cutting off the recording before the user has had time to start speaking after the wake word beep.
 
+### Priority 56: Conversation History Persistence (SQLite)
+**Document**: [backlog/54-conversation-history-sqlite.md](./backlog/54-conversation-history-sqlite.md)
+**Description**: Persist each conversation turn to a `conversation_history` SQLite table in the existing DB file. On startup, seed the in-memory list from the last `history_max_entries` rows so sessions resume naturally. Required foundation for multi-channel history sharing (Plan 57).
+
+### Priority 57: Telegram Channel
+**Document**: [backlog/55-telegram-channel.md](./backlog/55-telegram-channel.md)
+**Description**: Add an always-on Telegram channel as a background thread within the SandVoice process. Text messages from whitelisted user IDs are routed through the same AI, plugins, and conversation history as wake-word mode. Adds `telegram_enabled`, `telegram_bot_token`, and `telegram_allowed_user_ids` config keys. Phase 1 is text only; Phase 2 adds voice message support.
+
 ### Future Enhancements
 **Document**: [backlog/FUTURE.md](./backlog/FUTURE.md)
 **Description**: Long-term feature ideas: alternative providers (Anthropic, Ollama, Piper), local offline mode, conversation history truncation, user-triggered timers, conversation memory, export, plugin hot-reload, API cost tracking, music control, smart home, calendar, todo lists, multi-user support.

--- a/plan/backlog/54-conversation-history-sqlite.md
+++ b/plan/backlog/54-conversation-history-sqlite.md
@@ -27,8 +27,9 @@ table, giving them a shared, durable conversation history.
   channel runs as a background thread within the same process, not a separate process,
   so no multi-process SQLite guarantees are required.
 - History search, export, or summarisation — future work.
-- Pruning old entries beyond the startup load window — simple mtime/rowid pruning on
-  startup is sufficient.
+- Pruning old entries — rows accumulate indefinitely; a future plan can add a cleanup
+  job. The startup load window (`history_max_entries`) limits memory use without
+  touching the DB.
 
 ## Design
 
@@ -85,16 +86,18 @@ history = None
 if config.history_enabled:
     history = ConversationHistory(config.scheduler_db_path)
     atexit.register(history.close)
-# AI is constructed via its existing factory; history is seeded after construction:
-ai = AI.from_config(config)
-if history is not None:
-    ai.conversation_history = history.load_recent(config.history_max_entries)
+# Extend AI.from_config to accept optional history; it seeds conversation_history
+# and stores the reference so append_to_history() persists every future turn:
+ai = AI.from_config(config, history=history)
 ```
 
-Alternatively, `AI.from_config` can be extended to accept an optional `history`
-parameter so seeding is encapsulated inside the factory — either approach is valid.
-The key constraint is that `AI.__init__` takes provider objects (`llm`, `tts`, `stt`,
-`config`), not a raw config, so callers must go through `from_config`.
+`AI.from_config` passes `history` into `AI.__init__`, which:
+1. Seeds `self.conversation_history` from `history.load_recent(config.history_max_entries)`.
+2. Stores `self._history = history` so `append_to_history()` calls `history.append()`
+   on every subsequent turn.
+
+This keeps seeding **and** ongoing persistence inside `AI`, preventing double-writes
+from external callers.
 
 ## Acceptance Criteria
 - [ ] Each user/assistant turn is written to `conversation_history` table after it completes

--- a/plan/backlog/54-conversation-history-sqlite.md
+++ b/plan/backlog/54-conversation-history-sqlite.md
@@ -85,9 +85,16 @@ history = None
 if config.history_enabled:
     history = ConversationHistory(config.scheduler_db_path)
     atexit.register(history.close)
-# AI is constructed via its existing factory — history injected as optional param:
-ai = AI(config, history=history)   # internal OpenAI client created inside AI.__init__
+# AI is constructed via its existing factory; history is seeded after construction:
+ai = AI.from_config(config)
+if history is not None:
+    ai.conversation_history = history.load_recent(config.history_max_entries)
 ```
+
+Alternatively, `AI.from_config` can be extended to accept an optional `history`
+parameter so seeding is encapsulated inside the factory — either approach is valid.
+The key constraint is that `AI.__init__` takes provider objects (`llm`, `tts`, `stt`,
+`config`), not a raw config, so callers must go through `from_config`.
 
 ## Acceptance Criteria
 - [ ] Each user/assistant turn is written to `conversation_history` table after it completes

--- a/plan/backlog/54-conversation-history-sqlite.md
+++ b/plan/backlog/54-conversation-history-sqlite.md
@@ -1,0 +1,106 @@
+# Plan 54: Conversation History Persistence (SQLite)
+
+## Status
+📋 Backlog
+
+## Problem
+`AI.conversation_history` is an in-memory list that is lost on every restart. This
+means SandVoice has no memory of prior sessions. It also blocks multi-channel sharing:
+a Telegram channel running in the same process cannot safely read/write a list owned
+by the main thread, and there is no way to reconstruct context after a crash.
+
+## Goal
+Persist each conversation turn to SQLite. On startup, load the last N turns so the
+session resumes naturally. All channels (wake-word, Telegram) read and write the same
+table, giving them a shared, durable conversation history.
+
+## Scope
+
+**In scope:**
+- Persist every appended turn to a `conversation_history` SQLite table in the existing
+  DB file (shared with `VoiceCache` and `SchedulerDB`).
+- Load the last `history_max_entries` turns on startup to seed the in-memory list.
+- New config keys: `history_enabled`, `history_max_entries`.
+
+**Out of scope:**
+- Cross-process sharing — this plan targets in-process use only. Separate processes
+  reading the same SQLite file are covered by Plan 55's Telegram design.
+- History search, export, or summarisation — future work.
+- Pruning old entries beyond the startup load window — simple mtime/rowid pruning on
+  startup is sufficient.
+
+## Design
+
+### Schema
+New table in the existing DB file:
+
+```sql
+CREATE TABLE IF NOT EXISTS conversation_history (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    role      TEXT NOT NULL,   -- "user" or "assistant"
+    content   TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+```
+
+`role` mirrors the OpenAI message role so the table can be queried directly for
+context injection if needed in future.
+
+### VoiceCache / DB changes (`common/db.py` or `common/history.py`)
+A new `ConversationHistory` class (same pattern as `VoiceCache`):
+
+```python
+class ConversationHistory:
+    def append(self, role: str, content: str) -> None: ...
+    def load_recent(self, limit: int) -> list[str]: ...
+    def close(self) -> None: ...
+```
+
+`load_recent` returns the last `limit` entries as plain strings in the existing
+`"User: ..."` / `"Assistant: ..."` prefix format so `AI.conversation_history` stays
+unchanged.
+
+### AI changes (`common/ai.py`)
+`AI.__init__` accepts an optional `history: ConversationHistory | None` parameter.
+When present:
+- `conversation_history` is seeded from `history.load_recent(config.history_max_entries)`
+  on init.
+- Every call to `append_to_history(role, content)` also calls `history.append(role, content)`.
+
+`append_to_history` is extracted from the inline list appends scattered across `ai.py`
+into a single method, making the persistence hook a one-liner.
+
+### New config keys (`config.yaml` / `configuration.py`)
+| Key | Default | Description |
+|-----|---------|-------------|
+| `history_enabled` | `"disabled"` | Enable SQLite-backed history |
+| `history_max_entries` | `20` | Turns loaded on startup and kept in memory |
+
+All follow the 4-step config pattern.
+
+### Startup (`sandvoice.py`)
+```python
+history = None
+if config.history_enabled:
+    history = ConversationHistory(config.db_path)
+    atexit.register(history.close)
+ai = AI(config, openai_client, history=history)
+```
+
+## Acceptance Criteria
+- [ ] Each user/assistant turn is written to `conversation_history` table after it completes
+- [ ] On startup with `history_enabled: enabled`, last `history_max_entries` turns are loaded
+- [ ] On startup with `history_enabled: disabled`, behaviour is identical to today
+- [ ] DB file and table created automatically on first use
+- [ ] `history.close()` registered via `atexit`
+- [ ] All new code paths covered by unit tests (>80% coverage)
+
+## Testing Strategy
+- Unit-test `ConversationHistory.append` and `load_recent` with a temp DB.
+- Unit-test `AI` init with a mock history: assert `conversation_history` seeded correctly.
+- Unit-test turn append: assert `history.append` called after each response.
+- Unit-test `history_enabled: disabled`: assert no DB writes, no behaviour change.
+
+## Dependencies
+- `VoiceCache` / `SchedulerDB` pattern (`common/db.py`) — same WAL SQLite setup.
+- Required by Plan 55 (Telegram channel) for cross-channel history sharing.

--- a/plan/backlog/54-conversation-history-sqlite.md
+++ b/plan/backlog/54-conversation-history-sqlite.md
@@ -23,8 +23,9 @@ table, giving them a shared, durable conversation history.
 - New config keys: `history_enabled`, `history_max_entries`.
 
 **Out of scope:**
-- Cross-process sharing — this plan targets in-process use only. Separate processes
-  reading the same SQLite file are covered by Plan 55's Telegram design.
+- Cross-process sharing — this plan targets in-process use only. Plan 55's Telegram
+  channel runs as a background thread within the same process, not a separate process,
+  so no multi-process SQLite guarantees are required.
 - History search, export, or summarisation — future work.
 - Pruning old entries beyond the startup load window — simple mtime/rowid pruning on
   startup is sufficient.
@@ -57,8 +58,8 @@ class ConversationHistory:
 ```
 
 `load_recent` returns the last `limit` entries as plain strings in the existing
-`"User: ..."` / `"Assistant: ..."` prefix format so `AI.conversation_history` stays
-unchanged.
+`"User: ..."` / `"<botname>: ..."` prefix format (where botname comes from
+`config.botname`, e.g. `"Sandbot: ..."`) so `AI.conversation_history` stays unchanged.
 
 ### AI changes (`common/ai.py`)
 `AI.__init__` accepts an optional `history: ConversationHistory | None` parameter.
@@ -82,9 +83,10 @@ All follow the 4-step config pattern.
 ```python
 history = None
 if config.history_enabled:
-    history = ConversationHistory(config.db_path)
+    history = ConversationHistory(config.scheduler_db_path)
     atexit.register(history.close)
-ai = AI(config, openai_client, history=history)
+# AI is constructed via its existing factory — history injected as optional param:
+ai = AI(config, history=history)   # internal OpenAI client created inside AI.__init__
 ```
 
 ## Acceptance Criteria

--- a/plan/backlog/55-telegram-channel.md
+++ b/plan/backlog/55-telegram-channel.md
@@ -1,0 +1,116 @@
+# Plan 55: Telegram Channel
+
+## Status
+📋 Backlog
+
+## Problem
+SandVoice is only reachable at home, via microphone or terminal. There is no way to
+interact with it from a phone or while away. A Telegram channel would make the same
+brain — same plugins, same routing, same conversation history — reachable from anywhere
+via a messaging app most people already have.
+
+## Goal
+Add an always-on Telegram channel that runs as a background thread alongside wake-word
+mode. Text messages sent to a private bot are routed through SandVoice exactly like
+voice input, and the response is sent back as text. The channel shares conversation
+history with the wake-word session so context carries across channels seamlessly.
+
+## Scope
+
+**In scope:**
+- Text in / text out only (Phase 1). Voice messages deferred to Phase 2.
+- Single-user bot: `telegram_allowed_user_ids` whitelist; all other senders are silently
+  ignored.
+- Runs as a background thread within the existing `SandVoice` process — same instance,
+  same `AI`, same `VoiceCache`, same `ConversationHistory`.
+- Works alongside wake-word mode and CLI mode. Enabling Telegram does not affect either.
+
+**Out of scope:**
+- Voice message in / TTS audio out — deferred.
+- Multi-user support — out of scope.
+- Telegram groups or channels — private chat only.
+
+## Design
+
+### Architecture
+`TelegramChannel` is a class with a single background thread, matching the `TaskScheduler`
+pattern:
+
+```python
+class TelegramChannel:
+    def __init__(self, config, ai, plugins, cache): ...
+    def start(self) -> None: ...   # launches daemon thread
+    def close(self) -> None: ...   # signals thread to stop
+```
+
+The thread runs a `polling` loop using `python-telegram-bot` in its own asyncio event
+loop (`asyncio.new_event_loop()` + `loop.run_until_complete()`), isolating async code
+from the sync main thread.
+
+### Message flow
+```
+Telegram message arrives
+  → check sender user ID against whitelist → ignore if not allowed
+  → user_input = message.text
+  → route = ai.define_route(user_input, history=recent_history)
+  → if route in plugins: response = plugins[route].process(user_input, route, s)
+  → else: response = ai.generate_response(user_input, conversation_history)
+  → bot.send_message(chat_id, response)
+  → history.append("user", user_input)
+  → history.append("assistant", response)
+```
+
+History is written directly to `ConversationHistory` (Plan 54). No turn lock — per
+the design decision, occasional context interleave from parallel wake-word + Telegram
+turns is acceptable for a non-mission-critical assistant.
+
+### New config keys (`config.yaml` / `configuration.py`)
+| Key | Default | Description |
+|-----|---------|-------------|
+| `telegram_enabled` | `"disabled"` | Enable/disable the Telegram channel |
+| `telegram_bot_token` | `""` | Bot token from @BotFather |
+| `telegram_allowed_user_ids` | `[]` | List of Telegram user IDs allowed to interact |
+
+All follow the 4-step config pattern. Startup validation: if `telegram_enabled` is
+`"enabled"` and `telegram_bot_token` is empty, log a warning and disable the channel.
+
+### Startup (`sandvoice.py`)
+```python
+telegram = None
+if config.telegram_enabled:
+    telegram = TelegramChannel(config, s.ai, s.plugins, s.cache)
+    telegram.start()
+    atexit.register(telegram.close)
+```
+
+### New file: `common/telegram_channel.py`
+Contains `TelegramChannel` class only. No plugin logic — it delegates entirely to the
+existing `AI` and plugin system.
+
+### Dependency
+`python-telegram-bot>=20.0` added to `requirements.txt`.
+
+## Acceptance Criteria
+- [ ] Telegram messages from whitelisted users receive a text response
+- [ ] Messages from non-whitelisted users are silently ignored
+- [ ] Telegram channel shares `ConversationHistory` with the main session
+- [ ] wake-word mode and CLI mode are unaffected when `telegram_enabled: disabled`
+- [ ] `telegram_enabled: enabled` with empty token logs a warning and does not crash
+- [ ] `telegram.close()` registered via `atexit`; thread exits cleanly on shutdown
+- [ ] All new code paths covered by unit tests (>80% coverage)
+
+## Testing Strategy
+- Unit-test message dispatch: mock `AI.define_route` and plugin, assert response sent.
+- Unit-test whitelist: non-allowed user ID → assert no response, no history write.
+- Unit-test missing token: assert warning logged, channel disabled gracefully.
+- Unit-test history write: assert `ConversationHistory.append` called for user + assistant turns.
+- Integration smoke test: real bot token optional, skipped in CI via env var guard.
+
+## Dependencies
+- Plan 54 (Conversation History SQLite) — required for shared history.
+- `python-telegram-bot>=20.0` — new dependency.
+
+## Phase 2 (future)
+- Voice message in: download OGG, transcribe via Whisper, same routing flow.
+- TTS response: generate MP3, send as voice message via `bot.send_voice()`.
+- Audio cache (Plan 53) applies naturally to the TTS step.

--- a/plan/backlog/55-telegram-channel.md
+++ b/plan/backlog/55-telegram-channel.md
@@ -38,7 +38,7 @@ pattern:
 
 ```python
 class TelegramChannel:
-    def __init__(self, config, ai, plugins, cache): ...
+    def __init__(self, config, ai, plugins, cache, history): ...
     def start(self) -> None: ...   # launches daemon thread
     def close(self) -> None: ...   # signals thread to stop
 ```
@@ -58,10 +58,11 @@ async lifecycle methods directly) to avoid this.
 Telegram message arrives
   → check sender user ID against whitelist → ignore if not allowed
   → user_input = message.text
-  → route = ai.define_route(user_input)
+  → recent_history = history.load_recent(config.route_history_depth)
+  → route = ai.define_route(user_input, history=recent_history)
   → route_name = route["route"]
   → if route_name in plugins: response = plugins[route_name](user_input, route, ctx)
-  → else: response = ai.generate_response(user_input)
+  → else: response = ai.generate_response(user_input).content
   → bot.send_message(chat_id, response)
   → history.append("user", user_input)
   → history.append("assistant", response)
@@ -88,7 +89,7 @@ All follow the 4-step config pattern. Startup validation: if `telegram_enabled` 
 ```python
 telegram = None
 if config.telegram_enabled:
-    telegram = TelegramChannel(config, s.ai, s.plugins, s.cache)
+    telegram = TelegramChannel(config, s.ai, s.plugins, s.cache, history)
     telegram.start()
     atexit.register(telegram.close)
 ```

--- a/plan/backlog/55-telegram-channel.md
+++ b/plan/backlog/55-telegram-channel.md
@@ -47,22 +47,32 @@ The thread runs a `polling` loop using `python-telegram-bot` in its own asyncio 
 loop (`asyncio.new_event_loop()` + `loop.run_until_complete()`), isolating async code
 from the sync main thread.
 
+**Important**: `Application.run_polling()` installs signal handlers by default, which
+raises `ValueError: signal only works in main thread` when called from a non-main thread.
+The implementation must pass `stop_signals=()` (or `stop_signals=None`) to
+`run_polling()` (or use the lower-level `initialize()`/`start()`/`updater.start_polling()`
+async lifecycle methods directly) to avoid this.
+
 ### Message flow
 ```
 Telegram message arrives
   → check sender user ID against whitelist → ignore if not allowed
   → user_input = message.text
-  → route = ai.define_route(user_input, history=recent_history)
-  → if route in plugins: response = plugins[route].process(user_input, route, s)
-  → else: response = ai.generate_response(user_input, conversation_history)
+  → route = ai.define_route(user_input)
+  → route_name = route["route"]
+  → if route_name in plugins: response = plugins[route_name](user_input, route, ctx)
+  → else: response = ai.generate_response(user_input)
   → bot.send_message(chat_id, response)
   → history.append("user", user_input)
   → history.append("assistant", response)
 ```
 
-History is written directly to `ConversationHistory` (Plan 54). No turn lock — per
-the design decision, occasional context interleave from parallel wake-word + Telegram
-turns is acceptable for a non-mission-critical assistant.
+History is written directly to `ConversationHistory` (Plan 54). The in-memory
+`AI.conversation_history` list is not shared with the Telegram thread — each turn
+appends to the SQLite DB via `ConversationHistory`, and context is loaded fresh from DB
+per turn if needed. No turn lock — per the design decision, occasional context interleave
+from parallel wake-word + Telegram turns is acceptable for a non-mission-critical
+assistant. SQLite WAL mode handles concurrent writes safely.
 
 ### New config keys (`config.yaml` / `configuration.py`)
 | Key | Default | Description |

--- a/plan/backlog/55-telegram-channel.md
+++ b/plan/backlog/55-telegram-channel.md
@@ -22,7 +22,9 @@ history with the wake-word session so context carries across channels seamlessly
 - Single-user bot: `telegram_allowed_user_ids` whitelist; all other senders are silently
   ignored.
 - Runs as a background thread within the existing `SandVoice` process — same instance,
-  same `AI`, same `VoiceCache`, same `ConversationHistory`.
+  same `VoiceCache`, shared `ConversationHistory` (SQLite). `AI` is **not** shared
+  directly; the Telegram thread uses a separate `AI` instance seeded from the same DB
+  to avoid concurrent mutation of `AI.conversation_history`.
 - Works alongside wake-word mode and CLI mode. Enabling Telegram does not affect either.
 
 **Out of scope:**
@@ -38,10 +40,15 @@ pattern:
 
 ```python
 class TelegramChannel:
-    def __init__(self, config, ai, plugins, cache, history): ...
-    def start(self) -> None: ...   # launches daemon thread
+    def __init__(self, config, plugins, cache, history): ...
+    def start(self) -> None: ...   # launches daemon thread; creates own AI instance
     def close(self) -> None: ...   # signals thread to stop
 ```
+
+`TelegramChannel` creates its own `AI` instance (via `AI.from_config(config, history=history)`)
+inside the background thread, avoiding shared mutable state with the main thread's `AI`.
+Both AI instances persist turns through the same `ConversationHistory` (SQLite with
+`threading.Lock`, same as `VoiceCache`).
 
 The thread runs a `polling` loop using `python-telegram-bot` in its own asyncio event
 loop (`asyncio.new_event_loop()` + `loop.run_until_complete()`), isolating async code
@@ -58,22 +65,19 @@ async lifecycle methods directly) to avoid this.
 Telegram message arrives
   → check sender user ID against whitelist → ignore if not allowed
   → user_input = message.text
-  → recent_history = history.load_recent(config.route_history_depth)
-  → route = ai.define_route(user_input, history=recent_history)
+  → route = telegram_ai.define_route(user_input)
   → route_name = route["route"]
   → if route_name in plugins: response = plugins[route_name](user_input, route, ctx)
-  → else: response = ai.generate_response(user_input).content
+  → else: response = telegram_ai.generate_response(user_input).content
   → bot.send_message(chat_id, response)
-  → history.append("user", user_input)
-  → history.append("assistant", response)
 ```
 
-History is written directly to `ConversationHistory` (Plan 54). The in-memory
-`AI.conversation_history` list is not shared with the Telegram thread — each turn
-appends to the SQLite DB via `ConversationHistory`, and context is loaded fresh from DB
-per turn if needed. No turn lock — per the design decision, occasional context interleave
-from parallel wake-word + Telegram turns is acceptable for a non-mission-critical
-assistant. SQLite WAL mode handles concurrent writes safely.
+`telegram_ai` is the thread's own `AI` instance (created via `AI.from_config(config,
+history=history)`). History writes happen inside `AI.append_to_history()` — the same
+path as the main thread — so there is a single source of truth and no double-writes.
+`ConversationHistory` uses a `threading.Lock` (same pattern as `VoiceCache`) to make
+concurrent SQLite writes from both threads safe. No additional turn lock needed at the
+`TelegramChannel` level.
 
 ### New config keys (`config.yaml` / `configuration.py`)
 | Key | Default | Description |
@@ -89,9 +93,14 @@ All follow the 4-step config pattern. Startup validation: if `telegram_enabled` 
 ```python
 telegram = None
 if config.telegram_enabled:
-    telegram = TelegramChannel(config, s.ai, s.plugins, s.cache, history)
-    telegram.start()
-    atexit.register(telegram.close)
+    if not config.history_enabled:
+        logger.warning(
+            "telegram_enabled requires history_enabled; disabling Telegram channel"
+        )
+    else:
+        telegram = TelegramChannel(config, s.plugins, s.cache, history)
+        telegram.start()
+        atexit.register(telegram.close)
 ```
 
 ### New file: `common/telegram_channel.py`


### PR DESCRIPTION
## Summary
- **Plan 54**: Persist conversation turns to SQLite so history survives restarts and can be shared across channels. New `ConversationHistory` class, `history_enabled` / `history_max_entries` config keys.
- **Plan 55**: Telegram channel as a background thread — text in/out, user ID whitelist, shared `ConversationHistory` with wake-word session. Phase 1 text-only; Phase 2 adds voice. New `telegram_enabled`, `telegram_bot_token`, `telegram_allowed_user_ids` config keys.

## Planning Documents
- `plan/backlog/54-conversation-history-sqlite.md`
- `plan/backlog/55-telegram-channel.md`
- `plan/INDEX.md`: adds Priority 54 and 55 entries

## Design decisions
- Plan 54 is a hard dependency for Plan 55 — shared history requires SQLite persistence
- No turn lock: occasional context interleave from parallel channels is acceptable
- Telegram runs as a daemon thread (same `TaskScheduler` pattern), not a separate process
- Phase 1 is text-only to keep scope small and validate the architecture

## Testing
N/A — docs-only PR