### PR TITLE
Implement Plan 58: weather forecast for future date queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ tmp_files_path: /home/user/.sandvoice/tmp/   # must end with /
 
 # Identity and locale
 botname: SandVoice
-timezone: EST                # timezone name (e.g. EST, America/New_York)
+timezone: America/Toronto    # IANA timezone name (e.g. America/New_York, Europe/London)
 location: Toronto, ON, CA    # used by weather and routing
 unit: metric                 # metric or imperial
 language: English

--- a/common/configuration.py
+++ b/common/configuration.py
@@ -48,7 +48,7 @@ class Config:
             "chunk": 1024,
             "tmp_files_path": os.path.join(os.path.expanduser("~"), ".sandvoice", "tmp") + os.sep,
             "botname": "SandVoice",
-            "timezone": "EST",
+            "timezone": "America/Toronto",
             "location": "Toronto, ON, CA",
             "unit": "metric",
             "language": "English",

--- a/common/configuration.py
+++ b/common/configuration.py
@@ -136,6 +136,8 @@ class Config:
             "cache_enabled": "disabled",
             "cache_weather_ttl_s": 10800,    # 3 hours — refresh window
             "cache_weather_max_stale_s": 21600,  # 6 hours — hard expiry
+            "cache_weather_forecast_ttl_s": 3600,    # 1 hour — forecast refresh window
+            "cache_weather_forecast_max_stale_s": 7200,  # 2 hours — forecast hard expiry
             "cache_auto_refresh": [],
 
             # Blocking Cache Warmup (Plan 39)
@@ -308,6 +310,22 @@ class Config:
                 self.cache_weather_ttl_s,
             )
             self.cache_weather_max_stale_s = self.cache_weather_ttl_s
+        try:
+            self.cache_weather_forecast_ttl_s = max(1, int(self.get("cache_weather_forecast_ttl_s")))
+        except (TypeError, ValueError):
+            self.cache_weather_forecast_ttl_s = self.defaults["cache_weather_forecast_ttl_s"]
+        try:
+            self.cache_weather_forecast_max_stale_s = max(1, int(self.get("cache_weather_forecast_max_stale_s")))
+        except (TypeError, ValueError):
+            self.cache_weather_forecast_max_stale_s = self.defaults["cache_weather_forecast_max_stale_s"]
+        if self.cache_weather_forecast_max_stale_s < self.cache_weather_forecast_ttl_s:
+            logger.warning(
+                "cache_weather_forecast_max_stale_s (%d) is less than cache_weather_forecast_ttl_s (%d); "
+                "clamping max_stale to ttl value.",
+                self.cache_weather_forecast_max_stale_s,
+                self.cache_weather_forecast_ttl_s,
+            )
+            self.cache_weather_forecast_max_stale_s = self.cache_weather_forecast_ttl_s
         self.cache_auto_refresh = self._parse_cache_auto_refresh(self.get("cache_auto_refresh"))
         _timeout = _parse_exact_int(self.get("cache_warmup_timeout_s"))
         if isinstance(_timeout, int) and not isinstance(_timeout, bool):

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -255,7 +255,7 @@ plan/
 **Document**: [backlog/55-telegram-channel.md](./backlog/55-telegram-channel.md)
 **Description**: Add an always-on Telegram channel as a background thread within the SandVoice process. Text messages from whitelisted user IDs are routed through the same AI, plugins, and conversation history as wake-word mode. Adds `telegram_enabled`, `telegram_bot_token`, and `telegram_allowed_user_ids` config keys. Phase 1 is text only; Phase 2 adds voice message support.
 
-### Priority 58: Weather Forecast — 5-Day / Future Date Queries
+### Priority 58: Weather Forecast — 5-Day / Future Date Queries 🚧
 **Document**: [backlog/58-weather-forecast.md](./backlog/58-weather-forecast.md)
 **Description**: Extend the weather plugin to handle future-date queries ("will it rain tomorrow?", "what's the weather on Saturday?") by routing to the OpenWeatherMap 5-day/3-hour forecast endpoint. Adds `days_ahead` route parameter (0–5), separate cache keys and TTL config for forecast entries. Days beyond 5 return a graceful degradation message.
 

--- a/plan/backlog/58-weather-forecast.md
+++ b/plan/backlog/58-weather-forecast.md
@@ -1,7 +1,7 @@
 # Plan 58: Weather Forecast — 5-Day / Future Date Queries
 
 ## Status
-📋 Backlog
+🚧 In Progress
 
 ## Problem
 The weather plugin (`plugins/weather/plugin.py`) only queries the OpenWeatherMap **current weather** endpoint (`/data/2.5/weather`). When a user asks "what will the weather be like on Thursday?" or "will it rain this weekend?", the plugin returns today's conditions — which is misleading.

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -135,7 +135,15 @@ def process(user_input, route, s):
 
         location = route['location']
         unit = route['unit']
-        days_ahead = int(route.get('days_ahead', 0))
+        try:
+            days_ahead = int(route.get('days_ahead', 0))
+        except (TypeError, ValueError):
+            logger.warning("Invalid days_ahead value %r in route; defaulting to 0", route.get('days_ahead'))
+            days_ahead = 0
+
+        if days_ahead < 0:
+            logger.warning("Negative days_ahead %d in route; defaulting to 0", days_ahead)
+            days_ahead = 0
 
         if days_ahead > 5:
             return "I can only forecast up to 5 days ahead."

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -111,7 +111,7 @@ def _cache_key(location, unit, days_ahead=0):
     # Forecast keys include today's UTC date so a cached "tomorrow" entry is
     # never served on a different calendar day after midnight.
     if days_ahead >= 1:
-        today = datetime.date.today().isoformat()
+        today = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
         encoded = json.dumps([location, unit, days_ahead, today], separators=(",", ":"))
     else:
         encoded = json.dumps([location, unit, days_ahead], separators=(",", ":"))
@@ -153,10 +153,12 @@ def process(user_input, route, s):
             logger.warning("Negative days_ahead %d in route; defaulting to 0", days_ahead)
             days_ahead = 0
 
-        if days_ahead > 5:
-            return "I can only forecast up to 5 days ahead."
-
         refresh_only = route.get('refresh_only', False)
+
+        if days_ahead > 5:
+            if refresh_only:
+                return None
+            return "I can only forecast up to 5 days ahead."
         cache = getattr(s, 'cache', None)
         cache_key = _cache_key(location, unit, days_ahead)
 

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -123,7 +123,12 @@ def _cache_key(location, unit, days_ahead=0, timezone=None, _now=None):
                 tz = zoneinfo.ZoneInfo(timezone)
                 now = _now.astimezone(tz) if _now is not None else datetime.datetime.now(tz)
                 today = now.date().isoformat()
-            except Exception:
+            except Exception as exc:
+                logger.warning(
+                    "Weather: timezone %r could not be resolved (%s); falling back to UTC for cache key.",
+                    timezone,
+                    exc,
+                )
                 fallback = _now if _now is not None else datetime.datetime.now(datetime.timezone.utc)
                 today = fallback.date().isoformat()
         else:

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -5,7 +5,34 @@ import os
 
 import requests
 
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    ZoneInfo = None  # Python < 3.9 fallback
+
 logger = logging.getLogger(__name__)
+
+_TZ_CACHE = {}  # tz_name → ZoneInfo or None; avoids repeated resolution and duplicate warnings
+
+
+def _resolve_tz(tz_name):
+    """Return a ZoneInfo for tz_name, or None if unavailable or invalid."""
+    if not tz_name or ZoneInfo is None:
+        return None
+    if tz_name in _TZ_CACHE:
+        return _TZ_CACHE[tz_name]
+    try:
+        tz = ZoneInfo(tz_name)
+        _TZ_CACHE[tz_name] = tz
+        return tz
+    except Exception as exc:
+        logger.warning(
+            "Weather: timezone %r could not be resolved (%s); falling back to UTC for cache key.",
+            tz_name,
+            exc,
+        )
+        _TZ_CACHE[tz_name] = None
+        return None
 
 
 class OpenWeatherReader:
@@ -117,23 +144,12 @@ def _cache_key(location, unit, days_ahead=0, timezone=None, _now=None):
     # bounds any resulting stale-serve window.
     # _now is an optional datetime used to override "now" in tests.
     if days_ahead >= 1:
-        if timezone:
-            try:
-                import zoneinfo
-                tz = zoneinfo.ZoneInfo(timezone)
-                now = _now.astimezone(tz) if _now is not None else datetime.datetime.now(tz)
-                today = now.date().isoformat()
-            except Exception as exc:
-                logger.warning(
-                    "Weather: timezone %r could not be resolved (%s); falling back to UTC for cache key.",
-                    timezone,
-                    exc,
-                )
-                fallback = _now if _now is not None else datetime.datetime.now(datetime.timezone.utc)
-                today = fallback.date().isoformat()
+        tz = _resolve_tz(timezone)
+        if tz is not None:
+            now = _now.astimezone(tz) if _now is not None else datetime.datetime.now(tz)
         else:
-            fallback = _now if _now is not None else datetime.datetime.now(datetime.timezone.utc)
-            today = fallback.date().isoformat()
+            now = _now if _now is not None else datetime.datetime.now(datetime.timezone.utc)
+        today = now.date().isoformat()
         encoded = json.dumps([location, unit, days_ahead, today], separators=(",", ":"))
     else:
         encoded = json.dumps([location, unit, days_ahead], separators=(",", ":"))

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -17,11 +17,9 @@ _TZ_CACHE = {}  # tz_name → ZoneInfo or None; avoids repeated resolution and d
 
 def _resolve_tz(tz_name):
     """Return a ZoneInfo for tz_name, or None if unavailable or invalid."""
-    if not tz_name or ZoneInfo is None:
+    if not isinstance(tz_name, str) or not tz_name.strip() or ZoneInfo is None:
         return None
     tz_name = tz_name.strip()
-    if not tz_name:
-        return None
     if tz_name in _TZ_CACHE:
         return _TZ_CACHE[tz_name]
     try:
@@ -149,8 +147,8 @@ def _cache_key(location, unit, days_ahead=0, timezone=None, _now=None):
     # after local midnight.  Falls back to UTC if timezone is missing or invalid.
     # Note: uses s.config.timezone (the user's own timezone) as a best approximation.
     # For queries about a location in a different timezone, the date anchor may
-    # drift by up to one day around the location's local midnight; the 1 h TTL
-    # bounds any resulting stale-serve window.
+    # drift by up to one day around the location's local midnight; the configured
+    # forecast TTL bounds any resulting stale-serve window.
     # _now is an optional datetime used to override "now" in tests.
     if days_ahead >= 1:
         tz = _resolve_tz(timezone)
@@ -194,6 +192,9 @@ def process(user_input, route, s):
         raw_days_ahead = route.get('days_ahead', 0)
         if isinstance(raw_days_ahead, bool):
             logger.warning("Invalid days_ahead value %r in route; defaulting to 0", raw_days_ahead)
+            days_ahead = 0
+        elif isinstance(raw_days_ahead, float) and not raw_days_ahead.is_integer():
+            logger.warning("Non-integer float days_ahead %r in route; defaulting to 0", raw_days_ahead)
             days_ahead = 0
         else:
             try:

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -151,10 +151,11 @@ def _cache_key(location, unit, days_ahead=0, timezone=None, _now=None):
     # _now is an optional datetime used to override "now" in tests.
     if days_ahead >= 1:
         tz = _resolve_tz(timezone)
+        utc = datetime.timezone.utc
         if tz is not None:
             now = _now.astimezone(tz) if _now is not None else datetime.datetime.now(tz)
         else:
-            now = _now.astimezone(datetime.timezone.utc) if _now is not None else datetime.datetime.now(datetime.timezone.utc)
+            now = _now.astimezone(utc) if _now is not None else datetime.datetime.now(utc)
         today = now.date().isoformat()
         encoded = json.dumps([location, unit, days_ahead, today], separators=(",", ":"))
     else:
@@ -256,11 +257,8 @@ def process(user_input, route, s):
                 # Fetch returned an error dict or empty result — skip LLM on warmup, no caching
                 if refresh_only:
                     return None
-                response = s.ai.generate_response(
-                    user_input,
-                    f"You can answer questions about weather. This is the information of the weather the user asked: {str(forecast_slots)}\n",
-                )
-                return response.content
+                logger.warning("Forecast fetch failed or returned empty result: %s", forecast_slots)
+                return "Unable to fetch forecast data. Please try again later."
             else:
                 response = s.ai.generate_response(
                     user_input,
@@ -281,11 +279,8 @@ def process(user_input, route, s):
                 # Fetch returned an error dict — skip LLM on warmup, no caching
                 if refresh_only:
                     return None
-                response = s.ai.generate_response(
-                    user_input,
-                    f"You can answer questions about weather. This is the information of the weather the user asked: {str(current_weather)}\n",
-                )
-                return response.content
+                logger.warning("Current weather fetch failed: %s", current_weather)
+                return "Unable to fetch weather data. Please try again later."
 
         # Cache the full response text so future hits skip the LLM call entirely
         if response_text is not None and cache is not None:

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -107,8 +107,14 @@ class OpenWeatherReader:
 
 
 def _cache_key(location, unit, days_ahead=0):
-    # JSON-encode the triple to avoid collisions when location contains ':'.
-    encoded = json.dumps([location, unit, days_ahead], separators=(",", ":"))
+    # JSON-encode to avoid collisions when location contains ':'.
+    # Forecast keys include today's UTC date so a cached "tomorrow" entry is
+    # never served on a different calendar day after midnight.
+    if days_ahead >= 1:
+        today = datetime.date.today().isoformat()
+        encoded = json.dumps([location, unit, days_ahead, today], separators=(",", ":"))
+    else:
+        encoded = json.dumps([location, unit, days_ahead], separators=(",", ":"))
     return f"weather:{encoded}"
 
 

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -187,11 +187,16 @@ def process(user_input, route, s):
 
         location = route['location']
         unit = route['unit']
-        try:
-            days_ahead = int(route.get('days_ahead', 0))
-        except (TypeError, ValueError):
-            logger.warning("Invalid days_ahead value %r in route; defaulting to 0", route.get('days_ahead'))
+        raw_days_ahead = route.get('days_ahead', 0)
+        if isinstance(raw_days_ahead, bool):
+            logger.warning("Invalid days_ahead value %r in route; defaulting to 0", raw_days_ahead)
             days_ahead = 0
+        else:
+            try:
+                days_ahead = int(raw_days_ahead)
+            except (TypeError, ValueError):
+                logger.warning("Invalid days_ahead value %r in route; defaulting to 0", raw_days_ahead)
+                days_ahead = 0
 
         if days_ahead < 0:
             logger.warning("Negative days_ahead %d in route; defaulting to 0", days_ahead)

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -211,13 +211,13 @@ def process(user_input, route, s):
                 )
                 response_text = response.content
             else:
-                # Forecast fetch returned an error dict — generate a response without caching
+                # Forecast fetch returned an error dict — skip LLM on warmup, no caching
+                if refresh_only:
+                    return None
                 response = s.ai.generate_response(
                     user_input,
                     f"You can answer questions about weather. This is the information of the weather the user asked: {str(forecast_slots)}\n",
                 )
-                if refresh_only:
-                    return None
                 return response.content
         else:
             current_weather = weather.get_current_weather()
@@ -228,13 +228,13 @@ def process(user_input, route, s):
                 )
                 response_text = response.content
             else:
-                # Fetch returned an error dict — generate a response without caching
+                # Fetch returned an error dict — skip LLM on warmup, no caching
+                if refresh_only:
+                    return None
                 response = s.ai.generate_response(
                     user_input,
                     f"You can answer questions about weather. This is the information of the weather the user asked: {str(current_weather)}\n",
                 )
-                if refresh_only:
-                    return None
                 return response.content
 
         # Cache the full response text so future hits skip the LLM call entirely

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -96,8 +96,14 @@ class OpenWeatherReader:
             response.raise_for_status()
             data = response.json()
 
-            # Derive target date using the city's UTC offset (seconds east of UTC)
-            tz_offset_s = data.get("city", {}).get("timezone", 0)
+            # Derive target date using the city's UTC offset (seconds east of UTC).
+            # Coerce to int to guard against null or unexpected string values from the API.
+            raw_offset = data.get("city", {}).get("timezone", 0)
+            try:
+                tz_offset_s = int(raw_offset)
+            except (TypeError, ValueError):
+                logger.debug("Forecast: invalid city.timezone value %r; using UTC offset=0", raw_offset)
+                tz_offset_s = 0
             tz = datetime.timezone(datetime.timedelta(seconds=tz_offset_s))
             now_local = _now.astimezone(tz) if _now is not None else datetime.datetime.now(tz)
             target_date = (now_local + datetime.timedelta(days=days_ahead)).date()
@@ -148,7 +154,7 @@ def _cache_key(location, unit, days_ahead=0, timezone=None, _now=None):
         if tz is not None:
             now = _now.astimezone(tz) if _now is not None else datetime.datetime.now(tz)
         else:
-            now = _now if _now is not None else datetime.datetime.now(datetime.timezone.utc)
+            now = _now.astimezone(datetime.timezone.utc) if _now is not None else datetime.datetime.now(datetime.timezone.utc)
         today = now.date().isoformat()
         encoded = json.dumps([location, unit, days_ahead, today], separators=(",", ":"))
     else:
@@ -240,16 +246,9 @@ def process(user_input, route, s):
         response_text = None
         if days_ahead >= 1:
             forecast_slots = weather.get_forecast(days_ahead)
-            if "error" not in (forecast_slots if isinstance(forecast_slots, dict) else {}):
-                response = s.ai.generate_response(
-                    user_input,
-                    f"You can answer questions about weather forecasts. The user asked about weather "
-                    f"{days_ahead} day(s) from now. Here is the forecast data: {str(forecast_slots)}. "
-                    f"Summarize the expected conditions for that day in a natural, voice-friendly way.",
-                )
-                response_text = response.content
-            else:
-                # Forecast fetch returned an error dict — skip LLM on warmup, no caching
+            forecast_error = (isinstance(forecast_slots, dict) and "error" in forecast_slots) or not forecast_slots
+            if forecast_error:
+                # Fetch returned an error dict or empty result — skip LLM on warmup, no caching
                 if refresh_only:
                     return None
                 response = s.ai.generate_response(
@@ -257,6 +256,14 @@ def process(user_input, route, s):
                     f"You can answer questions about weather. This is the information of the weather the user asked: {str(forecast_slots)}\n",
                 )
                 return response.content
+            else:
+                response = s.ai.generate_response(
+                    user_input,
+                    f"You can answer questions about weather forecasts. The user asked about weather "
+                    f"{days_ahead} day(s) from now. Here is the forecast data: {str(forecast_slots)}. "
+                    f"Summarize the expected conditions for that day in a natural, voice-friendly way.",
+                )
+                response_text = response.content
         else:
             current_weather = weather.get_current_weather()
             if "error" not in current_weather:

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -106,12 +106,21 @@ class OpenWeatherReader:
             return {"error": "Forecast service unavailable"}
 
 
-def _cache_key(location, unit, days_ahead=0):
+def _cache_key(location, unit, days_ahead=0, timezone=None):
     # JSON-encode to avoid collisions when location contains ':'.
-    # Forecast keys include today's UTC date so a cached "tomorrow" entry is
-    # never served on a different calendar day after midnight.
+    # Forecast keys include today's local date (in the user's configured timezone)
+    # so a cached "tomorrow" entry is never served on a different calendar day
+    # after local midnight.  Falls back to UTC if timezone is missing or invalid.
     if days_ahead >= 1:
-        today = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+        if timezone:
+            try:
+                import zoneinfo
+                tz = zoneinfo.ZoneInfo(timezone)
+                today = datetime.datetime.now(tz).date().isoformat()
+            except Exception:
+                today = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+        else:
+            today = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
         encoded = json.dumps([location, unit, days_ahead, today], separators=(",", ":"))
     else:
         encoded = json.dumps([location, unit, days_ahead], separators=(",", ":"))
@@ -160,7 +169,7 @@ def process(user_input, route, s):
                 return None
             return "I can only forecast up to 5 days ahead."
         cache = getattr(s, 'cache', None)
-        cache_key = _cache_key(location, unit, days_ahead)
+        cache_key = _cache_key(location, unit, days_ahead, timezone=getattr(s.config, 'timezone', None))
 
         if days_ahead >= 1:
             ttl_s = route.get('ttl_s', s.config.cache_weather_forecast_ttl_s)

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -43,7 +43,7 @@ class OpenWeatherReader:
             )
             return {"error": "Weather service unavailable"}
 
-    def get_forecast(self, days_ahead):
+    def get_forecast(self, days_ahead, _now=None):
         """Fetch the 5-day/3-hour forecast and return slots matching today + days_ahead.
 
         Uses the city.timezone offset from the API response to convert each slot's
@@ -52,6 +52,8 @@ class OpenWeatherReader:
         Returns a list of forecast slot dicts.  Falls back to the full list if
         date-based filtering produces no matches.  Returns a dict with an "error"
         key on network/parse failure.
+
+        _now is an optional datetime (with tzinfo) used to override "now" in tests.
         """
         try:
             response = requests.get(
@@ -70,7 +72,7 @@ class OpenWeatherReader:
             # Derive target date using the city's UTC offset (seconds east of UTC)
             tz_offset_s = data.get("city", {}).get("timezone", 0)
             tz = datetime.timezone(datetime.timedelta(seconds=tz_offset_s))
-            now_local = datetime.datetime.now(tz)
+            now_local = _now.astimezone(tz) if _now is not None else datetime.datetime.now(tz)
             target_date = (now_local + datetime.timedelta(days=days_ahead)).date()
 
             slots = data.get("list", [])

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import os
@@ -15,12 +16,16 @@ class OpenWeatherReader:
         self.location = location
         self.unit = unit
         self.timeout = timeout
-        self.base_url = "https://api.openweathermap.org/data/2.5/weather?"
+        self.base_url = "https://api.openweathermap.org/data/2.5/weather"
+        self.forecast_url = "https://api.openweathermap.org/data/2.5/forecast"
 
     def get_current_weather(self):
         try:
-            url = f"{self.base_url}q={self.location}&appid={self.api_key}&units={self.unit}"
-            response = requests.get(url, timeout=self.timeout)
+            response = requests.get(
+                self.base_url,
+                params={"q": self.location, "appid": self.api_key, "units": self.unit},
+                timeout=self.timeout,
+            )
             response.raise_for_status()
             # not formatting the output, since the model can understand that
             return response.json()
@@ -38,10 +43,70 @@ class OpenWeatherReader:
             )
             return {"error": "Weather service unavailable"}
 
+    def get_forecast(self, days_ahead):
+        """Fetch the 5-day/3-hour forecast and return slots matching today + days_ahead.
 
-def _cache_key(location, unit):
-    # JSON-encode the pair to avoid collisions when location contains ':'.
-    encoded = json.dumps([location, unit], separators=(",", ":"))
+        Uses the city.timezone offset from the API response to convert each slot's
+        Unix timestamp to a local date, so the filtering is timezone-aware.
+
+        Returns a list of forecast slot dicts.  Falls back to the full list if
+        date-based filtering produces no matches.  Returns a dict with an "error"
+        key on network/parse failure.
+        """
+        try:
+            response = requests.get(
+                self.forecast_url,
+                params={
+                    "q": self.location,
+                    "appid": self.api_key,
+                    "units": self.unit,
+                    "cnt": 40,
+                },
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            # Derive target date using the city's UTC offset (seconds east of UTC)
+            tz_offset_s = data.get("city", {}).get("timezone", 0)
+            tz = datetime.timezone(datetime.timedelta(seconds=tz_offset_s))
+            now_local = datetime.datetime.now(tz)
+            target_date = (now_local + datetime.timedelta(days=days_ahead)).date()
+
+            slots = data.get("list", [])
+            filtered = [
+                slot for slot in slots
+                if datetime.datetime.fromtimestamp(slot["dt"], tz=tz).date() == target_date
+            ]
+
+            if filtered:
+                return filtered
+            # Graceful fallback: filtering produced nothing (e.g. target date is at edge
+            # of the 40-slot window), return everything so the LLM can still answer.
+            logger.debug(
+                "Forecast: no slots matched target date %s (tz_offset=%ds); returning full list",
+                target_date,
+                tz_offset_s,
+            )
+            return slots
+        except requests.exceptions.RequestException as e:
+            status = getattr(getattr(e, 'response', None), 'status_code', None)
+            if status is not None:
+                logger.error("Forecast API error: %s status=%d", type(e).__name__, status)
+            else:
+                logger.error("Forecast API error: %s", type(e).__name__)
+            return {"error": "Unable to fetch forecast data"}
+        except Exception as e:
+            logger.error(
+                "Forecast error: %s: %s", type(e).__name__, e,
+                exc_info=logger.isEnabledFor(logging.DEBUG),
+            )
+            return {"error": "Forecast service unavailable"}
+
+
+def _cache_key(location, unit, days_ahead=0):
+    # JSON-encode the triple to avoid collisions when location contains ':'.
+    encoded = json.dumps([location, unit, days_ahead], separators=(",", ":"))
     return f"weather:{encoded}"
 
 
@@ -70,11 +135,21 @@ def process(user_input, route, s):
 
         location = route['location']
         unit = route['unit']
+        days_ahead = int(route.get('days_ahead', 0))
+
+        if days_ahead > 5:
+            return "I can only forecast up to 5 days ahead."
+
         refresh_only = route.get('refresh_only', False)
         cache = getattr(s, 'cache', None)
-        cache_key = _cache_key(location, unit)
-        ttl_s = route.get('ttl_s', s.config.cache_weather_ttl_s)
-        max_stale_s = route.get('max_stale_s', s.config.cache_weather_max_stale_s)
+        cache_key = _cache_key(location, unit, days_ahead)
+
+        if days_ahead >= 1:
+            ttl_s = route.get('ttl_s', s.config.cache_weather_forecast_ttl_s)
+            max_stale_s = route.get('max_stale_s', s.config.cache_weather_forecast_max_stale_s)
+        else:
+            ttl_s = route.get('ttl_s', s.config.cache_weather_ttl_s)
+            max_stale_s = route.get('max_stale_s', s.config.cache_weather_max_stale_s)
 
         # Skip live fetch during warmup if the cached entry is still fresh
         if refresh_only and cache is not None:
@@ -105,28 +180,57 @@ def process(user_input, route, s):
 
         # Fetch live data
         weather = OpenWeatherReader(location, unit, s.config.api_timeout)
-        current_weather = weather.get_current_weather()
 
         response_text = None
-        if "error" not in current_weather:
-            response = s.ai.generate_response(
-                user_input,
-                f"You can answer questions about weather. This is the information of the weather the user asked: {str(current_weather)}. You are a voice bot, don't mention it, but keep the answer in an appropriate amount of words for such case. Also use correct punctuation, because your answer will be translated TTS. Don't overwhelm the user with a lot of information, they want to know how is the weather.\n",
-            )
-            response_text = response.content
+        if days_ahead >= 1:
+            forecast_slots = weather.get_forecast(days_ahead)
+            if "error" not in (forecast_slots if isinstance(forecast_slots, dict) else {}):
+                response = s.ai.generate_response(
+                    user_input,
+                    f"You can answer questions about weather forecasts. The user asked about weather "
+                    f"{days_ahead} day(s) from now. Here is the forecast data: {str(forecast_slots)}. "
+                    f"Summarize the expected conditions for that day in a natural, voice-friendly way.",
+                )
+                response_text = response.content
+            else:
+                # Forecast fetch returned an error dict — generate a response without caching
+                response = s.ai.generate_response(
+                    user_input,
+                    f"You can answer questions about weather. This is the information of the weather the user asked: {str(forecast_slots)}\n",
+                )
+                if refresh_only:
+                    return None
+                return response.content
+        else:
+            current_weather = weather.get_current_weather()
+            if "error" not in current_weather:
+                response = s.ai.generate_response(
+                    user_input,
+                    f"You can answer questions about weather. This is the information of the weather the user asked: {str(current_weather)}. You are a voice bot, don't mention it, but keep the answer in an appropriate amount of words for such case. Also use correct punctuation, because your answer will be translated TTS. Don't overwhelm the user with a lot of information, they want to know how is the weather.\n",
+                )
+                response_text = response.content
+            else:
+                # Fetch returned an error dict — generate a response without caching
+                response = s.ai.generate_response(
+                    user_input,
+                    f"You can answer questions about weather. This is the information of the weather the user asked: {str(current_weather)}\n",
+                )
+                if refresh_only:
+                    return None
+                return response.content
 
-            # Cache the full response text so future hits skip the LLM call entirely
-            if cache is not None:
-                try:
-                    cache.set(
-                        cache_key,
-                        response_text,
-                        ttl_s=ttl_s,
-                        max_stale_s=max_stale_s,
-                    )
-                    logger.debug("Weather cache updated: key=%r", cache_key)
-                except Exception as e:
-                    logger.warning("Weather cache write failed for key=%r: %s", cache_key, e)
+        # Cache the full response text so future hits skip the LLM call entirely
+        if response_text is not None and cache is not None:
+            try:
+                cache.set(
+                    cache_key,
+                    response_text,
+                    ttl_s=ttl_s,
+                    max_stale_s=max_stale_s,
+                )
+                logger.debug("Weather cache updated: key=%r", cache_key)
+            except Exception as e:
+                logger.warning("Weather cache write failed for key=%r: %s", cache_key, e)
 
         if refresh_only:
             return None
@@ -134,12 +238,7 @@ def process(user_input, route, s):
         if response_text is not None:
             return response_text
 
-        # Fetch returned an error dict — generate a response without caching
-        response = s.ai.generate_response(
-            user_input,
-            f"You can answer questions about weather. This is the information of the weather the user asked: {str(current_weather)}\n",
-        )
-        return response.content
+        return "Unable to fetch weather information. Please try again later."
     except ValueError as e:
         logger.error("Weather plugin configuration error: %s", e)
         if route.get('refresh_only', False):

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -19,6 +19,9 @@ def _resolve_tz(tz_name):
     """Return a ZoneInfo for tz_name, or None if unavailable or invalid."""
     if not tz_name or ZoneInfo is None:
         return None
+    tz_name = tz_name.strip()
+    if not tz_name:
+        return None
     if tz_name in _TZ_CACHE:
         return _TZ_CACHE[tz_name]
     try:

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -106,21 +106,29 @@ class OpenWeatherReader:
             return {"error": "Forecast service unavailable"}
 
 
-def _cache_key(location, unit, days_ahead=0, timezone=None):
+def _cache_key(location, unit, days_ahead=0, timezone=None, _now=None):
     # JSON-encode to avoid collisions when location contains ':'.
     # Forecast keys include today's local date (in the user's configured timezone)
     # so a cached "tomorrow" entry is never served on a different calendar day
     # after local midnight.  Falls back to UTC if timezone is missing or invalid.
+    # Note: uses s.config.timezone (the user's own timezone) as a best approximation.
+    # For queries about a location in a different timezone, the date anchor may
+    # drift by up to one day around the location's local midnight; the 1 h TTL
+    # bounds any resulting stale-serve window.
+    # _now is an optional datetime used to override "now" in tests.
     if days_ahead >= 1:
         if timezone:
             try:
                 import zoneinfo
                 tz = zoneinfo.ZoneInfo(timezone)
-                today = datetime.datetime.now(tz).date().isoformat()
+                now = _now.astimezone(tz) if _now is not None else datetime.datetime.now(tz)
+                today = now.date().isoformat()
             except Exception:
-                today = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+                fallback = _now if _now is not None else datetime.datetime.now(datetime.timezone.utc)
+                today = fallback.date().isoformat()
         else:
-            today = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+            fallback = _now if _now is not None else datetime.datetime.now(datetime.timezone.utc)
+            today = fallback.date().isoformat()
         encoded = json.dumps([location, unit, days_ahead, today], separators=(",", ":"))
     else:
         encoded = json.dumps([location, unit, days_ahead], separators=(",", ":"))

--- a/plugins/weather/plugin.yaml
+++ b/plugins/weather/plugin.yaml
@@ -2,21 +2,30 @@ name: weather
 version: 1.0.0
 
 route_description: >
-  The user is asking how the weather is or feels like, the user may or may not
-  mention what is the location. For example: "How is the weather outside now?"
-  The JSON answer must also include the keys location and unit. If no location
-  is defined, consider {{ location }}. Add a key "location" to the json with
-  the location. Convert the location to the following convention: City name,
-  state code (only for the US) and country code divided by comma. Also add a
-  key called "unit". The key unit, if not informed, is "metric" by default,
-  the other option is "imperial". Trim all spaces. Please use ISO 3166 country
-  codes. For example: Toronto,ON,CA. Example of result:
+  The user is asking about the weather, either current conditions or a future
+  date (e.g. "How is the weather outside now?", "Will it rain tomorrow?",
+  "What's the weather on Saturday?").
+  The JSON answer must include the keys location, unit, and days_ahead.
+  If no location is defined, consider {{ location }}. Add a key "location"
+  to the json with the location. Convert the location to the following
+  convention: City name, state code (only for the US) and country code
+  divided by comma. Also add a key called "unit". The key unit, if not
+  informed, is "metric" by default, the other option is "imperial". Trim
+  all spaces. Please use ISO 3166 country codes. For example: Toronto,ON,CA.
+  Add a key "days_ahead": set it to 0 (or omit it) for present-tense queries,
+  and set it to an integer from 1 to 5 for future-date queries (1 = tomorrow,
+  2 = day after tomorrow, etc.). Do not set days_ahead above 5.
+  Example of result for a current weather query:
   {"route": "weather", "reason": "The user asked for the weather",
-  "location": "Toronto,ON,CA", "unit": "metric"}
+  "location": "Toronto,ON,CA", "unit": "metric", "days_ahead": 0}
+  Example of result for a forecast query (tomorrow):
+  {"route": "weather", "reason": "The user asked about tomorrow's weather",
+  "location": "Toronto,ON,CA", "unit": "metric", "days_ahead": 1}
 
 route_extra_keys:
   - location
   - unit
+  - days_ahead
 
 env_vars:
   - OPENWEATHERMAP_API_KEY

--- a/plugins/weather/plugin.yaml
+++ b/plugins/weather/plugin.yaml
@@ -5,16 +5,16 @@ route_description: >
   The user is asking about the weather, either current conditions or a future
   date (e.g. "How is the weather outside now?", "Will it rain tomorrow?",
   "What's the weather on Saturday?").
-  The JSON answer must include the keys location, unit, and days_ahead.
   If no location is defined, consider {{ location }}. Add a key "location"
   to the json with the location. Convert the location to the following
   convention: City name, state code (only for the US) and country code
   divided by comma. Also add a key called "unit". The key unit, if not
   informed, is "metric" by default, the other option is "imperial". Trim
   all spaces. Please use ISO 3166 country codes. For example: Toronto,ON,CA.
-  Always include a key "days_ahead" with an integer value: use 0 for
-  present-tense queries, and 1 to 5 for future-date queries (1 = tomorrow,
-  2 = day after tomorrow, etc.). Do not set days_ahead above 5.
+  Always include a key "days_ahead" with an integer value: 0 for
+  present-tense queries (e.g. "what's the weather now?", "how is it outside?"),
+  and 1 to 5 for future-date queries (1 = tomorrow, 2 = day after tomorrow,
+  etc.). Do not set days_ahead above 5. days_ahead must always be present.
   Example of result for a current weather query:
   {"route": "weather", "reason": "The user asked for the weather",
   "location": "Toronto,ON,CA", "unit": "metric", "days_ahead": 0}

--- a/plugins/weather/plugin.yaml
+++ b/plugins/weather/plugin.yaml
@@ -12,8 +12,8 @@ route_description: >
   divided by comma. Also add a key called "unit". The key unit, if not
   informed, is "metric" by default, the other option is "imperial". Trim
   all spaces. Please use ISO 3166 country codes. For example: Toronto,ON,CA.
-  Add a key "days_ahead": set it to 0 (or omit it) for present-tense queries,
-  and set it to an integer from 1 to 5 for future-date queries (1 = tomorrow,
+  Always include a key "days_ahead" with an integer value: use 0 for
+  present-tense queries, and 1 to 5 for future-date queries (1 = tomorrow,
   2 = day after tomorrow, etc.). Do not set days_ahead above 5.
   Example of result for a current weather query:
   {"route": "weather", "reason": "The user asked for the weather",

--- a/routes.yaml
+++ b/routes.yaml
@@ -11,5 +11,3 @@ route_role: |
             default-route: General knowledge. No real time information required. For example: "What is the recipe for a Caipirinha?" or "How can I write a regex match in go?".
 
             technical: This is for general technical knowledge that does not depend on real time. Most technical questions should go here.
-
-            echo: This is route for testing the bot. The bot is going to repeat what the user said. For example: "Repeat this message."

--- a/routes.yaml
+++ b/routes.yaml
@@ -11,3 +11,5 @@ route_role: |
             default-route: General knowledge. No real time information required. For example: "What is the recipe for a Caipirinha?" or "How can I write a regex match in go?".
 
             technical: This is for general technical knowledge that does not depend on real time. Most technical questions should go here.
+
+            echo: This is route for testing the bot. The bot is going to repeat what the user said. For example: "Repeat this message."

--- a/routes.yaml
+++ b/routes.yaml
@@ -12,4 +12,4 @@ route_role: |
 
             technical: This is for general technical knowledge that does not depend on real time. Most technical questions should go here.
 
-            echo: This is route for testing the bot. The bot is going to repeat what the user said. For example: "Repeat this message."
+            echo: This is a route for testing the bot. The bot is going to repeat what the user said. For example: "Repeat this message."

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -514,6 +514,16 @@ class TestWeatherForecastProcess(unittest.TestCase):
         MockReader.return_value.get_current_weather.assert_called_once()
         MockReader.return_value.get_forecast.assert_not_called()
 
+    def test_days_ahead_bool_true_defaults_to_zero(self):
+        # bool is a subclass of int; True would cast to 1 and route to forecast path
+        s = _make_sandvoice(cache=None)
+        from plugins.weather import process
+        with patch('plugins.weather.plugin.OpenWeatherReader') as MockReader:
+            MockReader.return_value.get_current_weather.return_value = _WEATHER_DATA
+            process("weather", {"days_ahead": True}, s)
+        MockReader.return_value.get_current_weather.assert_called_once()
+        MockReader.return_value.get_forecast.assert_not_called()
+
     @patch('plugins.weather.plugin.OpenWeatherReader')
     def test_forecast_refresh_only_skips_llm_on_api_error(self, MockReader):
         # When refresh_only=True and the forecast API returns an error,

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -474,9 +474,11 @@ class TestWeatherForecastProcess(unittest.TestCase):
             cache_weather_forecast_max_stale_s=7200,
         )
         from plugins.weather import _cache_key as ck, process
+        # Compute expected_key before process() so both use the same UTC date
+        # (avoids a theoretical mismatch if the test straddles a UTC midnight).
+        expected_key = ck("London", "metric", 1)
         with patch.object(self.cache, 'set', wraps=self.cache.set) as mock_set:
             process("weather tomorrow", {"days_ahead": 1}, s)
-        expected_key = ck("London", "metric", 1)
         mock_set.assert_called_once_with(
             expected_key,
             "It is 20°C in London.",
@@ -490,10 +492,11 @@ class TestWeatherForecastProcess(unittest.TestCase):
         MockReader.return_value.get_forecast.return_value = forecast_slots
         s = _make_sandvoice(cache=self.cache)
         from plugins.weather import _cache_key as ck, process
+        # Compute expected_key before process() so both use the same UTC date.
+        expected_key = ck("London", "metric", 1)
         with patch.object(self.cache, 'get', wraps=self.cache.get) as mock_get, \
              patch.object(self.cache, 'set', wraps=self.cache.set) as mock_set:
             process("weather tomorrow", {"days_ahead": 1}, s)
-        expected_key = ck("London", "metric", 1)
         mock_get.assert_called_with(expected_key)
         mock_set.assert_called_once()
         call_args = mock_set.call_args
@@ -606,7 +609,7 @@ class TestGetForecast(unittest.TestCase):
 
     @patch('plugins.weather.plugin.requests.get')
     def test_get_forecast_returns_error_on_request_exception(self, mock_get):
-        mock_get.side_effect = ConnectionError("network down")
+        mock_get.side_effect = req_lib.exceptions.ConnectionError("network down")
         from plugins.weather import OpenWeatherReader
         reader = OpenWeatherReader("London", "metric", timeout=5)
         result = reader.get_forecast(1)

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -572,18 +572,18 @@ class TestWeatherForecastProcess(unittest.TestCase):
             cache_weather_forecast_ttl_s=3600,
             cache_weather_forecast_max_stale_s=7200,
         )
-        from plugins.weather import _cache_key as ck, process
-        # Compute expected_key before process() so both use the same local date
-        # (avoids a theoretical mismatch if the test straddles midnight).
-        expected_key = ck("London", "metric", 1, timezone="UTC")
+        from plugins.weather import process
         with patch.object(self.cache, 'set', wraps=self.cache.set) as mock_set:
             process("weather tomorrow", {"days_ahead": 1}, s)
-        mock_set.assert_called_once_with(
-            expected_key,
-            "It is 20°C in London.",
-            ttl_s=s.config.cache_weather_forecast_ttl_s,
-            max_stale_s=s.config.cache_weather_forecast_max_stale_s,
-        )
+        mock_set.assert_called_once()
+        call_key, call_value = mock_set.call_args[0]
+        call_kwargs = mock_set.call_args[1]
+        # Key must be a forecast key: starts with "weather:" and embeds a date
+        self.assertTrue(call_key.startswith("weather:"))
+        self.assertRegex(call_key, r'\d{4}-\d{2}-\d{2}')
+        self.assertEqual(call_value, "It is 20°C in London.")
+        self.assertEqual(call_kwargs['ttl_s'], s.config.cache_weather_forecast_ttl_s)
+        self.assertEqual(call_kwargs['max_stale_s'], s.config.cache_weather_forecast_max_stale_s)
 
     @patch('plugins.weather.plugin.OpenWeatherReader')
     def test_forecast_cache_key_includes_days_ahead(self, MockReader):
@@ -591,15 +591,18 @@ class TestWeatherForecastProcess(unittest.TestCase):
         MockReader.return_value.get_forecast.return_value = forecast_slots
         s = _make_sandvoice(cache=self.cache)
         from plugins.weather import _cache_key as ck, process
-        # Compute expected_key before process() so both use the same local date.
-        expected_key = ck("London", "metric", 1, timezone="UTC")
         with patch.object(self.cache, 'get', wraps=self.cache.get) as mock_get, \
              patch.object(self.cache, 'set', wraps=self.cache.set) as mock_set:
             process("weather tomorrow", {"days_ahead": 1}, s)
-        mock_get.assert_called_with(expected_key)
         mock_set.assert_called_once()
-        call_args = mock_set.call_args
-        self.assertEqual(call_args[0][0], expected_key)
+        used_key = mock_set.call_args[0][0]
+        # Forecast key must embed a date so it rotates at local midnight
+        self.assertRegex(used_key, r'\d{4}-\d{2}-\d{2}')
+        # Must differ from the current-weather key (days_ahead=0 has no date)
+        current_key = ck("London", "metric", 0)
+        self.assertNotEqual(used_key, current_key)
+        # cache.get must have been called with the same key that was written
+        mock_get.assert_called_with(used_key)
 
 
 class TestGetForecast(unittest.TestCase):

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -511,13 +511,12 @@ class TestGetForecast(unittest.TestCase):
     @patch('plugins.weather.plugin.requests.get')
     def test_get_forecast_filters_by_target_date(self, mock_get):
         import datetime as dt_mod
-        # Use UTC (tz_offset=0) for simplicity
+        # Use UTC (tz_offset=0) for simplicity; build timestamps relative to real now
         tz = dt_mod.timezone.utc
         now = dt_mod.datetime.now(tz)
-        tomorrow = now + dt_mod.timedelta(days=1)
 
         # Slot on tomorrow at noon UTC
-        tomorrow_noon = tomorrow.replace(hour=12, minute=0, second=0, microsecond=0)
+        tomorrow_noon = (now + dt_mod.timedelta(days=1)).replace(hour=12, minute=0, second=0, microsecond=0)
         # Slot on the day after tomorrow at noon UTC
         day_after = (now + dt_mod.timedelta(days=2)).replace(hour=12, minute=0, second=0, microsecond=0)
 
@@ -542,8 +541,8 @@ class TestGetForecast(unittest.TestCase):
         import datetime as dt_mod
         tz = dt_mod.timezone.utc
         now = dt_mod.datetime.now(tz)
-        # All slots are on today, not tomorrow — filtering for days_ahead=1 should return nothing,
-        # triggering the fallback
+
+        # Slot is today at noon UTC; filtering for days_ahead=5 finds nothing → full-list fallback
         today_noon = now.replace(hour=12, minute=0, second=0, microsecond=0)
         slot = self._make_slot(int(today_noon.timestamp()))
         payload = self._make_forecast_payload([slot], tz_offset=0)

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -440,9 +440,13 @@ class TestCacheKeyForecast(unittest.TestCase):
         from plugins.weather import _cache_key
         utc = dt_mod.timezone.utc
         fixed_now = dt_mod.datetime(2026, 5, 31, 12, 0, 0, tzinfo=utc)
-        key_invalid = _cache_key("London", "metric", 1, timezone="NOT_A_TZ", _now=fixed_now)
+        with patch('plugins.weather.plugin.logger') as mock_logger:
+            key_invalid = _cache_key("London", "metric", 1, timezone="NOT_A_TZ", _now=fixed_now)
         key_utc = _cache_key("London", "metric", 1, timezone="UTC", _now=fixed_now)
         self.assertEqual(key_invalid, key_utc)
+        # Invalid timezone must log a warning so misconfiguration is visible
+        warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
+        self.assertTrue(any("NOT_A_TZ" in c for c in warning_calls))
 
     def test_cache_key_zero_differs_from_legacy(self):
         from plugins.weather import _cache_key

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -438,6 +438,13 @@ class TestCacheKeyForecast(unittest.TestCase):
         self.assertIn("2026-05-31", key_utc)
         self.assertIn("2026-06-01", key_plus12)
 
+    def test_resolve_tz_non_string_timezone_returns_none(self):
+        # If config.timezone is a non-string (e.g. YAML number), _resolve_tz must not raise
+        from plugins.weather.plugin import _resolve_tz
+        self.assertIsNone(_resolve_tz(123))
+        self.assertIsNone(_resolve_tz(True))
+        self.assertIsNone(_resolve_tz(None))
+
     def test_forecast_cache_key_invalid_timezone_falls_back_to_utc(self):
         import datetime as dt_mod
         from plugins.weather import _cache_key
@@ -523,6 +530,16 @@ class TestWeatherForecastProcess(unittest.TestCase):
         with patch('plugins.weather.plugin.OpenWeatherReader') as MockReader:
             MockReader.return_value.get_current_weather.return_value = _WEATHER_DATA
             process("weather", {"days_ahead": True}, s)
+        MockReader.return_value.get_current_weather.assert_called_once()
+        MockReader.return_value.get_forecast.assert_not_called()
+
+    def test_days_ahead_non_integer_float_defaults_to_zero(self):
+        # Non-integer floats (e.g. 1.9) must not silently truncate to 1 and hit the forecast path
+        s = _make_sandvoice(cache=None)
+        from plugins.weather import process
+        with patch('plugins.weather.plugin.OpenWeatherReader') as MockReader:
+            MockReader.return_value.get_current_weather.return_value = _WEATHER_DATA
+            process("weather", {"days_ahead": 1.9}, s)
         MockReader.return_value.get_current_weather.assert_called_once()
         MockReader.return_value.get_forecast.assert_not_called()
 

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -456,6 +456,17 @@ class TestWeatherForecastProcess(unittest.TestCase):
         self.assertIn("5 days", result)
 
     @patch('plugins.weather.plugin.OpenWeatherReader')
+    def test_forecast_refresh_only_skips_llm_on_api_error(self, MockReader):
+        # When refresh_only=True and the forecast API returns an error,
+        # process() must return None without calling the LLM.
+        MockReader.return_value.get_forecast.return_value = {"error": "network down"}
+        s = _make_sandvoice(cache=None)
+        from plugins.weather import process
+        result = process("weather tomorrow", {"days_ahead": 1, "refresh_only": True}, s)
+        self.assertIsNone(result)
+        s.ai.generate_response.assert_not_called()
+
+    @patch('plugins.weather.plugin.OpenWeatherReader')
     def test_forecast_called_when_days_ahead_1(self, MockReader):
         forecast_slots = [{"dt": 1700000000, "main": {"temp": 15}, "weather": [{"description": "rain"}]}]
         MockReader.return_value.get_forecast.return_value = forecast_slots

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -232,8 +232,10 @@ class TestWeatherPluginWithCache(unittest.TestCase):
         MockReader.return_value.get_current_weather.return_value = {"error": "bad"}
         s = _make_sandvoice(cache=self.cache)
         from plugins.weather import process
-        process("weather", {}, s)
-        s.ai.generate_response.assert_called_once()
+        result = process("weather", {}, s)
+        # Error path skips LLM and returns deterministic message
+        s.ai.generate_response.assert_not_called()
+        self.assertIn("Unable to fetch", result)
         self.assertIsNone(self.cache.get(_CACHE_KEY))
 
     @patch('plugins.weather.plugin.OpenWeatherReader')

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -425,16 +425,15 @@ class TestCacheKeyForecast(unittest.TestCase):
         self.assertNotEqual(new_key, legacy_key)
 
     def test_forecast_cache_key_includes_date(self):
-        # Forecast keys must embed today's UTC date so cached "tomorrow" entries
-        # are not served after midnight when the target day has shifted.
-        import datetime as dt_mod
+        # Forecast keys must embed a UTC date (YYYY-MM-DD) so a cached "tomorrow"
+        # entry is never served on a different calendar day after midnight.
+        import re
         from plugins.weather import _cache_key
-        today = dt_mod.date.today().isoformat()
         key = _cache_key("London", "metric", 1)
-        self.assertIn(today, key)
-        # Current-weather key must NOT include a date (no cross-day issue).
+        self.assertRegex(key, r'\d{4}-\d{2}-\d{2}', "forecast key should contain a date")
+        # Current-weather key must NOT include a date (no cross-day issue for point-in-time data).
         key0 = _cache_key("London", "metric", 0)
-        self.assertNotIn(today, key0)
+        self.assertNotRegex(key0, r'\d{4}-\d{2}-\d{2}')
 
 
 class TestWeatherForecastProcess(unittest.TestCase):
@@ -571,6 +570,39 @@ class TestGetForecast(unittest.TestCase):
         # Request days_ahead=5; slot is today so filtering finds nothing → full list returned
         result = reader.get_forecast(5, _now=fixed_now)
         self.assertEqual(result, [slot])
+
+    @patch('plugins.weather.plugin.requests.get')
+    def test_get_forecast_filters_by_local_date_non_utc_offset(self, mock_get):
+        # Validate timezone-aware filtering with a non-zero city.timezone offset.
+        # tz_offset = +36000s (UTC+10, e.g. Sydney).
+        # _now is 2026-06-01 22:00 UTC = 2026-06-02 08:00 local.
+        # days_ahead=1 → target local date = 2026-06-03.
+        import datetime as dt_mod
+        utc = dt_mod.timezone.utc
+        fixed_now_utc = dt_mod.datetime(2026, 6, 1, 22, 0, 0, tzinfo=utc)
+        tz_offset_s = 36000  # UTC+10
+        local_tz = dt_mod.timezone(dt_mod.timedelta(seconds=tz_offset_s))
+
+        # Slot on 2026-06-03 local (2026-06-02 14:00 UTC) — should be included
+        target_local = dt_mod.datetime(2026, 6, 3, 10, 0, 0, tzinfo=local_tz)
+        match_slot = self._make_slot(int(target_local.timestamp()), temp=22, desc="sunny")
+        # Slot on 2026-06-02 local (today) — should be excluded
+        today_local = dt_mod.datetime(2026, 6, 2, 10, 0, 0, tzinfo=local_tz)
+        other_slot = self._make_slot(int(today_local.timestamp()), temp=15, desc="cloudy")
+
+        payload = self._make_forecast_payload([match_slot, other_slot], tz_offset=tz_offset_s)
+
+        mock_resp = Mock()
+        mock_resp.json.return_value = payload
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        from plugins.weather import OpenWeatherReader
+        reader = OpenWeatherReader("Sydney,AU", "metric", timeout=5)
+        result = reader.get_forecast(1, _now=fixed_now_utc)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["dt"], match_slot["dt"])
 
     @patch('plugins.weather.plugin.requests.get')
     def test_get_forecast_returns_error_on_request_exception(self, mock_get):

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -511,14 +511,14 @@ class TestGetForecast(unittest.TestCase):
     @patch('plugins.weather.plugin.requests.get')
     def test_get_forecast_filters_by_target_date(self, mock_get):
         import datetime as dt_mod
-        # Use UTC (tz_offset=0) for simplicity; build timestamps relative to real now
+        # Freeze "now" via _now injection to avoid midnight flakiness
         tz = dt_mod.timezone.utc
-        now = dt_mod.datetime.now(tz)
+        fixed_now = dt_mod.datetime(2026, 6, 1, 10, 0, 0, tzinfo=tz)
 
         # Slot on tomorrow at noon UTC
-        tomorrow_noon = (now + dt_mod.timedelta(days=1)).replace(hour=12, minute=0, second=0, microsecond=0)
+        tomorrow_noon = (fixed_now + dt_mod.timedelta(days=1)).replace(hour=12, minute=0, second=0, microsecond=0)
         # Slot on the day after tomorrow at noon UTC
-        day_after = (now + dt_mod.timedelta(days=2)).replace(hour=12, minute=0, second=0, microsecond=0)
+        day_after = (fixed_now + dt_mod.timedelta(days=2)).replace(hour=12, minute=0, second=0, microsecond=0)
 
         tomorrow_slot = self._make_slot(int(tomorrow_noon.timestamp()), temp=10, desc="rain")
         other_slot = self._make_slot(int(day_after.timestamp()), temp=20, desc="sunny")
@@ -531,7 +531,7 @@ class TestGetForecast(unittest.TestCase):
 
         from plugins.weather import OpenWeatherReader
         reader = OpenWeatherReader("London", "metric", timeout=5)
-        result = reader.get_forecast(1)
+        result = reader.get_forecast(1, _now=fixed_now)
 
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["dt"], tomorrow_slot["dt"])
@@ -539,11 +539,13 @@ class TestGetForecast(unittest.TestCase):
     @patch('plugins.weather.plugin.requests.get')
     def test_get_forecast_falls_back_to_full_list_if_no_match(self, mock_get):
         import datetime as dt_mod
+        # Freeze "now" via _now injection to avoid midnight flakiness
         tz = dt_mod.timezone.utc
-        now = dt_mod.datetime.now(tz)
+        fixed_now = dt_mod.datetime(2026, 6, 1, 10, 0, 0, tzinfo=tz)
 
-        # Slot is today at noon UTC; filtering for days_ahead=5 finds nothing → full-list fallback
-        today_noon = now.replace(hour=12, minute=0, second=0, microsecond=0)
+        # Slot is on fixed_now's date (2026-06-01); filtering for days_ahead=5
+        # finds nothing (target = 2026-06-06) → full-list fallback
+        today_noon = fixed_now.replace(hour=12, minute=0, second=0, microsecond=0)
         slot = self._make_slot(int(today_noon.timestamp()))
         payload = self._make_forecast_payload([slot], tz_offset=0)
 
@@ -555,7 +557,7 @@ class TestGetForecast(unittest.TestCase):
         from plugins.weather import OpenWeatherReader
         reader = OpenWeatherReader("London", "metric", timeout=5)
         # Request days_ahead=5; slot is today so filtering finds nothing → full list returned
-        result = reader.get_forecast(5)
+        result = reader.get_forecast(5, _now=fixed_now)
         self.assertEqual(result, [slot])
 
     @patch('plugins.weather.plugin.requests.get')

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -16,7 +16,9 @@ _CACHE_KEY = _cache_key("London", "metric")
 
 def _make_sandvoice(cache=None, debug=False, location="London", unit="metric",
                     api_timeout=10, cache_weather_ttl_s=10800,
-                    cache_weather_max_stale_s=21600):
+                    cache_weather_max_stale_s=21600,
+                    cache_weather_forecast_ttl_s=3600,
+                    cache_weather_forecast_max_stale_s=7200):
     """Build a minimal SandVoice-like mock for weather plugin tests."""
     s = MagicMock()
     s.config.debug = debug
@@ -25,6 +27,8 @@ def _make_sandvoice(cache=None, debug=False, location="London", unit="metric",
     s.config.api_timeout = api_timeout
     s.config.cache_weather_ttl_s = cache_weather_ttl_s
     s.config.cache_weather_max_stale_s = cache_weather_max_stale_s
+    s.config.cache_weather_forecast_ttl_s = cache_weather_forecast_ttl_s
+    s.config.cache_weather_forecast_max_stale_s = cache_weather_forecast_max_stale_s
     s.cache = cache
 
     # ai.generate_response returns an object with .content
@@ -402,4 +406,163 @@ class TestOpenWeatherReader(unittest.TestCase):
         from plugins.weather import OpenWeatherReader
         reader = OpenWeatherReader("London", "metric", timeout=5)
         result = reader.get_current_weather()
+        self.assertIn("error", result)
+
+
+class TestCacheKeyForecast(unittest.TestCase):
+    """Tests for _cache_key with days_ahead parameter."""
+
+    def test_cache_key_includes_days_ahead(self):
+        from plugins.weather import _cache_key
+        key0 = _cache_key("London", "metric", 0)
+        key2 = _cache_key("London", "metric", 2)
+        self.assertNotEqual(key0, key2)
+
+    def test_cache_key_zero_differs_from_legacy(self):
+        from plugins.weather import _cache_key
+        new_key = _cache_key("London", "metric", 0)
+        legacy_key = 'weather:["London","metric"]'
+        self.assertNotEqual(new_key, legacy_key)
+
+
+class TestWeatherForecastProcess(unittest.TestCase):
+    """Tests for forecast code paths in process()."""
+
+    def setUp(self):
+        os.environ['OPENWEATHERMAP_API_KEY'] = 'test-key'
+        self.tmp = tempfile.mkdtemp()
+        self.cache = VoiceCache(os.path.join(self.tmp, "cache.db"))
+
+    def tearDown(self):
+        os.environ.pop('OPENWEATHERMAP_API_KEY', None)
+        self.cache.close()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_days_ahead_gt_5_returns_friendly_message(self):
+        s = _make_sandvoice(cache=None)
+        from plugins.weather import process
+        result = process("weather saturday", {"days_ahead": 6}, s)
+        self.assertIn("5 days", result)
+
+    @patch('plugins.weather.plugin.OpenWeatherReader')
+    def test_forecast_called_when_days_ahead_1(self, MockReader):
+        forecast_slots = [{"dt": 1700000000, "main": {"temp": 15}, "weather": [{"description": "rain"}]}]
+        MockReader.return_value.get_forecast.return_value = forecast_slots
+        s = _make_sandvoice(cache=None)
+        from plugins.weather import process
+        process("weather tomorrow", {"days_ahead": 1}, s)
+        MockReader.return_value.get_forecast.assert_called_once_with(1)
+
+    @patch('plugins.weather.plugin.OpenWeatherReader')
+    def test_forecast_uses_forecast_ttl_config(self, MockReader):
+        forecast_slots = [{"dt": 1700000000, "main": {"temp": 15}}]
+        MockReader.return_value.get_forecast.return_value = forecast_slots
+        s = _make_sandvoice(
+            cache=self.cache,
+            cache_weather_forecast_ttl_s=3600,
+            cache_weather_forecast_max_stale_s=7200,
+        )
+        from plugins.weather import _cache_key as ck, process
+        with patch.object(self.cache, 'set', wraps=self.cache.set) as mock_set:
+            process("weather tomorrow", {"days_ahead": 1}, s)
+        expected_key = ck("London", "metric", 1)
+        mock_set.assert_called_once_with(
+            expected_key,
+            "It is 20°C in London.",
+            ttl_s=s.config.cache_weather_forecast_ttl_s,
+            max_stale_s=s.config.cache_weather_forecast_max_stale_s,
+        )
+
+    @patch('plugins.weather.plugin.OpenWeatherReader')
+    def test_forecast_cache_key_includes_days_ahead(self, MockReader):
+        forecast_slots = [{"dt": 1700000000, "main": {"temp": 15}}]
+        MockReader.return_value.get_forecast.return_value = forecast_slots
+        s = _make_sandvoice(cache=self.cache)
+        from plugins.weather import _cache_key as ck, process
+        with patch.object(self.cache, 'get', wraps=self.cache.get) as mock_get, \
+             patch.object(self.cache, 'set', wraps=self.cache.set) as mock_set:
+            process("weather tomorrow", {"days_ahead": 1}, s)
+        expected_key = ck("London", "metric", 1)
+        mock_get.assert_called_with(expected_key)
+        mock_set.assert_called_once()
+        call_args = mock_set.call_args
+        self.assertEqual(call_args[0][0], expected_key)
+
+
+class TestGetForecast(unittest.TestCase):
+    """Unit tests for OpenWeatherReader.get_forecast()."""
+
+    def setUp(self):
+        os.environ['OPENWEATHERMAP_API_KEY'] = 'test-key'
+
+    def tearDown(self):
+        os.environ.pop('OPENWEATHERMAP_API_KEY', None)
+
+    def _make_forecast_payload(self, slots, tz_offset=0):
+        """Build a minimal forecast API response payload."""
+        return {
+            "city": {"name": "London", "timezone": tz_offset},
+            "list": slots,
+        }
+
+    def _make_slot(self, dt_unix, temp=15, desc="cloudy"):
+        return {"dt": dt_unix, "main": {"temp": temp}, "weather": [{"description": desc}]}
+
+    @patch('plugins.weather.plugin.requests.get')
+    def test_get_forecast_filters_by_target_date(self, mock_get):
+        import datetime as dt_mod
+        # Use UTC (tz_offset=0) for simplicity
+        tz = dt_mod.timezone.utc
+        now = dt_mod.datetime.now(tz)
+        tomorrow = now + dt_mod.timedelta(days=1)
+
+        # Slot on tomorrow at noon UTC
+        tomorrow_noon = tomorrow.replace(hour=12, minute=0, second=0, microsecond=0)
+        # Slot on the day after tomorrow at noon UTC
+        day_after = (now + dt_mod.timedelta(days=2)).replace(hour=12, minute=0, second=0, microsecond=0)
+
+        tomorrow_slot = self._make_slot(int(tomorrow_noon.timestamp()), temp=10, desc="rain")
+        other_slot = self._make_slot(int(day_after.timestamp()), temp=20, desc="sunny")
+        payload = self._make_forecast_payload([tomorrow_slot, other_slot], tz_offset=0)
+
+        mock_resp = Mock()
+        mock_resp.json.return_value = payload
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        from plugins.weather import OpenWeatherReader
+        reader = OpenWeatherReader("London", "metric", timeout=5)
+        result = reader.get_forecast(1)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["dt"], tomorrow_slot["dt"])
+
+    @patch('plugins.weather.plugin.requests.get')
+    def test_get_forecast_falls_back_to_full_list_if_no_match(self, mock_get):
+        import datetime as dt_mod
+        tz = dt_mod.timezone.utc
+        now = dt_mod.datetime.now(tz)
+        # All slots are on today, not tomorrow — filtering for days_ahead=1 should return nothing,
+        # triggering the fallback
+        today_noon = now.replace(hour=12, minute=0, second=0, microsecond=0)
+        slot = self._make_slot(int(today_noon.timestamp()))
+        payload = self._make_forecast_payload([slot], tz_offset=0)
+
+        mock_resp = Mock()
+        mock_resp.json.return_value = payload
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        from plugins.weather import OpenWeatherReader
+        reader = OpenWeatherReader("London", "metric", timeout=5)
+        # Request days_ahead=5; slot is today so filtering finds nothing → full list returned
+        result = reader.get_forecast(5)
+        self.assertEqual(result, [slot])
+
+    @patch('plugins.weather.plugin.requests.get')
+    def test_get_forecast_returns_error_on_request_exception(self, mock_get):
+        mock_get.side_effect = ConnectionError("network down")
+        from plugins.weather import OpenWeatherReader
+        reader = OpenWeatherReader("London", "metric", timeout=5)
+        result = reader.get_forecast(1)
         self.assertIn("error", result)

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -18,7 +18,8 @@ def _make_sandvoice(cache=None, debug=False, location="London", unit="metric",
                     api_timeout=10, cache_weather_ttl_s=10800,
                     cache_weather_max_stale_s=21600,
                     cache_weather_forecast_ttl_s=3600,
-                    cache_weather_forecast_max_stale_s=7200):
+                    cache_weather_forecast_max_stale_s=7200,
+                    timezone="UTC"):
     """Build a minimal SandVoice-like mock for weather plugin tests."""
     s = MagicMock()
     s.config.debug = debug
@@ -29,6 +30,7 @@ def _make_sandvoice(cache=None, debug=False, location="London", unit="metric",
     s.config.cache_weather_max_stale_s = cache_weather_max_stale_s
     s.config.cache_weather_forecast_ttl_s = cache_weather_forecast_ttl_s
     s.config.cache_weather_forecast_max_stale_s = cache_weather_forecast_max_stale_s
+    s.config.timezone = timezone
     s.cache = cache
 
     # ai.generate_response returns an object with .content
@@ -418,6 +420,24 @@ class TestCacheKeyForecast(unittest.TestCase):
         key2 = _cache_key("London", "metric", 2)
         self.assertNotEqual(key0, key2)
 
+    def test_forecast_cache_key_uses_user_timezone(self):
+        # Keys for the same location/unit/days_ahead but different timezones should
+        # differ when the local dates differ (e.g. UTC-12 vs UTC+12 around midnight).
+        from plugins.weather import _cache_key
+        key_utc = _cache_key("London", "metric", 1, timezone="UTC")
+        key_no_tz = _cache_key("London", "metric", 1)
+        # Both should contain a date
+        import re
+        self.assertRegex(key_utc, r'\d{4}-\d{2}-\d{2}')
+        # Without timezone falls back to UTC, so keys are equal
+        self.assertEqual(key_utc, key_no_tz)
+
+    def test_forecast_cache_key_invalid_timezone_falls_back_to_utc(self):
+        from plugins.weather import _cache_key
+        key_invalid = _cache_key("London", "metric", 1, timezone="NOT_A_TZ")
+        key_utc = _cache_key("London", "metric", 1, timezone="UTC")
+        self.assertEqual(key_invalid, key_utc)
+
     def test_cache_key_zero_differs_from_legacy(self):
         from plugins.weather import _cache_key
         new_key = _cache_key("London", "metric", 0)
@@ -425,11 +445,11 @@ class TestCacheKeyForecast(unittest.TestCase):
         self.assertNotEqual(new_key, legacy_key)
 
     def test_forecast_cache_key_includes_date(self):
-        # Forecast keys must embed a UTC date (YYYY-MM-DD) so a cached "tomorrow"
-        # entry is never served on a different calendar day after midnight.
+        # Forecast keys must embed a date (YYYY-MM-DD) so a cached "tomorrow"
+        # entry is never served on a different calendar day after local midnight.
         import re
         from plugins.weather import _cache_key
-        key = _cache_key("London", "metric", 1)
+        key = _cache_key("London", "metric", 1, timezone="UTC")
         self.assertRegex(key, r'\d{4}-\d{2}-\d{2}', "forecast key should contain a date")
         # Current-weather key must NOT include a date (no cross-day issue for point-in-time data).
         key0 = _cache_key("London", "metric", 0)
@@ -485,9 +505,9 @@ class TestWeatherForecastProcess(unittest.TestCase):
             cache_weather_forecast_max_stale_s=7200,
         )
         from plugins.weather import _cache_key as ck, process
-        # Compute expected_key before process() so both use the same UTC date
-        # (avoids a theoretical mismatch if the test straddles a UTC midnight).
-        expected_key = ck("London", "metric", 1)
+        # Compute expected_key before process() so both use the same local date
+        # (avoids a theoretical mismatch if the test straddles midnight).
+        expected_key = ck("London", "metric", 1, timezone="UTC")
         with patch.object(self.cache, 'set', wraps=self.cache.set) as mock_set:
             process("weather tomorrow", {"days_ahead": 1}, s)
         mock_set.assert_called_once_with(
@@ -503,8 +523,8 @@ class TestWeatherForecastProcess(unittest.TestCase):
         MockReader.return_value.get_forecast.return_value = forecast_slots
         s = _make_sandvoice(cache=self.cache)
         from plugins.weather import _cache_key as ck, process
-        # Compute expected_key before process() so both use the same UTC date.
-        expected_key = ck("London", "metric", 1)
+        # Compute expected_key before process() so both use the same local date.
+        expected_key = ck("London", "metric", 1, timezone="UTC")
         with patch.object(self.cache, 'get', wraps=self.cache.get) as mock_get, \
              patch.object(self.cache, 'set', wraps=self.cache.set) as mock_set:
             process("weather tomorrow", {"days_ahead": 1}, s)

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -421,21 +421,27 @@ class TestCacheKeyForecast(unittest.TestCase):
         self.assertNotEqual(key0, key2)
 
     def test_forecast_cache_key_uses_user_timezone(self):
-        # Keys for the same location/unit/days_ahead but different timezones should
-        # differ when the local dates differ (e.g. UTC-12 vs UTC+12 around midnight).
+        # At 23:30 UTC, UTC+12 is already the next calendar day.
+        # Keys for the same location/days_ahead but different timezones must differ.
+        import datetime as dt_mod
         from plugins.weather import _cache_key
-        key_utc = _cache_key("London", "metric", 1, timezone="UTC")
-        key_no_tz = _cache_key("London", "metric", 1)
-        # Both should contain a date
-        import re
-        self.assertRegex(key_utc, r'\d{4}-\d{2}-\d{2}')
-        # Without timezone falls back to UTC, so keys are equal
-        self.assertEqual(key_utc, key_no_tz)
+        utc = dt_mod.timezone.utc
+        # 2026-05-31 23:30 UTC = 2026-06-01 11:30 in UTC+12 (Etc/GMT-12)
+        fixed_now = dt_mod.datetime(2026, 5, 31, 23, 30, 0, tzinfo=utc)
+        key_utc = _cache_key("London", "metric", 1, timezone="UTC", _now=fixed_now)
+        key_plus12 = _cache_key("London", "metric", 1, timezone="Etc/GMT-12", _now=fixed_now)
+        # UTC is still 2026-05-31; UTC+12 is already 2026-06-01 — keys must differ
+        self.assertNotEqual(key_utc, key_plus12)
+        self.assertIn("2026-05-31", key_utc)
+        self.assertIn("2026-06-01", key_plus12)
 
     def test_forecast_cache_key_invalid_timezone_falls_back_to_utc(self):
+        import datetime as dt_mod
         from plugins.weather import _cache_key
-        key_invalid = _cache_key("London", "metric", 1, timezone="NOT_A_TZ")
-        key_utc = _cache_key("London", "metric", 1, timezone="UTC")
+        utc = dt_mod.timezone.utc
+        fixed_now = dt_mod.datetime(2026, 5, 31, 12, 0, 0, tzinfo=utc)
+        key_invalid = _cache_key("London", "metric", 1, timezone="NOT_A_TZ", _now=fixed_now)
+        key_utc = _cache_key("London", "metric", 1, timezone="UTC", _now=fixed_now)
         self.assertEqual(key_invalid, key_utc)
 
     def test_cache_key_zero_differs_from_legacy(self):

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -469,7 +469,6 @@ class TestCacheKeyForecast(unittest.TestCase):
     def test_forecast_cache_key_includes_date(self):
         # Forecast keys must embed a date (YYYY-MM-DD) so a cached "tomorrow"
         # entry is never served on a different calendar day after local midnight.
-        import re
         from plugins.weather import _cache_key
         key = _cache_key("London", "metric", 1, timezone="UTC")
         self.assertRegex(key, r'\d{4}-\d{2}-\d{2}', "forecast key should contain a date")

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -421,8 +421,9 @@ class TestCacheKeyForecast(unittest.TestCase):
         self.assertNotEqual(key0, key2)
 
     def test_forecast_cache_key_uses_user_timezone(self):
-        # At 23:30 UTC, UTC+12 is already the next calendar day.
-        # Keys for the same location/days_ahead but different timezones must differ.
+        # At 23:30 UTC, the local date in UTC+12 is already the next calendar day.
+        # Keys must differ because their local date anchors differ, not merely
+        # because their timezone names differ.
         import datetime as dt_mod
         from plugins.weather import _cache_key
         utc = dt_mod.timezone.utc
@@ -430,7 +431,7 @@ class TestCacheKeyForecast(unittest.TestCase):
         fixed_now = dt_mod.datetime(2026, 5, 31, 23, 30, 0, tzinfo=utc)
         key_utc = _cache_key("London", "metric", 1, timezone="UTC", _now=fixed_now)
         key_plus12 = _cache_key("London", "metric", 1, timezone="Etc/GMT-12", _now=fixed_now)
-        # UTC is still 2026-05-31; UTC+12 is already 2026-06-01 — keys must differ
+        # UTC date anchor = 2026-05-31; UTC+12 date anchor = 2026-06-01
         self.assertNotEqual(key_utc, key_plus12)
         self.assertIn("2026-05-31", key_utc)
         self.assertIn("2026-06-01", key_plus12)
@@ -440,7 +441,9 @@ class TestCacheKeyForecast(unittest.TestCase):
         from plugins.weather import _cache_key
         utc = dt_mod.timezone.utc
         fixed_now = dt_mod.datetime(2026, 5, 31, 12, 0, 0, tzinfo=utc)
-        with patch('plugins.weather.plugin.logger') as mock_logger:
+        # Clear the tz cache so the warning fires even if this tz was seen before
+        with patch.dict('plugins.weather.plugin._TZ_CACHE', {}, clear=True), \
+             patch('plugins.weather.plugin.logger') as mock_logger:
             key_invalid = _cache_key("London", "metric", 1, timezone="NOT_A_TZ", _now=fixed_now)
         key_utc = _cache_key("London", "metric", 1, timezone="UTC", _now=fixed_now)
         self.assertEqual(key_invalid, key_utc)
@@ -484,6 +487,32 @@ class TestWeatherForecastProcess(unittest.TestCase):
         from plugins.weather import process
         result = process("weather saturday", {"days_ahead": 6}, s)
         self.assertIn("5 days", result)
+
+    def test_days_ahead_gt_5_refresh_only_returns_none(self):
+        s = _make_sandvoice(cache=None)
+        from plugins.weather import process
+        result = process("weather", {"days_ahead": 6, "refresh_only": True}, s)
+        self.assertIsNone(result)
+
+    def test_days_ahead_non_int_defaults_to_zero(self):
+        # Router may occasionally return a non-integer; plugin should default to 0
+        s = _make_sandvoice(cache=None)
+        from plugins.weather import process
+        with patch('plugins.weather.plugin.OpenWeatherReader') as MockReader:
+            MockReader.return_value.get_current_weather.return_value = _WEATHER_DATA
+            process("weather", {"days_ahead": "tomorrow"}, s)
+        # Should have called get_current_weather (days_ahead=0 path), not get_forecast
+        MockReader.return_value.get_current_weather.assert_called_once()
+        MockReader.return_value.get_forecast.assert_not_called()
+
+    def test_days_ahead_negative_defaults_to_zero(self):
+        s = _make_sandvoice(cache=None)
+        from plugins.weather import process
+        with patch('plugins.weather.plugin.OpenWeatherReader') as MockReader:
+            MockReader.return_value.get_current_weather.return_value = _WEATHER_DATA
+            process("weather", {"days_ahead": -1}, s)
+        MockReader.return_value.get_current_weather.assert_called_once()
+        MockReader.return_value.get_forecast.assert_not_called()
 
     @patch('plugins.weather.plugin.OpenWeatherReader')
     def test_forecast_refresh_only_skips_llm_on_api_error(self, MockReader):

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -424,6 +424,18 @@ class TestCacheKeyForecast(unittest.TestCase):
         legacy_key = 'weather:["London","metric"]'
         self.assertNotEqual(new_key, legacy_key)
 
+    def test_forecast_cache_key_includes_date(self):
+        # Forecast keys must embed today's UTC date so cached "tomorrow" entries
+        # are not served after midnight when the target day has shifted.
+        import datetime as dt_mod
+        from plugins.weather import _cache_key
+        today = dt_mod.date.today().isoformat()
+        key = _cache_key("London", "metric", 1)
+        self.assertIn(today, key)
+        # Current-weather key must NOT include a date (no cross-day issue).
+        key0 = _cache_key("London", "metric", 0)
+        self.assertNotIn(today, key0)
+
 
 class TestWeatherForecastProcess(unittest.TestCase):
     """Tests for forecast code paths in process()."""


### PR DESCRIPTION
## Summary
Extends the weather plugin to handle future-date queries ("will it rain tomorrow?", "what's the weather on Saturday?") using the OpenWeatherMap 5-day/3-hour forecast endpoint.

## Planning Document
Implements plan/backlog/58-weather-forecast.md

## Changes
- **`plugins/weather/plugin.py`**: Added `get_forecast(days_ahead)` to `OpenWeatherReader` with timezone-aware date filtering via `city.timezone` offset. Updated `_cache_key()` to include `days_ahead`. Updated `process()` to route to forecast path for `days_ahead` 1–5, return friendly message for >5, use forecast-specific TTL config
- **`plugins/weather/plugin.yaml`**: Added `days_ahead` to `route_extra_keys`, updated `route_description` to cover current and future weather queries
- **`common/configuration.py`**: Added `cache_weather_forecast_ttl_s` (default 1h) and `cache_weather_forecast_max_stale_s` (default 2h) config keys
- **`tests/test_weather.py`**: 9 new tests covering forecast path, cache key separation, timezone filtering, fallback, and error handling

## Configuration Changes
```yaml
cache_weather_forecast_ttl_s: 3600    # 1 hour (default)
cache_weather_forecast_max_stale_s: 7200  # 2 hours (default)
```

## Testing
- [x] All tests pass (1026 total)
- [x] Coverage >80%
- [x] No regression in existing current-weather tests
- [x] Tested on Mac M1