### PR TITLE
Add plans 52-55: openWakeWord, Pi audio fixes, VAD grace period

### DIFF
--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -204,7 +204,7 @@ plan/
 
 ### Priority 5: Raspberry Pi Compatibility
 **Document**: [backlog/05-raspberry-pi-compatibility.md](./backlog/05-raspberry-pi-compatibility.md)
-**Description**: Full compatibility testing and documentation for Raspberry Pi 3B deployment. Setup process, dependencies, and performance validation.
+**Description**: Documentation and setup guide for Raspberry Pi 3B deployment (headless, USB audio). Depends on Plans 52–55 for all code changes; this plan covers only `docs/raspberry-pi-setup.md`.
 
 ### Priority 14: Energy-Based Speech Detection
 **Document**: [backlog/14-energy-based-speech-detection.md](./backlog/14-energy-based-speech-detection.md)
@@ -230,6 +230,22 @@ plan/
 ### Priority 51: Greeting Plugin — Extra Instructions
 **Document**: [backlog/51-greeting-extra-instructions.md](./backlog/51-greeting-extra-instructions.md)
 **Description**: Add optional `greeting_extra` config key that appends user-defined instructions to the greeting plugin's generation prompt (e.g. "end the greeting with a short proverb"). Separate from `system_prompt_extra` — affects only the greeting plugin's live generation.
+
+### Priority 52: Replace Porcupine with openWakeWord
+**Document**: [backlog/52-replace-porcupine-with-openwakeword.md](./backlog/52-replace-porcupine-with-openwakeword.md)
+**Description**: Swap the Picovoice Porcupine engine for openWakeWord (MIT, no account required). New `common/openwakeword_detector.py` wraps openWakeWord behind Porcupine's interface. Pins `onnxruntime==1.20.0` for Pi 3B stability. Adds `openwakeword_model` config key.
+
+### Priority 53: Linux ALSA Input Device Auto-Selection
+**Document**: [backlog/53-linux-alsa-input-device-auto-selection.md](./backlog/53-linux-alsa-input-device-auto-selection.md)
+**Description**: On Linux, explicitly select the first `hw:N,M` PyAudio input device instead of the virtual ALSA `default` (which delivers silence on Pi). Affects wake word detection and barge-in detection. No change on macOS.
+
+### Priority 54: Linux Audio Output Device Auto-Detection
+**Document**: [backlog/54-linux-audio-output-device-auto-detection.md](./backlog/54-linux-audio-output-device-auto-detection.md)
+**Description**: On Linux, set `SDL_AUDIODRIVER=alsa` and auto-detect `AUDIODEV=plughw:N,M` before importing pygame, so TTS plays through the USB headset instead of the onboard bcm2835 device. Also moves `pynput` import inside `init_recording()` to prevent headless Linux crash.
+
+### Priority 55: VAD Pre-Speech Grace Period
+**Document**: [backlog/55-vad-pre-speech-grace-period.md](./backlog/55-vad-pre-speech-grace-period.md)
+**Description**: Only start the VAD silence countdown after at least one speech frame has been detected. Prevents the 1.5 s silence window from cutting off the recording before the user has had time to start speaking after the wake word beep.
 
 ### Future Enhancements
 **Document**: [backlog/FUTURE.md](./backlog/FUTURE.md)

--- a/plan/backlog/05-raspberry-pi-compatibility.md
+++ b/plan/backlog/05-raspberry-pi-compatibility.md
@@ -1,6 +1,6 @@
 # Raspberry Pi Compatibility
 
-**Status**: 📋 Planned
+**Status**: 📋 Backlog
 **Priority**: 5
 **Platforms**: Raspberry Pi 3B (primary target)
 

--- a/plan/backlog/05-raspberry-pi-compatibility.md
+++ b/plan/backlog/05-raspberry-pi-compatibility.md
@@ -34,7 +34,7 @@ Tested and working:
 | Component | Model |
 |-----------|-------|
 | Board | Raspberry Pi 3 Model B (1 GB RAM) |
-| OS | Raspberry Pi OS Lite 64-bit (Bookworm / Debian 12) |
+| OS | Raspberry Pi OS Lite 64-bit (Trixie / Debian 13) |
 | Audio | Razer Barracuda X 2.4 USB wireless headset |
 | Storage | 32 GB microSD (Class 10) |
 

--- a/plan/backlog/05-raspberry-pi-compatibility.md
+++ b/plan/backlog/05-raspberry-pi-compatibility.md
@@ -108,7 +108,7 @@ Tested and working:
 - [ ] Verifying audio device detection (ALSA device listing)
 - [ ] Running SandVoice in wake word mode:
   ```bash
-  OPENAI_API_KEY=sk-... python3 sandvoice.py --wake-word
+  OPENAI_API_KEY=YOUR_OPENAI_API_KEY python3 sandvoice.py --wake-word
   ```
 - [ ] Troubleshooting:
   - No audio output → check `AUDIODEV` env var; try `aplay -l`

--- a/plan/backlog/05-raspberry-pi-compatibility.md
+++ b/plan/backlog/05-raspberry-pi-compatibility.md
@@ -22,8 +22,8 @@ Implement those first, then write the setup guide.
 
 Document and validate the complete process for deploying SandVoice on a
 Raspberry Pi 3B from scratch. The target is a headless Pi running
-Raspberry Pi OS Lite 64-bit (Bookworm) with a USB audio device (headset or
-separate mic + speaker).
+Raspberry Pi OS Lite 64-bit (Trixie / Debian 13) with a USB audio device
+(headset or separate mic + speaker).
 
 ---
 
@@ -90,10 +90,12 @@ Tested and working:
 - [ ] Python virtual environment setup
 - [ ] Repository clone and dependency installation:
   ```bash
-  pip install -r requirements.txt
-  # openWakeWord: install without tflite-runtime (not available on Python 3.13)
+  # Install openWakeWord first with --no-deps to skip tflite-runtime
+  # (no wheel for Python 3.13 on aarch64); must come before requirements.txt
+  # because requirements.txt does not list openwakeword (see Plan 52).
   pip install openwakeword>=0.6.0 --no-deps
   pip install scipy
+  pip install -r requirements.txt
   ```
 - [ ] First-run model download (`openwakeword.utils.download_models()`)
 - [ ] `~/.sandvoice/config.yaml` minimum configuration:

--- a/plan/backlog/05-raspberry-pi-compatibility.md
+++ b/plan/backlog/05-raspberry-pi-compatibility.md
@@ -2,243 +2,128 @@
 
 **Status**: 📋 Planned
 **Priority**: 5
-**Platforms**: Raspberry Pi 3B (primary target), also Pi 4/5
-
----
-
-## Overview
-
-Ensure SandVoice works seamlessly on Raspberry Pi 3B with USB audio devices. Document setup process, dependencies, and testing procedures. The goal is to make Raspberry Pi a viable platform for deploying SandVoice as a personal voice assistant.
-
----
-
-## Problem Statement
-
-Current development is Mac-focused with no Pi testing:
-- Unknown if dependencies install correctly on Pi
-- No documentation for Pi setup
-- No testing on ARM architecture
-- No performance benchmarks for Pi 3B
-- USB audio device setup not documented
-
-This prevents users from deploying on affordable, dedicated hardware like Raspberry Pi.
-
----
-
-## User Stories
-
-**As a user**, I want to run SandVoice on a Raspberry Pi, so I can have a dedicated, always-available voice assistant.
-
-**As a new Pi user**, I want clear setup instructions, so I can get SandVoice running without troubleshooting.
-
-**As a developer**, I want to know SandVoice works on Pi, so I can confidently develop features for both platforms.
-
----
-
-## Acceptance Criteria
-
-### Raspberry Pi OS Compatibility
-- [ ] Identify Python version shipped with latest Raspberry Pi OS
-- [ ] Verify all dependencies install on Pi 3B
-- [ ] Document any Pi-specific package requirements
-- [ ] Test on Raspberry Pi OS (64-bit preferred)
-
-### USB Audio Device Support
-- [ ] Document recommended USB audio devices
-- [ ] Document setup for USB headsets
-- [ ] Document setup for USB microphones + speakers
-- [ ] Provide audio device troubleshooting guide
-
-### Performance
-- [ ] Verify acceptable performance on Pi 3B
-- [ ] Measure latency for full interaction cycle
-- [ ] Verify wake word detection works on Pi
-- [ ] Document any performance limitations
-
-### Documentation
-- [ ] Complete setup guide for Pi installation
-- [ ] List of required apt packages
-- [ ] Python package installation instructions
-- [ ] Audio device configuration steps
-- [ ] Common troubleshooting issues
-- [ ] Performance optimization tips
-
----
-
-## Technical Requirements
-
-### Research Tasks
-
-**Raspberry Pi OS Python Version:**
-- Identify Python version in latest Raspberry Pi OS Lite and Desktop
-- Verify compatibility with SandVoice requirements
-- Document any version-specific issues
-
-**USB Audio Devices:**
-- Test with common USB headsets
-- Test with USB microphone + 3.5mm speakers
-- Test with USB audio adapters
-- Document device selection in PyAudio
-
-### System Requirements
-
-**Minimum Hardware:**
-- Raspberry Pi 3B (1GB RAM)
-- 8GB+ microSD card
-- USB audio device (microphone + speakers or headset)
-- Internet connection
-
-**Recommended Hardware:**
-- Raspberry Pi 4 (2GB+ RAM) or Pi 5 for better performance
-- 16GB+ microSD card (Class 10)
-- Quality USB headset with noise cancellation
-- Ethernet connection (more stable than WiFi)
-
-### Installation Steps (To Be Documented)
-
-**System Setup:**
-1. Flash Raspberry Pi OS (64-bit recommended)
-2. Configure WiFi/Ethernet
-3. Update system packages
-4. Install required apt packages
-
-**Audio Setup:**
-1. Connect USB audio device
-2. Verify device detected
-3. Test recording
-4. Test playback
-5. Configure ALSA settings if needed
-
-**SandVoice Installation:**
-1. Install Python dependencies
-2. Clone repository
-3. Create virtual environment
-4. Install requirements
-5. Configure settings
-6. Test basic functionality
-
-**Wake Word Setup (if enabled):**
-1. Install Porcupine
-2. Configure wake word model
-3. Test detection
-4. Optimize sensitivity
-
-### Performance Expectations
-
-**Pi 3B (realistic expectations):**
-- Wake word detection: Should work well (lightweight)
-- Audio recording: No issues
-- OpenAI API calls: Network bound (same as Mac)
-- Audio playback: No issues
-- MP3 encoding: May be slower than Mac (acceptable delay)
-
-**Bottlenecks:**
-- lameenc MP3 encoding on Pi 3B may add 1-2 seconds
-- Network latency to OpenAI (not hardware specific)
-- SD card I/O (use quality card)
-
-### Platform-Specific Code
-
-Ensure platform detection correctly identifies Pi:
-- Detect ARM architecture
-- Detect Linux OS
-- Configure audio appropriately
-- Use ALSA library correctly
-
----
-
-## Configuration Changes
-
-No config changes needed - platform auto-detection should handle Pi setup.
-
-Document recommended config.yaml settings for Pi in setup guide.
-
----
-
-## Documentation Structure
-
-Create `docs/raspberry-pi-setup.md`:
-
-```markdown
-# Raspberry Pi Setup Guide
-
-## Hardware Requirements
-## Raspberry Pi OS Installation
-## Audio Device Setup
-## SandVoice Installation
-## Testing
-## Troubleshooting
-## Performance Tips
-```
-
----
-
-## Testing Requirements
-
-### Initial Testing
-- [ ] Test on Raspberry Pi 3B with Raspberry Pi OS
-- [ ] Test with USB headset
-- [ ] Test all three interaction modes (voice, CLI, wake word)
-- [ ] Test all plugins
-- [ ] Measure performance metrics
-
-### Performance Metrics to Collect
-- Time from wake word to start recording
-- Audio encoding time (WAV to MP3)
-- Round-trip time for full interaction
-- CPU usage idle vs active
-- Memory usage
-
-### Compatibility Testing
-- [ ] Test with different USB audio devices
-- [ ] Test with Raspberry Pi 4 (if available)
-- [ ] Test on 32-bit vs 64-bit Pi OS
-
-### Regression Testing
-- Ensure changes for Pi don't break Mac functionality
-- Test on Mac M1 after Pi compatibility changes
+**Platforms**: Raspberry Pi 3B (primary target)
 
 ---
 
 ## Dependencies
 
-- **Depends on**: Error Handling (Priority 1) - need robust error handling for Pi
-- **Depends on**: Platform Auto-Detection (Priority 2) - critical for Pi setup
-- **Depends on**: Unit Tests (Priority 3) - verify Pi compatibility
-- **Depends on**: Wake Word Mode (Priority 4) - main use case for Pi
+- **Plan 52** — openWakeWord engine (replaces Porcupine)
+- **Plan 53** — Linux ALSA input device auto-selection
+- **Plan 54** — Linux audio output device auto-detection
+- **Plan 55** — VAD pre-speech grace period
 
-**Pi-Specific System Packages (to be documented):**
-```bash
-# Expected packages (TBD during implementation)
-sudo apt-get update
-sudo apt-get install -y \
-    python3-dev \
-    portaudio19-dev \
-    python3-pyaudio \
-    libasound2-dev \
-    # ... others as discovered
-```
+This plan is documentation-only. All code changes are covered by plans 52–55.
+Implement those first, then write the setup guide.
+
+---
+
+## Overview
+
+Document and validate the complete process for deploying SandVoice on a
+Raspberry Pi 3B from scratch. The target is a headless Pi running
+Raspberry Pi OS Lite 64-bit (Bookworm) with a USB audio device (headset or
+separate mic + speaker).
+
+---
+
+## Validated Hardware
+
+Tested and working:
+
+| Component | Model |
+|-----------|-------|
+| Board | Raspberry Pi 3 Model B (1 GB RAM) |
+| OS | Raspberry Pi OS Lite 64-bit (Bookworm / Debian 12) |
+| Audio | Razer Barracuda X 2.4 USB wireless headset |
+| Storage | 32 GB microSD (Class 10) |
+
+---
+
+## Known Pi-Specific Issues (Resolved by code plans)
+
+| Issue | Resolution |
+|-------|-----------|
+| Porcupine requires company email + per-device activation | Plan 52: replace with openWakeWord |
+| `onnxruntime>=1.21` crashes on Pi 3B (C++ STL assertion) | Plan 52: pin `onnxruntime==1.20.0` |
+| `tflite-runtime` fails on Python 3.13 | Plan 52: install openWakeWord with `--no-deps` |
+| PyAudio opens virtual ALSA `default` device (amplitude=0) | Plan 53: auto-select `hw:N,M` input |
+| `pygame` binds to `bcm2835` onboard device instead of USB headset | Plan 54: auto-detect SDL `AUDIODEV` |
+| `pynput` import crashes on headless Linux | Plan 54: lazy import inside `init_recording()` |
+| VAD cuts off before user has time to speak | Plan 55: pre-speech grace period |
+| Confirmation beep blocks when PyAudio input stream holds hw: device | Plan 52/53: beep played after `_cleanup_pyaudio()` |
+
+---
+
+## System Requirements
+
+**Minimum hardware:**
+- Raspberry Pi 3B (1 GB RAM)
+- 8 GB+ microSD card
+- USB audio device (headset, or mic + speaker)
+- Internet connection (OpenAI API calls)
+
+**Recommended:**
+- 16 GB+ microSD card (Class 10 or better)
+- USB headset with mic (single device, simpler ALSA config)
+- Ethernet (more stable than WiFi for API latency)
+
+---
+
+## Acceptance Criteria (Documentation)
+
+### `docs/raspberry-pi-setup.md` must cover:
+
+- [ ] Hardware requirements
+- [ ] Flashing Raspberry Pi OS Lite 64-bit with Raspberry Pi Imager
+  - Enable SSH, set hostname (`sandvoice.local`), configure WiFi during flash
+- [ ] First boot and SSH access
+- [ ] System package installation:
+  ```bash
+  sudo apt-get update && sudo apt-get upgrade -y
+  sudo apt-get install -y \
+      python3-dev python3-venv python3-pip \
+      portaudio19-dev libasound2-dev \
+      libopenblas-dev libatlas-base-dev \
+      git
+  ```
+- [ ] Python virtual environment setup
+- [ ] Repository clone and dependency installation:
+  ```bash
+  pip install -r requirements.txt
+  # openWakeWord: install without tflite-runtime (not available on Python 3.13)
+  pip install openwakeword>=0.6.0 --no-deps
+  pip install scipy
+  ```
+- [ ] First-run model download (`openwakeword.utils.download_models()`)
+- [ ] `~/.sandvoice/config.yaml` minimum configuration:
+  ```yaml
+  openwakeword_model: hey_jarvis
+  wake_word_sensitivity: 0.35
+  wake_phrase: "hey sandvoice"
+  log_level: info
+  ```
+- [ ] Verifying audio device detection (ALSA device listing)
+- [ ] Running SandVoice in wake word mode:
+  ```bash
+  OPENAI_API_KEY=sk-... python3 sandvoice.py --wake-word
+  ```
+- [ ] Troubleshooting:
+  - No audio output → check `AUDIODEV` env var; try `aplay -l`
+  - Wake word not triggering → lower `wake_word_sensitivity` (try `0.25`)
+  - VAD cuts off early → `vad_silence_duration: 2.0` in config
+  - High CPU → verify `onnxruntime==1.20.0` is installed
+  - `tflite-runtime` install error → use `--no-deps` (documented above)
+- [ ] Recommended `~/.sandvoice/config.yaml` for Pi (with timezone, TTS voice, etc.)
+- [ ] Running as a systemd service (optional section)
 
 ---
 
 ## Out of Scope
 
-- Raspberry Pi Zero support (too slow)
-- Raspberry Pi 1/2 support (outdated)
-- GUI/touch screen interface
-- Custom Pi OS images
-- Automated Pi provisioning
-- Hardware HATs (stick with USB audio)
-- Power management/optimization
-
----
-
-## Success Metrics
-
-- Complete setup guide written and tested
-- Successfully runs on Pi 3B from fresh install
-- All features work on Pi (voice, CLI, wake word, all plugins)
-- Performance acceptable (<5 second total latency)
-- Wake word detection >90% accuracy on Pi
-- No platform-specific crashes
-- Setup takes <30 minutes for new user
+- Raspberry Pi Zero (too slow for real-time inference)
+- Raspberry Pi 1/2 (outdated)
+- GUI or touch screen
+- Custom OS images or automated provisioning
+- Hardware HATs (USB audio only)
+- Bluetooth audio devices

--- a/plan/backlog/05-raspberry-pi-compatibility.md
+++ b/plan/backlog/05-raspberry-pi-compatibility.md
@@ -46,7 +46,7 @@ Tested and working:
 |-------|-----------|
 | Porcupine requires company email + per-device activation | Plan 52: replace with openWakeWord |
 | `onnxruntime>=1.21` crashes on Pi 3B (C++ STL assertion) | Plan 52: pin `onnxruntime==1.20.0` |
-| `tflite-runtime` fails on Python 3.13 | Plan 52: install openWakeWord with `--no-deps` |
+| `tflite-runtime` unavailable on Pi/aarch64 (confirmed Python 3.13 / Trixie; outside CI coverage) | Plan 52: install openWakeWord with `--no-deps` |
 | PyAudio opens virtual ALSA `default` device (amplitude=0) | Plan 53: auto-select `hw:N,M` input |
 | `pygame` binds to `bcm2835` onboard device instead of USB headset | Plan 54: auto-detect SDL `AUDIODEV` |
 | `pynput` import crashes on headless Linux | Plan 54: lazy import inside `init_recording()` |

--- a/plan/backlog/05-raspberry-pi-compatibility.md
+++ b/plan/backlog/05-raspberry-pi-compatibility.md
@@ -51,7 +51,7 @@ Tested and working:
 | `pygame` binds to `bcm2835` onboard device instead of USB headset | Plan 54: auto-detect SDL `AUDIODEV` |
 | `pynput` import crashes on headless Linux | Plan 54: lazy import inside `init_recording()` |
 | VAD cuts off before user has time to speak | Plan 55: pre-speech grace period |
-| Confirmation beep blocks when PyAudio input stream holds hw: device | Plan 52/53: beep played after `_cleanup_pyaudio()` |
+| Confirmation beep blocks when PyAudio input stream holds hw: device | Plan 52: move beep after `_cleanup_pyaudio()` in `_state_idle()` |
 
 ---
 
@@ -101,8 +101,8 @@ Tested and working:
 - [ ] `~/.sandvoice/config.yaml` minimum configuration:
   ```yaml
   openwakeword_model: hey_jarvis
+  wake_phrase: "hey jarvis"
   wake_word_sensitivity: 0.35
-  wake_phrase: "hey sandvoice"
   log_level: info
   ```
 - [ ] Verifying audio device detection (ALSA device listing)

--- a/plan/backlog/52-replace-porcupine-with-openwakeword.md
+++ b/plan/backlog/52-replace-porcupine-with-openwakeword.md
@@ -82,6 +82,10 @@ Handles both short built-in model names (`hey_jarvis`, `alexa`, …) and absolut
   `OpenWakeWordDetector(model_name=..., threshold=..., device_sample_rate=config.rate)`.
 - Call `self.porcupine.reset()` at the top of `_state_idle()` before opening the
   PyAudio stream (clears buffer state left over from the previous TTS cycle).
+- Move `_play_confirmation_beep()` to after `_cleanup_pyaudio()` in
+  `_state_idle()`. On Linux, PyAudio holds exclusive `hw:` device access while
+  the input stream is open; playing the beep through pygame while the stream is
+  still open blocks indefinitely. Closing the stream first avoids the contention.
 
 ### Changes to `common/barge_in.py`
 
@@ -92,11 +96,34 @@ Handles both short built-in model names (`hey_jarvis`, `alexa`, …) and absolut
 
 | Key | Default | Notes |
 |-----|---------|-------|
-| `openwakeword_model` | `"hey_jarvis"` | Short built-in name or absolute `.onnx` path |
+| `openwakeword_model` | `"hey_jarvis"` | Short built-in name or absolute `.onnx` path; authoritative for detection |
+| `wake_phrase` | *(derived)* | User-facing label; see interaction rules below |
 | `wake_word_sensitivity` | `0.35` | Lowered from `0.5`; openWakeWord scores differ from Porcupine |
 
+**`wake_phrase` / `openwakeword_model` interaction:**
+
+With Porcupine, `wake_phrase` drove keyword selection. With openWakeWord the
+detectable phrase is fixed by the model, so `openwakeword_model` is
+authoritative. The two keys interact as follows:
+
+- **Built-in model** (e.g. `hey_jarvis`, `alexa`): the phrase is fixed by the
+  model. `wake_phrase` must match the model's phrase (e.g. `"hey jarvis"` for
+  `hey_jarvis`) so UI labels, logs, and the terminal prompt are consistent with
+  what the detector actually listens for. Validation at startup should warn (or
+  error) if they are mismatched.
+- **Custom `.onnx` path**: the phrase cannot be reliably inferred from the
+  filename. `wake_phrase` is user-provided and informational only; no mismatch
+  validation is possible.
+
+For the default config, set both keys consistently:
+```yaml
+openwakeword_model: hey_jarvis
+wake_phrase: "hey jarvis"
+```
+
 Remove `porcupine_access_key` and `porcupine_keyword_paths` from defaults
-(no longer needed). Keep validation only for the new keys.
+(no longer needed). Keep validation for the new keys and the
+`wake_phrase`/`openwakeword_model` consistency rule.
 
 ### `requirements.txt`
 

--- a/plan/backlog/52-replace-porcupine-with-openwakeword.md
+++ b/plan/backlog/52-replace-porcupine-with-openwakeword.md
@@ -100,14 +100,39 @@ Remove `porcupine_access_key` and `porcupine_keyword_paths` from defaults
 
 ### `requirements.txt`
 
-- Add `openwakeword>=0.6.0`
 - Add `onnxruntime==1.20.0` (**hard pin — do not bump without Pi 3B testing**)
 - Remove `pvporcupine`
+- **Do NOT add `openwakeword` to `requirements.txt`** — see platform-specific
+  install section below.
+
+### Platform-specific install handling
+
+`openwakeword` cannot be installed via `pip install -r requirements.txt` on
+Raspberry Pi because `tflite-runtime` (a transitive dependency) has no wheel
+for Python 3.13 on aarch64. To support both platforms without a broken
+`requirements.txt`, `openwakeword` is kept out of the shared requirements file
+and documented as a separate install step per platform.
+
+**macOS (development):**
+```bash
+pip install openwakeword>=0.6.0
+```
+
+**Raspberry Pi 3B:**
+```bash
+# Install before requirements.txt; --no-deps skips tflite-runtime
+pip install openwakeword>=0.6.0 --no-deps
+pip install scipy   # required transitive dep not pulled in by --no-deps
+pip install -r requirements.txt
+```
+
+Document this in `docs/raspberry-pi-setup.md` (Plan 05) and in a comment in
+`requirements.txt` near the `onnxruntime` pin.
 
 ### Critical Pi 3B version constraints
 
-> These were discovered through direct testing on Pi 3B (Bookworm, Python 3.13,
-> aarch64). Both constraints must be preserved exactly.
+> These were discovered through direct testing on Pi 3B (Trixie / Debian 13,
+> Python 3.13, aarch64). Both constraints must be preserved exactly.
 
 **`onnxruntime==1.20.0`**
 Versions 1.21+ crash at model load time on Pi 3B with a C++ STL vector
@@ -118,18 +143,10 @@ Assertion failed: (index < size_), function operator[], ...
 1.20.0 is the last version confirmed stable on armv8/aarch64 Pi 3B.
 Pin it exactly; do not use `>=` or `~=`.
 
-**`openwakeword>=0.6.0 --no-deps` (Pi only)**
-`tflite-runtime` (an optional openWakeWord dependency) has no wheel for
-Python 3.13 on aarch64. Installing with `--no-deps` skips it; openWakeWord
-works fine without it when using the ONNX inference backend (which is the
-default and the one we use). `scipy` must be installed separately:
-
-```bash
-pip install openwakeword>=0.6.0 --no-deps
-pip install scipy
-```
-
-On macOS `pip install openwakeword>=0.6.0` (with deps) works normally.
+**`openwakeword` — platform-specific install (see above)**
+Covered in the "Platform-specific install handling" section above.
+Full rationale: `tflite-runtime` has no wheel for Python 3.13 on aarch64;
+`--no-deps` skips it; ONNX inference backend works without it.
 
 Document both constraints in `docs/raspberry-pi-setup.md` (Plan 05).
 

--- a/plan/backlog/52-replace-porcupine-with-openwakeword.md
+++ b/plan/backlog/52-replace-porcupine-with-openwakeword.md
@@ -1,0 +1,171 @@
+# Replace Porcupine with openWakeWord
+
+**Status**: 📋 Planned
+**Priority**: 52
+**Platforms**: macOS M1, Raspberry Pi 3B
+
+---
+
+## Dependencies
+
+- None — this is a self-contained engine swap.
+
+---
+
+## Overview
+
+Replace the Picovoice Porcupine wake word engine with
+[openWakeWord](https://github.com/dscripka/openWakeWord): a fully open-source,
+free-to-use wake word detection library. Porcupine requires a Picovoice account
+(now company-email-only) and enforces per-device activation limits, making it
+unsuitable for self-hosted deployment. openWakeWord uses pre-trained ONNX models
+(no account, no limits) and provides equivalent accuracy.
+
+The new engine is wrapped behind a Porcupine-compatible interface
+(`common/openwakeword_detector.py`) so `WakeWordMode` and `BargeInDetector` need
+only minimal changes: swap the import and the constructor call.
+
+---
+
+## Problem Statement
+
+- Porcupine free tier now requires a company email to obtain an access key.
+- Per-device activation limits block re-deployment on a new Pi without a new key.
+- `pvporcupine` is a closed binary; no path to self-hosted or offline use.
+
+openWakeWord fixes all three issues: MIT-licensed, no account, runs on-device.
+
+---
+
+## Proposed Solution
+
+### New file: `common/openwakeword_detector.py`
+
+A Porcupine-compatible wrapper around openWakeWord's `Model` class:
+
+```python
+class OpenWakeWordDetector:
+    """Wraps openWakeWord to expose the Porcupine interface used by WakeWordMode
+    and BargeInDetector: sample_rate, device_sample_rate, frame_length,
+    process(pcm) → int, reset(), delete()."""
+
+    def __init__(self, model_name="hey_jarvis", threshold=0.5, device_sample_rate=None):
+        ...
+
+    @property
+    def frame_length(self) -> int:
+        """Samples per frame at device_sample_rate (covers the same 80 ms window)."""
+
+    def process(self, pcm) -> int:
+        """Return 0 if wake word detected, -1 otherwise.
+        Resamples from device_sample_rate to 16 kHz when they differ
+        (using scipy.signal.resample_poly for correct non-integer ratios).
+        """
+
+    def reset(self):
+        """Clear the model's internal 30-frame rolling prediction buffer.
+        Call before re-entering IDLE to prevent residual TTS audio (bot's voice
+        picked up by the mic) from triggering a false positive on the first frame.
+        """
+
+    def delete(self):
+        """No-op — openWakeWord holds no native resources."""
+```
+
+Handles both short built-in model names (`hey_jarvis`, `alexa`, …) and absolute
+`.onnx` file paths for custom models.
+
+### Changes to `common/wake_word.py`
+
+- Replace `import pvporcupine` with `from common.openwakeword_detector import OpenWakeWordDetector`.
+- Rename `_create_porcupine_instance()` → `_create_detector_instance()`, returning
+  `OpenWakeWordDetector(model_name=..., threshold=..., device_sample_rate=config.rate)`.
+- Call `self.porcupine.reset()` at the top of `_state_idle()` before opening the
+  PyAudio stream (clears buffer state left over from the previous TTS cycle).
+
+### Changes to `common/barge_in.py`
+
+- Replace `import pvporcupine` with `from common.openwakeword_detector import OpenWakeWordDetector`.
+- Update `_create_porcupine_instance()` to return `OpenWakeWordDetector(...)`.
+
+### Configuration changes (`common/configuration.py`)
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `openwakeword_model` | `"hey_jarvis"` | Short built-in name or absolute `.onnx` path |
+| `wake_word_sensitivity` | `0.35` | Lowered from `0.5`; openWakeWord scores differ from Porcupine |
+
+Remove `porcupine_access_key` and `porcupine_keyword_paths` from defaults
+(no longer needed). Keep validation only for the new keys.
+
+### `requirements.txt`
+
+- Add `openwakeword>=0.6.0`
+- Add `onnxruntime==1.20.0` (**hard pin — do not bump without Pi 3B testing**)
+- Remove `pvporcupine`
+
+### Critical Pi 3B version constraints
+
+> These were discovered through direct testing on Pi 3B (Bookworm, Python 3.13,
+> aarch64). Both constraints must be preserved exactly.
+
+**`onnxruntime==1.20.0`**
+Versions 1.21+ crash at model load time on Pi 3B with a C++ STL vector
+assertion error deep in the ONNX runtime native library:
+```
+Assertion failed: (index < size_), function operator[], ...
+```
+1.20.0 is the last version confirmed stable on armv8/aarch64 Pi 3B.
+Pin it exactly; do not use `>=` or `~=`.
+
+**`openwakeword>=0.6.0 --no-deps` (Pi only)**
+`tflite-runtime` (an optional openWakeWord dependency) has no wheel for
+Python 3.13 on aarch64. Installing with `--no-deps` skips it; openWakeWord
+works fine without it when using the ONNX inference backend (which is the
+default and the one we use). `scipy` must be installed separately:
+
+```bash
+pip install openwakeword>=0.6.0 --no-deps
+pip install scipy
+```
+
+On macOS `pip install openwakeword>=0.6.0` (with deps) works normally.
+
+Document both constraints in `docs/raspberry-pi-setup.md` (Plan 05).
+
+---
+
+## Files to Touch
+
+| File | Change |
+|------|--------|
+| `common/openwakeword_detector.py` | New file |
+| `common/wake_word.py` | Swap engine; add `reset()` call in `_state_idle()` |
+| `common/barge_in.py` | Swap engine |
+| `common/configuration.py` | Add `openwakeword_model`; lower sensitivity default; remove Porcupine keys |
+| `requirements.txt` | Add openwakeword + onnxruntime; remove pvporcupine |
+| `tests/test_openwakeword_detector.py` | New test file |
+| `tests/test_wake_word.py` | Update mocks |
+| `tests/test_barge_in.py` | Update mocks |
+
+---
+
+## Out of Scope
+
+- Custom wake word training (use any `.onnx` model via `openwakeword_model` path)
+- Acoustic echo cancellation
+- Sensitivity auto-tuning
+
+---
+
+## Acceptance Criteria
+
+- [ ] `common/openwakeword_detector.py` created with `OpenWakeWordDetector` class
+- [ ] `process()` resamples correctly for both 44100 Hz (Mac) and 48000 Hz (Pi)
+- [ ] `reset()` clears the model buffer; no false positive on first IDLE frame after TTS
+- [ ] `wake_word.py` and `barge_in.py` use `OpenWakeWordDetector`; no reference to pvporcupine
+- [ ] `porcupine_access_key` removed from config defaults and validation
+- [ ] `openwakeword_model` config key documented
+- [ ] `onnxruntime==1.20.0` pinned in `requirements.txt`
+- [ ] Tests pass on macOS M1 and Raspberry Pi 3B
+- [ ] >80% coverage on `openwakeword_detector.py`

--- a/plan/backlog/52-replace-porcupine-with-openwakeword.md
+++ b/plan/backlog/52-replace-porcupine-with-openwakeword.md
@@ -160,7 +160,7 @@ Document both constraints in `docs/raspberry-pi-setup.md` (Plan 05).
 | `common/wake_word.py` | Swap engine; add `reset()` call in `_state_idle()` |
 | `common/barge_in.py` | Swap engine |
 | `common/configuration.py` | Add `openwakeword_model`; lower sensitivity default; remove Porcupine keys |
-| `requirements.txt` | Add openwakeword + onnxruntime; remove pvporcupine |
+| `requirements.txt` | Add `onnxruntime==1.20.0` (hard pin); remove `pvporcupine`; **do not add `openwakeword`** (platform-specific install — see above) |
 | `tests/test_openwakeword_detector.py` | New test file |
 | `tests/test_wake_word.py` | Update mocks |
 | `tests/test_barge_in.py` | Update mocks |

--- a/plan/backlog/52-replace-porcupine-with-openwakeword.md
+++ b/plan/backlog/52-replace-porcupine-with-openwakeword.md
@@ -1,6 +1,6 @@
 # Replace Porcupine with openWakeWord
 
-**Status**: 📋 Planned
+**Status**: 📋 Backlog
 **Priority**: 52
 **Platforms**: macOS M1, Raspberry Pi 3B
 

--- a/plan/backlog/52-replace-porcupine-with-openwakeword.md
+++ b/plan/backlog/52-replace-porcupine-with-openwakeword.md
@@ -54,7 +54,14 @@ class OpenWakeWordDetector:
 
     @property
     def frame_length(self) -> int:
-        """Samples per frame at device_sample_rate (covers the same 80 ms window)."""
+        """Samples per frame at device_sample_rate (80 ms window at 16 kHz = 1280 samples).
+
+        NOTE: openWakeWord requires 80 ms / 1280 samples per frame, which
+        differs from Porcupine's 32 ms / 512 samples. The interface is
+        compatible (same property name) but the value changes. All existing
+        test mocks that hardcode ``frame_length = 512`` must be updated to
+        ``frame_length = 1280`` when switching to this implementation.
+        """
 
     def process(self, pcm) -> int:
         """Return 0 if wake word detected, -1 otherwise.
@@ -135,8 +142,11 @@ Remove `porcupine_access_key` and `porcupine_keyword_paths` from defaults
 ### Platform-specific install handling
 
 `openwakeword` cannot be installed via `pip install -r requirements.txt` on
-Raspberry Pi because `tflite-runtime` (a transitive dependency) has no wheel
-for Python 3.13 on aarch64. To support both platforms without a broken
+Raspberry Pi because `tflite-runtime` (a transitive dependency) is not
+reliably available as a wheel on Pi/aarch64. This was confirmed on the
+validated Pi target (Trixie / Debian 13, Python 3.13) which is outside the
+project's current CI coverage (Python 3.10–3.12); the issue may also affect
+earlier Python versions on aarch64. To support both platforms without a broken
 `requirements.txt`, `openwakeword` is kept out of the shared requirements file
 and documented as a separate install step per platform.
 
@@ -189,8 +199,8 @@ Document both constraints in `docs/raspberry-pi-setup.md` (Plan 05).
 | `common/configuration.py` | Add `openwakeword_model`; lower sensitivity default; remove Porcupine keys |
 | `requirements.txt` | Add `onnxruntime==1.20.0` (hard pin); remove `pvporcupine`; **do not add `openwakeword`** (platform-specific install — see above) |
 | `tests/test_openwakeword_detector.py` | New test file |
-| `tests/test_wake_word.py` | Update mocks |
-| `tests/test_barge_in.py` | Update mocks |
+| `tests/test_wake_word.py` | Update mocks: `frame_length = 512` → `1280`; `device_sample_rate`; swap pvporcupine references |
+| `tests/test_barge_in.py` | Update mocks: `frame_length = 512` → `1280`; swap pvporcupine references |
 
 ---
 

--- a/plan/backlog/53-linux-alsa-input-device-auto-selection.md
+++ b/plan/backlog/53-linux-alsa-input-device-auto-selection.md
@@ -1,0 +1,120 @@
+# Linux ALSA Input Device Auto-Selection
+
+**Status**: 📋 Planned
+**Priority**: 53
+**Platforms**: Raspberry Pi 3B (Linux). No change on macOS.
+
+---
+
+## Dependencies
+
+- **Plan 52** — the openWakeWord engine must be in place first; this plan
+  adjusts how the engine's PyAudio stream is opened, not which engine is used.
+
+---
+
+## Overview
+
+On Linux, PyAudio's default input device is a virtual ALSA device (`default`,
+`dmix`, or similar) that may deliver silence or low-quality audio instead of
+routing to the real USB microphone. SandVoice's wake word detection and
+barge-in detection both open their own PyAudio stream; without explicitly
+selecting a real hardware device the mic signal is often zero and wake word
+detection never fires.
+
+This plan adds a helper `_find_hw_input_device(pa)` that scans the PyAudio
+device list for the first device whose ALSA name matches `hw:N,M` and has at
+least one input channel, then passes that index to `pa.open()`. On macOS the
+helper returns `None` and PyAudio uses its normal default.
+
+---
+
+## Problem Statement
+
+- Pi 3B with Razer Barracuda X 2.4 USB headset: PyAudio device index 7
+  is the ALSA `default` virtual device — it enumerates successfully but
+  delivers amplitude=0 frames.
+- Device index 2 (`hw:2,0`) is the actual USB audio hardware — it works.
+- Without explicit selection, `_state_idle()` logs `frame 1 max_amplitude=0`
+  forever and no wake word is ever detected.
+- The same issue affects `BargeInDetector._detection_loop()`.
+
+---
+
+## Proposed Solution
+
+### `common/wake_word.py`
+
+Add module-level helper (not a method — it has no dependency on `WakeWordMode`
+state):
+
+```python
+def _find_hw_input_device(pa):
+    """Return the index of the first real ALSA hardware input device.
+
+    Scans PyAudio's device list for the first entry whose name contains
+    'hw:N,M' and has maxInputChannels > 0. Returns None on non-Linux
+    platforms or when no hw: device is found (PyAudio picks the default).
+    """
+    import re, platform
+    if platform.system().lower() != "linux":
+        return None
+    for i in range(pa.get_device_count()):
+        dev = pa.get_device_info_by_index(i)
+        if dev.get("maxInputChannels", 0) > 0 and re.search(r'hw:\d+,\d+', dev.get("name", "")):
+            logger.debug("Wake word: selected hw input device index=%s name=%s", i, dev["name"])
+            return i
+    return None
+```
+
+Use it in `_state_idle()`:
+
+```python
+pa = pyaudio.PyAudio()
+input_device_index = _find_hw_input_device(pa)
+audio_stream = pa.open(
+    rate=self.porcupine.device_sample_rate,
+    channels=1,
+    format=pyaudio.paInt16,
+    input=True,
+    input_device_index=input_device_index,  # None → PyAudio default on Mac
+    frames_per_buffer=self.porcupine.frame_length,
+)
+```
+
+### `common/barge_in.py`
+
+Identical inline scan in `_detection_loop()` (or import and call the same
+helper from `wake_word.py` if it makes sense to expose it; otherwise
+duplicate the short scan to keep barge_in.py self-contained).
+
+---
+
+## Files to Touch
+
+| File | Change |
+|------|--------|
+| `common/wake_word.py` | Add `_find_hw_input_device()`; use in `_state_idle()` |
+| `common/barge_in.py` | Add equivalent hw: scan in `_detection_loop()` |
+| `tests/test_wake_word.py` | Test helper returns correct index / None |
+| `tests/test_barge_in.py` | Test detection loop passes correct device index |
+
+---
+
+## Out of Scope
+
+- Output device selection (that is Plan 54)
+- ALSA configuration files (`~/.asoundrc`)
+- Multi-card setups beyond "first matching hw: input device"
+
+---
+
+## Acceptance Criteria
+
+- [ ] `_find_hw_input_device()` returns `None` on macOS
+- [ ] Returns the index of the first `hw:N,M` input device on Linux
+- [ ] `_state_idle()` passes the returned index to `pa.open()`
+- [ ] `_detection_loop()` in `barge_in.py` does the same
+- [ ] Debug log emitted showing selected device name and index
+- [ ] Tests pass on macOS M1 and Raspberry Pi 3B
+- [ ] >80% coverage on new helper

--- a/plan/backlog/53-linux-alsa-input-device-auto-selection.md
+++ b/plan/backlog/53-linux-alsa-input-device-auto-selection.md
@@ -1,6 +1,6 @@
 # Linux ALSA Input Device Auto-Selection
 
-**Status**: 📋 Planned
+**Status**: 📋 Backlog
 **Priority**: 53
 **Platforms**: Raspberry Pi 3B (Linux). No change on macOS.
 

--- a/plan/backlog/53-linux-alsa-input-device-auto-selection.md
+++ b/plan/backlog/53-linux-alsa-input-device-auto-selection.md
@@ -35,8 +35,8 @@ helper returns `None` and PyAudio uses its normal default.
   is the ALSA `default` virtual device — it enumerates successfully but
   delivers amplitude=0 frames.
 - Device index 2 (`hw:2,0`) is the actual USB audio hardware — it works.
-- Without explicit selection, `_state_idle()` logs `frame 1 max_amplitude=0`
-  forever and no wake word is ever detected.
+- Without explicit selection, `_state_idle()` can remain on a silent input
+  stream (zeroed / near-zero frames), so no wake word is ever detected.
 - The same issue affects `BargeInDetector._detection_loop()`.
 
 ---

--- a/plan/backlog/54-linux-audio-output-device-auto-detection.md
+++ b/plan/backlog/54-linux-audio-output-device-auto-detection.md
@@ -1,0 +1,134 @@
+# Linux Audio Output Device Auto-Detection
+
+**Status**: 📋 Planned
+**Priority**: 54
+**Platforms**: Raspberry Pi 3B (Linux). No change on macOS.
+
+---
+
+## Dependencies
+
+- None — this is an `audio.py` change independent of the wake word engine.
+
+---
+
+## Overview
+
+On Raspberry Pi, SDL2 (used by `pygame.mixer` for TTS playback) defaults to the
+first ALSA device it finds. On a Pi 3B this is typically `bcm2835` — the onboard
+HDMI/headphone output — even when a USB audio headset is connected and set as
+the ALSA system default. The result: TTS audio plays on the wrong device (or not
+at all if the onboard device has no speaker connected), while the user hears
+nothing through their USB headset.
+
+This plan adds startup code in `audio.py` that detects the correct ALSA output
+device and sets the `SDL_AUDIODRIVER` and `AUDIODEV` environment variables
+**before** `pygame` is imported, so pygame picks up the right device
+automatically on every platform.
+
+Also included: move `from pynput import keyboard` from module-level to inside
+`Audio.init_recording()`. The module-level import crashes on headless Linux
+(`ImportError: this platform is not supported`) even when `init_recording` is
+never called.
+
+---
+
+## Problem Statement
+
+1. **Wrong SDL output device**: `pygame.mixer.init()` binds to `bcm2835` on Pi
+   instead of the USB headset. TTS responses are inaudible.
+
+2. **pynput crashes on import**: `from pynput import keyboard` at the top of
+   `audio.py` raises `ImportError` on headless Linux because pynput requires a
+   display server (X11/Wayland). SandVoice in `--wake-word` mode never calls
+   `init_recording()`, so the import is unconditionally executed but never needed.
+
+---
+
+## Proposed Solution
+
+### `common/audio.py` — SDL output device auto-detection
+
+At module load time, before `import pygame`:
+
+```python
+if platform.system().lower() == "linux" and "SDL_AUDIODRIVER" not in os.environ:
+    os.environ["SDL_AUDIODRIVER"] = "alsa"
+    try:
+        import re as _re, pyaudio as _pa
+        _audio = _pa.PyAudio()
+        try:
+            _audiodev = None
+            _fallback = None
+            for _i in range(_audio.get_device_count()):
+                _dev = _audio.get_device_info_by_index(_i)
+                _m = _re.search(r'hw:(\d+),(\d+)', _dev.get("name", ""))
+                if not _m:
+                    continue
+                _plug = f"plughw:{_m.group(1)},{_m.group(2)}"
+                # Prefer a device with both input AND output (USB headset).
+                if _dev.get("maxOutputChannels", 0) > 0 and _dev.get("maxInputChannels", 0) > 0:
+                    _audiodev = _plug
+                    break
+                if _fallback is None and _dev.get("maxOutputChannels", 0) > 0:
+                    _fallback = _plug
+            os.environ["AUDIODEV"] = _audiodev or _fallback or "default"
+        finally:
+            _audio.terminate()
+    except Exception:
+        os.environ["AUDIODEV"] = "default"
+
+import pygame
+```
+
+Why `plughw:N,M` (not `hw:N,M`)? `plughw` goes through ALSA's plug layer which
+handles sample rate conversion automatically; `hw` requires exact format match
+and will fail if pygame requests a rate the device doesn't natively support.
+
+Why prefer a device with both in+out channels? On a USB headset (e.g. Razer
+Barracuda X) the same `hw:2,0` device handles mic and speakers. Preferring
+combined devices avoids accidentally picking an output-only onboard device as
+the fallback when a headset is present.
+
+### `common/audio.py` — lazy pynput import
+
+```python
+# Before (top of file):
+from pynput import keyboard   # ← crashes on headless Linux
+
+# After (inside init_recording only):
+def init_recording(self):
+    from pynput import keyboard  # imported only when actually needed
+    listener = keyboard.Listener(on_press=self.on_press)
+    ...
+```
+
+---
+
+## Files to Touch
+
+| File | Change |
+|------|--------|
+| `common/audio.py` | SDL AUDIODEV auto-detection block; lazy pynput import |
+| `tests/test_audio.py` | Test AUDIODEV is set on Linux; test lazy import path |
+
+---
+
+## Out of Scope
+
+- Input device selection for PyAudio (that is Plan 53)
+- ALSA configuration files (`~/.asoundrc`, `/etc/asound.conf`)
+- Windows audio support
+
+---
+
+## Acceptance Criteria
+
+- [ ] `SDL_AUDIODRIVER=alsa` and `AUDIODEV=plughw:N,M` set before `pygame` import on Linux
+- [ ] Prefers `hw:N,M` device with both input and output channels (USB headset)
+- [ ] Falls back to first output-only `hw:N,M` device, then `"default"`
+- [ ] Env vars not overwritten if already set by the user
+- [ ] `from pynput import keyboard` moved inside `init_recording()`
+- [ ] No crash on headless Linux when `init_recording()` is never called
+- [ ] macOS behavior unchanged
+- [ ] Tests pass on macOS M1 and Raspberry Pi 3B

--- a/plan/backlog/54-linux-audio-output-device-auto-detection.md
+++ b/plan/backlog/54-linux-audio-output-device-auto-detection.md
@@ -1,6 +1,6 @@
 # Linux Audio Output Device Auto-Detection
 
-**Status**: 📋 Planned
+**Status**: 📋 Backlog
 **Priority**: 54
 **Platforms**: Raspberry Pi 3B (Linux). No change on macOS.
 

--- a/plan/backlog/54-linux-audio-output-device-auto-detection.md
+++ b/plan/backlog/54-linux-audio-output-device-auto-detection.md
@@ -113,7 +113,8 @@ def init_recording(self):
 | File | Change |
 |------|--------|
 | `common/audio.py` | SDL AUDIODEV auto-detection block; lazy pynput import |
-| `tests/test_audio.py` | Test AUDIODEV is set on Linux; test lazy import path |
+| `tests/test_audio_playback.py` | Test `SDL_AUDIODRIVER`/`AUDIODEV` env vars set correctly on Linux before pygame import |
+| `tests/test_audio_device_detection.py` | Test device scanning logic, fallback behaviour, and lazy `pynput` import path |
 
 ---
 

--- a/plan/backlog/54-linux-audio-output-device-auto-detection.md
+++ b/plan/backlog/54-linux-audio-output-device-auto-detection.md
@@ -24,7 +24,8 @@ nothing through their USB headset.
 This plan adds startup code in `audio.py` that detects the correct ALSA output
 device and sets the `SDL_AUDIODRIVER` and `AUDIODEV` environment variables
 **before** `pygame` is imported, so pygame picks up the right device
-automatically on every platform.
+automatically on Linux systems such as the Raspberry Pi, with no change on
+other platforms.
 
 Also included: move `from pynput import keyboard` from module-level to inside
 `Audio.init_recording()`. The module-level import crashes on headless Linux

--- a/plan/backlog/54-linux-audio-output-device-auto-detection.md
+++ b/plan/backlog/54-linux-audio-output-device-auto-detection.md
@@ -52,31 +52,34 @@ never called.
 At module load time, before `import pygame`:
 
 ```python
-if platform.system().lower() == "linux" and "SDL_AUDIODRIVER" not in os.environ:
-    os.environ["SDL_AUDIODRIVER"] = "alsa"
-    try:
-        import re as _re, pyaudio as _pa
-        _audio = _pa.PyAudio()
+if platform.system().lower() == "linux":
+    if "SDL_AUDIODRIVER" not in os.environ:
+        os.environ["SDL_AUDIODRIVER"] = "alsa"
+
+    if "AUDIODEV" not in os.environ:
         try:
-            _audiodev = None
-            _fallback = None
-            for _i in range(_audio.get_device_count()):
-                _dev = _audio.get_device_info_by_index(_i)
-                _m = _re.search(r'hw:(\d+),(\d+)', _dev.get("name", ""))
-                if not _m:
-                    continue
-                _plug = f"plughw:{_m.group(1)},{_m.group(2)}"
-                # Prefer a device with both input AND output (USB headset).
-                if _dev.get("maxOutputChannels", 0) > 0 and _dev.get("maxInputChannels", 0) > 0:
-                    _audiodev = _plug
-                    break
-                if _fallback is None and _dev.get("maxOutputChannels", 0) > 0:
-                    _fallback = _plug
-            os.environ["AUDIODEV"] = _audiodev or _fallback or "default"
-        finally:
-            _audio.terminate()
-    except Exception:
-        os.environ["AUDIODEV"] = "default"
+            import re as _re, pyaudio as _pa
+            _audio = _pa.PyAudio()
+            try:
+                _audiodev = None
+                _fallback = None
+                for _i in range(_audio.get_device_count()):
+                    _dev = _audio.get_device_info_by_index(_i)
+                    _m = _re.search(r'hw:(\d+),(\d+)', _dev.get("name", ""))
+                    if not _m:
+                        continue
+                    _plug = f"plughw:{_m.group(1)},{_m.group(2)}"
+                    # Prefer a device with both input AND output (USB headset).
+                    if _dev.get("maxOutputChannels", 0) > 0 and _dev.get("maxInputChannels", 0) > 0:
+                        _audiodev = _plug
+                        break
+                    if _fallback is None and _dev.get("maxOutputChannels", 0) > 0:
+                        _fallback = _plug
+                os.environ["AUDIODEV"] = _audiodev or _fallback or "default"
+            finally:
+                _audio.terminate()
+        except Exception:
+            os.environ["AUDIODEV"] = "default"
 
 import pygame
 ```
@@ -124,10 +127,11 @@ def init_recording(self):
 
 ## Acceptance Criteria
 
-- [ ] `SDL_AUDIODRIVER=alsa` and `AUDIODEV=plughw:N,M` set before `pygame` import on Linux
-- [ ] Prefers `hw:N,M` device with both input and output channels (USB headset)
-- [ ] Falls back to first output-only `hw:N,M` device, then `"default"`
-- [ ] Env vars not overwritten if already set by the user
+- [ ] `SDL_AUDIODRIVER` set to `alsa` on Linux if not already set by the user
+- [ ] `AUDIODEV` set to `plughw:N,M` on Linux if not already set by the user
+- [ ] Scans PyAudio devices for `hw:N,M` names; prefers device with both input and output channels (USB headset)
+- [ ] Falls back to first output-only `hw:N,M` device and sets `AUDIODEV=plughw:N,M`, then `"default"`
+- [ ] `SDL_AUDIODRIVER` and `AUDIODEV` checked and set independently — a user-set `AUDIODEV` is not overwritten
 - [ ] `from pynput import keyboard` moved inside `init_recording()`
 - [ ] No crash on headless Linux when `init_recording()` is never called
 - [ ] macOS behavior unchanged

--- a/plan/backlog/55-vad-pre-speech-grace-period.md
+++ b/plan/backlog/55-vad-pre-speech-grace-period.md
@@ -73,8 +73,19 @@ else:
   take as long as they need to start talking.
 - After the user speaks and stops: the 1.5 s silence window closes the recording
   exactly as before.
-- Empty-input behavior: if the user never speaks, the full `vad_timeout` elapses
-  and the recording is discarded (existing behavior for truly silent recordings).
+- Empty-input behavior: if the user never speaks, the full `vad_timeout` elapses.
+  The loop exits with `speech_detected = False`. A post-loop guard must return
+  `None` in this case to avoid writing and returning a WAV file full of silence:
+
+  ```python
+  if not speech_detected:
+      return None
+  ```
+
+  Note: the current code only returns `None` when `frames` is empty (i.e. the
+  stream read failed immediately). With the `speech_detected` flag, the post-loop
+  check must be added explicitly, otherwise a 30 s silent recording would still
+  be transcribed and sent to the LLM.
 
 No config changes required. Existing `vad_silence_duration` and `vad_timeout`
 semantics are preserved.
@@ -85,7 +96,7 @@ semantics are preserved.
 
 | File | Change |
 |------|--------|
-| `common/vad_recorder.py` | Add `speech_detected` flag; gate silence countdown on it |
+| `common/vad_recorder.py` | Add `speech_detected` flag; gate silence countdown on it; return `None` post-loop if no speech detected |
 | `tests/test_vad_recorder.py` | Add tests for pre-speech silence (no early cutoff) and post-speech silence (normal cutoff) |
 
 ---
@@ -101,9 +112,12 @@ semantics are preserved.
 
 - [ ] `VadRecorder.record()` does not cut off before the first speech frame is seen
 - [ ] After speech is detected, silence of `vad_silence_duration` still ends the recording
-- [ ] `vad_timeout` still terminates the recording if the user never speaks
+- [ ] `vad_timeout` elapses and `record()` returns `None` if the user never speaks (no WAV written, no ack earcon)
 - [ ] No config changes required
-- [ ] Tests cover: starts speaking immediately, starts speaking after 2 s delay,
-      never speaks (timeout), speaks then pauses
+- [ ] Tests cover:
+  - starts speaking immediately
+  - starts speaking after 2 s delay
+  - never speaks (timeout) — must return `None`
+  - speaks then pauses
 - [ ] All existing tests pass
 - [ ] >80% coverage

--- a/plan/backlog/55-vad-pre-speech-grace-period.md
+++ b/plan/backlog/55-vad-pre-speech-grace-period.md
@@ -1,6 +1,6 @@
 # VAD Pre-Speech Grace Period
 
-**Status**: 📋 Planned
+**Status**: 📋 Backlog
 **Priority**: 55
 **Platforms**: macOS M1, Raspberry Pi 3B
 

--- a/plan/backlog/55-vad-pre-speech-grace-period.md
+++ b/plan/backlog/55-vad-pre-speech-grace-period.md
@@ -1,0 +1,109 @@
+# VAD Pre-Speech Grace Period
+
+**Status**: 📋 Planned
+**Priority**: 55
+**Platforms**: macOS M1, Raspberry Pi 3B
+
+---
+
+## Dependencies
+
+- None — standalone change to `common/vad_recorder.py`.
+
+---
+
+## Overview
+
+After the wake word fires and the confirmation beep plays, `VadRecorder` opens the
+microphone and immediately starts counting silence. The user has at most
+`vad_silence_duration` seconds (default 1.5 s) to start speaking before the
+recording is cut short and sent for transcription as near-empty audio — wasting
+an API call and giving the impression the assistant didn't hear anything.
+
+This plan adds a `speech_detected` flag to the VAD loop. The silence countdown
+only starts once at least one speech frame has been seen. Before any speech, the
+loop waits up to `vad_timeout` (default 30 s) for the user to begin talking.
+
+---
+
+## Problem Statement
+
+Current VAD loop logic (simplified):
+
+```python
+if is_speech:
+    silence_start = None
+else:
+    if silence_start is None:
+        silence_start = time.time()          # ← starts immediately on first silent frame
+    elif time.time() - silence_start >= vad_silence_duration:
+        break                                 # ← cuts off before user speaks
+```
+
+After the beep, the first frames are silence (the user is still composing their
+thought). The timer starts, reaches 1.5 s, and the loop exits — recording 1.5 s
+of near-silence and sending `User: ` (empty) to the LLM.
+
+---
+
+## Proposed Solution
+
+Add a `speech_detected` boolean, initialized to `False`. Only enter the silence
+countdown branch once `speech_detected` is `True`.
+
+```python
+speech_detected = False
+
+...
+
+if is_speech:
+    speech_detected = True
+    silence_start = None
+else:
+    if speech_detected:                      # ← only count silence after speech starts
+        if silence_start is None:
+            silence_start = time.time()
+        elif time.time() - silence_start >= vad_silence_duration:
+            logger.debug("Silence detected (%.2fs)", time.time() - silence_start)
+            break
+```
+
+**Effect**:
+- Before the user speaks: loop continues until `vad_timeout` (30 s). User can
+  take as long as they need to start talking.
+- After the user speaks and stops: the 1.5 s silence window closes the recording
+  exactly as before.
+- Empty-input behavior: if the user never speaks, the full `vad_timeout` elapses
+  and the recording is discarded (existing behavior for truly silent recordings).
+
+No config changes required. Existing `vad_silence_duration` and `vad_timeout`
+semantics are preserved.
+
+---
+
+## Files to Touch
+
+| File | Change |
+|------|--------|
+| `common/vad_recorder.py` | Add `speech_detected` flag; gate silence countdown on it |
+| `tests/test_vad_recorder.py` | Add tests for pre-speech silence (no early cutoff) and post-speech silence (normal cutoff) |
+
+---
+
+## Out of Scope
+
+- Changing `vad_silence_duration` or `vad_timeout` defaults
+- Acoustic noise detection or energy thresholding (Plan 14)
+
+---
+
+## Acceptance Criteria
+
+- [ ] `VadRecorder.record()` does not cut off before the first speech frame is seen
+- [ ] After speech is detected, silence of `vad_silence_duration` still ends the recording
+- [ ] `vad_timeout` still terminates the recording if the user never speaks
+- [ ] No config changes required
+- [ ] Tests cover: starts speaking immediately, starts speaking after 2 s delay,
+      never speaks (timeout), speaks then pauses
+- [ ] All existing tests pass
+- [ ] >80% coverage


### PR DESCRIPTION
## Summary

- Plan 52: Replace Porcupine with openWakeWord (MIT, no account required; `onnxruntime==1.20.0` pinned for Pi 3B stability)
- Plan 53: Linux ALSA input device auto-selection (pick real `hw:N,M` mic, not virtual ALSA default)
- Plan 54: Linux audio output device auto-detection (SDL `AUDIODEV` auto-detect + lazy pynput import)
- Plan 55: VAD pre-speech grace period (silence countdown only starts after first speech frame)
- Plan 05: Updated to documentation-only; depends on 52–55; reflects Trixie/Debian 13, validated hardware, and full table of Pi-specific issues

## Planning Documents

- `plan/backlog/52-replace-porcupine-with-openwakeword.md`
- `plan/backlog/53-linux-alsa-input-device-auto-selection.md`
- `plan/backlog/54-linux-audio-output-device-auto-detection.md`
- `plan/backlog/55-vad-pre-speech-grace-period.md`
- `plan/backlog/05-raspberry-pi-compatibility.md` (updated)

## Changes

- 4 new plan documents added to `plan/backlog/`
- `plan/backlog/05-raspberry-pi-compatibility.md` rewritten: now documentation-only, lists dependencies on plans 52–55, documents validated hardware (Pi 3B + Razer Barracuda X, Trixie/Debian 13), and captures all Pi-specific issues discovered during testing
- `plan/INDEX.md` updated with entries for plans 52–55 and revised description for plan 05

## Testing

- N/A — plan documents only, no code changes