### PR TITLE
Replace Porcupine with openWakeWord (Plan 52)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install "setuptools<81"  # Required for pkg_resources used by webrtcvad (removed in v81+)
+          pip install openwakeword>=0.6.0 --no-deps  # tflite-runtime has no Linux wheel for Python 3.10-3.12
           pip install -r requirements.txt
 
       - name: Run tests with coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,15 +31,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install "setuptools<81"  # Required for pkg_resources used by webrtcvad (removed in v81+)
-          # openwakeword declares tflite-runtime as a Linux dep, but has no wheel for
+          # openwakeword declares tflite-runtime as a Linux dep but no wheel exists for
           # Python 3.10-3.12. We use ONNX inference only, so install a stub to satisfy pip.
-          python -c "
-import tempfile, os, subprocess, sys
-td = tempfile.mkdtemp()
-with open(os.path.join(td, 'setup.py'), 'w') as f:
-    f.write(\"from setuptools import setup; setup(name='tflite-runtime', version='2.14.0', packages=[])\")
-subprocess.run([sys.executable, '-m', 'pip', 'install', td], check=True)
-"
+          TD=$(mktemp -d) && echo "from setuptools import setup; setup(name='tflite-runtime', version='2.14.0', packages=[])" > $TD/setup.py && pip install $TD
           pip install -r requirements.txt
 
       - name: Run tests with coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install "setuptools<81"  # Required for pkg_resources used by webrtcvad (removed in v81+)
-          pip install openwakeword>=0.6.0 --no-deps  # tflite-runtime has no Linux wheel for Python 3.10-3.12
+          # openwakeword declares tflite-runtime as a Linux dep, but has no wheel for
+          # Python 3.10-3.12. We use ONNX inference only, so install a stub to satisfy pip.
+          python -c "
+import tempfile, os, subprocess, sys
+td = tempfile.mkdtemp()
+with open(os.path.join(td, 'setup.py'), 'w') as f:
+    f.write(\"from setuptools import setup; setup(name='tflite-runtime', version='2.14.0', packages=[])\")
+subprocess.run([sys.executable, '-m', 'pip', 'install', td], check=True)
+"
           pip install -r requirements.txt
 
       - name: Run tests with coverage

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ rss_news_max_items: "5"
 # Wake word (--wake-word mode)
 wake_word_enabled: enabled   # global toggle; --wake-word flag is still required to start the mode
 wake_phrase: hey jarvis
-wake_word_sensitivity: 0.35  # 0.0-1.0; higher = more sensitive
+wake_word_sensitivity: 0.35  # 0.0-1.0; higher = stricter (fewer false positives), lower = more sensitive
 openwakeword_model: hey_jarvis  # built-in model name or path to a .onnx file
 
 # Voice activity detection (required in --wake-word mode)

--- a/README.md
+++ b/README.md
@@ -51,10 +51,9 @@ bot_voice: enabled
 stream_responses: enabled
 stream_tts: enabled
 vad_enabled: enabled
-porcupine_access_key: "YOUR_KEY_HERE"   # free key at https://console.picovoice.ai/
 ```
 
-The wake phrase defaults to `hey sandvoice`. Change it with `wake_phrase` in config (must be a built-in Porcupine keyword, or provide a custom `.ppn` model via `porcupine_keyword_paths`).
+The wake phrase defaults to `hey jarvis`. Change it with `wake_phrase` and `openwakeword_model` in config. The model name must be a built-in openWakeWord model (e.g. `hey_jarvis`, `alexa`) or an absolute path to a custom `.onnx` file.
 
 ## API keys
 
@@ -62,7 +61,6 @@ The wake phrase defaults to `hey sandvoice`. Change it with `wake_phrase` in con
 |---|---|---|
 | `OPENAI_API_KEY` | Always | All AI features |
 | `OPENWEATHERMAP_API_KEY` | Weather plugin only | `weather` plugin |
-| `porcupine_access_key` (in config) | Wake word mode only | Wake word, barge-in |
 
 ## Configuration
 
@@ -131,10 +129,9 @@ rss_news_max_items: "5"
 
 # Wake word (--wake-word mode)
 wake_word_enabled: enabled   # global toggle; --wake-word flag is still required to start the mode
-wake_phrase: hey sandvoice
-wake_word_sensitivity: 0.5   # 0.0-1.0; higher = more sensitive
-porcupine_access_key: ""
-porcupine_keyword_paths: null   # path(s) to custom .ppn model(s), or null
+wake_phrase: hey jarvis
+wake_word_sensitivity: 0.35  # 0.0-1.0; higher = more sensitive
+openwakeword_model: hey_jarvis  # built-in model name or absolute path to a custom .onnx file
 
 # Voice activity detection (required in --wake-word mode)
 vad_enabled: enabled

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ vad_enabled: enabled
 
 The wake phrase defaults to `hey jarvis`. Change it with `wake_phrase` and `openwakeword_model` in config. The model name must be a built-in openWakeWord model (e.g. `hey_jarvis`, `alexa`) or a path to a `.onnx` file.
 
+**Raspberry Pi / Linux install note:** `tflite-runtime` (a transitive dependency of openWakeWord) has no wheels for Python 3.10–3.12 on Linux. Install a no-op stub before running `pip install -r requirements.txt`:
+
+```bash
+TD=$(mktemp -d) && echo "from setuptools import setup; setup(name='tflite-runtime', version='2.14.0', packages=[])" > $TD/setup.py && pip install $TD
+pip install -r requirements.txt
+```
+
 ## API keys
 
 | Key | Required | Used by |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ vad_enabled: enabled
 
 The wake phrase defaults to `hey jarvis`. Change it with `wake_phrase` and `openwakeword_model` in config. The model name must be a built-in openWakeWord model (e.g. `hey_jarvis`, `alexa`) or a path to a `.onnx` file.
 
-**Raspberry Pi / Linux install note:** `tflite-runtime` (a transitive dependency of openWakeWord) has no wheels for Python 3.10–3.12 on Linux. Install a no-op stub before running `pip install -r requirements.txt`:
+**Raspberry Pi / Linux install note:** `tflite-runtime` (a transitive dependency of openWakeWord) has no compatible wheels for current Python versions on Linux. Install a no-op stub before running `pip install -r requirements.txt`:
 
 ```bash
 TD=$(mktemp -d) && echo "from setuptools import setup; setup(name='tflite-runtime', version='2.14.0', packages=[])" > $TD/setup.py && pip install $TD

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ stream_tts: enabled
 vad_enabled: enabled
 ```
 
-The wake phrase defaults to `hey jarvis`. Change it with `wake_phrase` and `openwakeword_model` in config. The model name must be a built-in openWakeWord model (e.g. `hey_jarvis`, `alexa`) or an absolute path to a custom `.onnx` file.
+The wake phrase defaults to `hey jarvis`. Change it with `wake_phrase` and `openwakeword_model` in config. The model name must be a built-in openWakeWord model (e.g. `hey_jarvis`, `alexa`) or a path to a `.onnx` file.
 
 ## API keys
 
@@ -131,7 +131,7 @@ rss_news_max_items: "5"
 wake_word_enabled: enabled   # global toggle; --wake-word flag is still required to start the mode
 wake_phrase: hey jarvis
 wake_word_sensitivity: 0.35  # 0.0-1.0; higher = more sensitive
-openwakeword_model: hey_jarvis  # built-in model name or absolute path to a custom .onnx file
+openwakeword_model: hey_jarvis  # built-in model name or path to a .onnx file
 
 # Voice activity detection (required in --wake-word mode)
 vad_enabled: enabled

--- a/common/audio.py
+++ b/common/audio.py
@@ -1,14 +1,43 @@
 #import re, os, pyaudio, wave
 #from pydub import AudioSegment
 import contextlib
-import os, platform, time, threading, pyaudio, wave, lameenc, logging, queue
-from pynput import keyboard
+import os, platform, time, threading, pyaudio, wave, lameenc, logging, queue, re
 from common.error_handling import handle_file_error
 
 logger = logging.getLogger(__name__)
 
 # this is necessary to mute some outputs from pygame
 os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = "hide"
+
+# On Linux, SDL defaults to the first ALSA device which may not be the USB audio device.
+# Point SDL at the first real hardware output device (name contains "hw:N,M").
+# Prefer a combined in+out device (USB headset) over output-only.
+# Falls back to "default" if no hardware device is found.
+# Users can override by setting SDL_AUDIODRIVER / AUDIODEV in their environment.
+if platform.system().lower() == "linux" and "SDL_AUDIODRIVER" not in os.environ:
+    os.environ["SDL_AUDIODRIVER"] = "alsa"
+    try:
+        _pa = pyaudio.PyAudio()
+        try:
+            _audiodev = None
+            _fallback = None
+            for _i in range(_pa.get_device_count()):
+                _dev = _pa.get_device_info_by_index(_i)
+                _m = re.search(r'hw:(\d+),(\d+)', _dev.get("name", ""))
+                if not _m:
+                    continue
+                _plug = f"plughw:{_m.group(1)},{_m.group(2)}"
+                if _dev.get("maxOutputChannels", 0) > 0 and _dev.get("maxInputChannels", 0) > 0:
+                    _audiodev = _plug
+                    break
+                if _fallback is None and _dev.get("maxOutputChannels", 0) > 0:
+                    _fallback = _plug
+            os.environ["AUDIODEV"] = _audiodev or _fallback or "default"
+        finally:
+            _pa.terminate()
+    except Exception:
+        os.environ["AUDIODEV"] = "default"
+
 import pygame
 
 
@@ -55,6 +84,7 @@ class Audio:
             logger.debug(">>> MIXER STATE [%s]: Error getting state: %s", context, e)
 
     def init_recording(self):
+        from pynput import keyboard
         listener = keyboard.Listener(on_press=self.on_press)
         listener.start()
         self.start_recording()

--- a/common/audio.py
+++ b/common/audio.py
@@ -9,6 +9,30 @@ logger = logging.getLogger(__name__)
 # this is necessary to mute some outputs from pygame
 os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = "hide"
 
+# Kept at module scope so the ctypes callback is never garbage-collected
+# while ALSA may still invoke it (local variables would be GC'd on return).
+_ALSA_NOOP_HANDLER = None
+_alsa_suppression_attempted = False
+
+
+def _suppress_alsa_errors():
+    """Silence noisy ALSA error messages on Linux/Pi. Best-effort: no-op if libasound is not found."""
+    global _ALSA_NOOP_HANDLER, _alsa_suppression_attempted
+    if _alsa_suppression_attempted or platform.system() != "Linux":
+        return
+    _alsa_suppression_attempted = True
+    try:
+        from ctypes import CFUNCTYPE, cdll, c_char_p, c_int
+        from ctypes.util import find_library
+        lib_name = find_library("asound")
+        if lib_name is None:
+            return
+        _ALSA_NOOP_HANDLER = CFUNCTYPE(None, c_char_p, c_int, c_char_p, c_int, c_char_p)(lambda *_: None)
+        cdll.LoadLibrary(lib_name).snd_lib_error_set_handler(_ALSA_NOOP_HANDLER)
+    except Exception:
+        pass  # best-effort: never raise from a noise-suppression helper
+
+
 # On Linux, SDL defaults to the first ALSA device which may not be the USB audio device.
 # Point SDL at the first real hardware output device (name contains "hw:N,M").
 # Prefer a combined in+out device (USB headset) over output-only.
@@ -16,6 +40,7 @@ os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = "hide"
 # Users can override by setting SDL_AUDIODRIVER / AUDIODEV in their environment.
 if platform.system().lower() == "linux" and "SDL_AUDIODRIVER" not in os.environ:
     os.environ["SDL_AUDIODRIVER"] = "alsa"
+    _suppress_alsa_errors()
     try:
         _pa = pyaudio.PyAudio()
         try:
@@ -41,30 +66,6 @@ if platform.system().lower() == "linux" and "SDL_AUDIODRIVER" not in os.environ:
             os.environ["AUDIODEV"] = "default"
 
 import pygame
-
-
-# Kept at module scope so the ctypes callback is never garbage-collected
-# while ALSA may still invoke it (local variables would be GC'd on return).
-_ALSA_NOOP_HANDLER = None
-_alsa_suppression_attempted = False
-
-
-def _suppress_alsa_errors():
-    """Silence noisy ALSA error messages on Linux/Pi. Best-effort: no-op if libasound is not found."""
-    global _ALSA_NOOP_HANDLER, _alsa_suppression_attempted
-    if _alsa_suppression_attempted or platform.system() != "Linux":
-        return
-    _alsa_suppression_attempted = True
-    try:
-        from ctypes import CFUNCTYPE, cdll, c_char_p, c_int
-        from ctypes.util import find_library
-        lib_name = find_library("asound")
-        if lib_name is None:
-            return
-        _ALSA_NOOP_HANDLER = CFUNCTYPE(None, c_char_p, c_int, c_char_p, c_int, c_char_p)(lambda *_: None)
-        cdll.LoadLibrary(lib_name).snd_lib_error_set_handler(_ALSA_NOOP_HANDLER)
-    except Exception:
-        pass  # best-effort: never raise from a noise-suppression helper
 
 class Audio:
     def __init__(self, config):

--- a/common/audio.py
+++ b/common/audio.py
@@ -39,31 +39,35 @@ def _suppress_alsa_errors():
 # Falls back to "default" if no hardware device is found.
 # Users can override by setting SDL_AUDIODRIVER / AUDIODEV in their environment.
 if platform.system().lower() == "linux" and "SDL_AUDIODRIVER" not in os.environ:
-    os.environ["SDL_AUDIODRIVER"] = "alsa"
-    _suppress_alsa_errors()
-    try:
-        _pa = pyaudio.PyAudio()
+    # Only probe devices when libasound is present; skip silently otherwise
+    # (e.g. CI runners without ALSA hardware).
+    from ctypes.util import find_library as _find_library
+    if _find_library("asound") is not None:
+        os.environ["SDL_AUDIODRIVER"] = "alsa"
+        _suppress_alsa_errors()
         try:
-            _audiodev = None
-            _fallback = None
-            for _i in range(_pa.get_device_count()):
-                _dev = _pa.get_device_info_by_index(_i)
-                _m = re.search(r'hw:(\d+),(\d+)', _dev.get("name", ""))
-                if not _m:
-                    continue
-                _plug = f"plughw:{_m.group(1)},{_m.group(2)}"
-                if _dev.get("maxOutputChannels", 0) > 0 and _dev.get("maxInputChannels", 0) > 0:
-                    _audiodev = _plug
-                    break
-                if _fallback is None and _dev.get("maxOutputChannels", 0) > 0:
-                    _fallback = _plug
+            _pa = pyaudio.PyAudio()
+            try:
+                _audiodev = None
+                _fallback = None
+                for _i in range(_pa.get_device_count()):
+                    _dev = _pa.get_device_info_by_index(_i)
+                    _m = re.search(r'hw:(\d+),(\d+)', _dev.get("name", ""))
+                    if not _m:
+                        continue
+                    _plug = f"plughw:{_m.group(1)},{_m.group(2)}"
+                    if _dev.get("maxOutputChannels", 0) > 0 and _dev.get("maxInputChannels", 0) > 0:
+                        _audiodev = _plug
+                        break
+                    if _fallback is None and _dev.get("maxOutputChannels", 0) > 0:
+                        _fallback = _plug
+                if "AUDIODEV" not in os.environ:
+                    os.environ["AUDIODEV"] = _audiodev or _fallback or "default"
+            finally:
+                _pa.terminate()
+        except Exception:
             if "AUDIODEV" not in os.environ:
-                os.environ["AUDIODEV"] = _audiodev or _fallback or "default"
-        finally:
-            _pa.terminate()
-    except Exception:
-        if "AUDIODEV" not in os.environ:
-            os.environ["AUDIODEV"] = "default"
+                os.environ["AUDIODEV"] = "default"
 
 import pygame
 

--- a/common/audio.py
+++ b/common/audio.py
@@ -92,10 +92,13 @@ class Audio:
     def init_recording(self):
         from pynput import keyboard
         self._keyboard = keyboard
-        listener = keyboard.Listener(on_press=self.on_press)
-        listener.start()
-        self.start_recording()
-        self.convert_to_mp3()
+        self._listener = keyboard.Listener(on_press=self.on_press)
+        self._listener.start()
+        try:
+            self.start_recording()
+            self.convert_to_mp3()
+        finally:
+            self._listener.stop()
 
     def initialize_audio(self):
         _suppress_alsa_errors()

--- a/common/audio.py
+++ b/common/audio.py
@@ -85,6 +85,7 @@ class Audio:
 
     def init_recording(self):
         from pynput import keyboard
+        self._keyboard = keyboard
         listener = keyboard.Listener(on_press=self.on_press)
         listener.start()
         self.start_recording()
@@ -106,7 +107,8 @@ class Audio:
             self.audio = None
 
     def on_press(self, key):
-        if key == keyboard.Key.esc:
+        _kb = getattr(self, '_keyboard', None)
+        if _kb is not None and key == _kb.Key.esc:
             self.is_recording = False
 
     def start_recording(self):

--- a/common/audio.py
+++ b/common/audio.py
@@ -44,7 +44,6 @@ if platform.system().lower() == "linux" and "SDL_AUDIODRIVER" not in os.environ:
     from ctypes.util import find_library as _find_library
     if _find_library("asound") is not None:
         os.environ["SDL_AUDIODRIVER"] = "alsa"
-        _suppress_alsa_errors()
         try:
             _pa = pyaudio.PyAudio()
             try:

--- a/common/audio.py
+++ b/common/audio.py
@@ -32,11 +32,13 @@ if platform.system().lower() == "linux" and "SDL_AUDIODRIVER" not in os.environ:
                     break
                 if _fallback is None and _dev.get("maxOutputChannels", 0) > 0:
                     _fallback = _plug
-            os.environ["AUDIODEV"] = _audiodev or _fallback or "default"
+            if "AUDIODEV" not in os.environ:
+                os.environ["AUDIODEV"] = _audiodev or _fallback or "default"
         finally:
             _pa.terminate()
     except Exception:
-        os.environ["AUDIODEV"] = "default"
+        if "AUDIODEV" not in os.environ:
+            os.environ["AUDIODEV"] = "default"
 
 import pygame
 

--- a/common/audio_devices.py
+++ b/common/audio_devices.py
@@ -5,7 +5,7 @@ import re
 logger = logging.getLogger(__name__)
 
 
-def _find_hw_input_device(pa):
+def find_hw_input_device(pa):
     """Return the index of the first real hardware input device on Linux.
 
     On Linux the PyAudio default input is often a virtual 'default' device

--- a/common/audio_devices.py
+++ b/common/audio_devices.py
@@ -1,0 +1,28 @@
+import logging
+import platform
+import re
+
+logger = logging.getLogger(__name__)
+
+
+def _find_hw_input_device(pa):
+    """Return the index of the first real hardware input device on Linux.
+
+    On Linux the PyAudio default input is often a virtual 'default' device
+    that may not deliver audio from the actual USB mic. Explicitly picking
+    the first hw: input device ensures we use the real hardware.
+
+    Returns None on macOS/non-Linux (let PyAudio pick the system default).
+    Returns None (and logs a warning) if device enumeration fails.
+    """
+    if platform.system().lower() != "linux":
+        return None
+    try:
+        for i in range(pa.get_device_count()):
+            dev = pa.get_device_info_by_index(i)
+            if dev.get("maxInputChannels", 0) > 0 and re.search(r'hw:\d+,\d+', dev.get("name", "")):
+                logger.debug("Selected hw input device index=%s name=%s", i, dev.get("name", ""))
+                return i
+    except Exception as e:
+        logger.warning("Failed to enumerate audio input devices, using default: %s", e)
+    return None

--- a/common/barge_in.py
+++ b/common/barge_in.py
@@ -3,7 +3,7 @@ import struct
 import threading
 import time
 
-import pvporcupine
+from common.openwakeword_detector import OpenWakeWordDetector
 import pyaudio
 
 logger = logging.getLogger(__name__)
@@ -13,7 +13,7 @@ _BARGE_IN = object()
 
 
 class BargeInDetector:
-    """Encapsulates barge-in detection using Porcupine wake-word engine.
+    """Encapsulates barge-in detection using OpenWakeWord wake word engine.
 
     Runs a background thread that listens for the wake word while other
     operations are in progress (e.g. TTS playback, API calls). When the
@@ -23,7 +23,7 @@ class BargeInDetector:
     Usage::
 
         detector = BargeInDetector(
-            access_key=..., keyword_paths=..., sensitivity=...,
+            model_name=..., threshold=...,
             audio_lock=..., audio=..., config=...
         )
         detector.start()
@@ -33,24 +33,21 @@ class BargeInDetector:
         detector.stop()
     """
 
-    def __init__(self, access_key, keyword_paths, sensitivity, audio_lock, audio, config):
+    def __init__(self, model_name, threshold, audio_lock, audio, config):
         """Initialise the detector.
 
         Args:
-            access_key: Porcupine access key string.
-            keyword_paths: List of .ppn file paths, or None to use built-in
-                keywords derived from ``config.wake_phrase``.
-            sensitivity: Float sensitivity for wake-word detection (0.0–1.0).
+            model_name: OpenWakeWord model name string.
+            threshold: Float sensitivity for wake-word detection (0.0–1.0).
             audio_lock: threading.Lock (or None) acquired around playback
                 calls inside the host WakeWordMode.  Not used by the detector
                 itself; stored so callers can pass it along if needed.
             audio: Audio instance (stored for future use; not used internally).
-            config: Config instance; used to read ``wake_phrase`` when
-                creating Porcupine instances with built-in keywords.
+            config: Config instance; used to read ``rate`` when
+                creating OpenWakeWordDetector instances.
         """
-        self._access_key = access_key
-        self._keyword_paths = keyword_paths
-        self._sensitivity = sensitivity
+        self._model_name = model_name
+        self._sensitivity = threshold
         self._audio_lock = audio_lock
         self._audio = audio
         self._config = config
@@ -208,25 +205,13 @@ class BargeInDetector:
     # Internal
     # ------------------------------------------------------------------
 
-    def _create_porcupine_instance(self):
-        """Create a fresh Porcupine instance for this thread."""
-        if self._keyword_paths:
-            paths = self._keyword_paths
-            if not isinstance(paths, (list, tuple)):
-                paths = [paths]
-            sensitivities = [self._sensitivity] * len(paths)
-            return pvporcupine.create(
-                access_key=self._access_key,
-                keyword_paths=paths,
-                sensitivities=sensitivities,
-            )
-        else:
-            wake_keyword = self._config.wake_phrase.lower()
-            return pvporcupine.create(
-                access_key=self._access_key,
-                keywords=[wake_keyword],
-                sensitivities=[self._sensitivity],
-            )
+    def _create_detector_instance(self):
+        """Create a fresh OpenWakeWordDetector for this detection thread."""
+        return OpenWakeWordDetector(
+            model_name=self._model_name,
+            threshold=self._sensitivity,
+            device_sample_rate=self._config.rate,
+        )
 
     def _cleanup_pyaudio(self, stream, pa):
         """Stop and close a PyAudio stream, then terminate the PyAudio instance."""
@@ -248,26 +233,26 @@ class BargeInDetector:
     def _detection_loop(self):
         """Background thread body: listen for barge-in wake word.
 
-        Creates its own Porcupine instance to avoid thread-safety issues with
-        the main Porcupine instance used in IDLE state.
+        Creates its own OpenWakeWord detector instance to avoid thread-safety
+        issues with the main detector instance used in IDLE state.
         """
-        porcupine_instance = None
+        detector_instance = None
         pa = None
         audio_stream = None
 
         try:
-            logger.debug("Barge-in thread: Creating Porcupine instance...")
-            porcupine_instance = self._create_porcupine_instance()
-            logger.debug("Barge-in thread: Porcupine created successfully")
+            logger.debug("Barge-in thread: Creating OpenWakeWord detector instance...")
+            detector_instance = self._create_detector_instance()
+            logger.debug("Barge-in thread: OpenWakeWord detector created successfully")
 
             logger.debug("Barge-in thread: Opening PyAudio stream...")
             pa = pyaudio.PyAudio()
             audio_stream = pa.open(
-                rate=porcupine_instance.sample_rate,
+                rate=detector_instance.sample_rate,
                 channels=1,
                 format=pyaudio.paInt16,
                 input=True,
-                frames_per_buffer=porcupine_instance.frame_length,
+                frames_per_buffer=detector_instance.frame_length,
             )
 
             logger.debug("Barge-in thread: Audio stream opened, listening for wake word...")
@@ -275,12 +260,12 @@ class BargeInDetector:
             while not self._event.is_set() and not self._stop_flag.is_set():
                 try:
                     pcm = audio_stream.read(
-                        porcupine_instance.frame_length,
+                        detector_instance.frame_length,
                         exception_on_overflow=False,
                     )
-                    pcm = struct.unpack_from("h" * porcupine_instance.frame_length, pcm)
+                    pcm = struct.unpack_from("h" * detector_instance.frame_length, pcm)
 
-                    keyword_index = porcupine_instance.process(pcm)
+                    keyword_index = detector_instance.process(pcm)
 
                     if keyword_index >= 0:
                         logger.info("Barge-in: Wake word detected! Interrupting...")
@@ -300,8 +285,8 @@ class BargeInDetector:
             logger.error("Barge-in detection thread error: %s", e)
         finally:
             self._cleanup_pyaudio(audio_stream, pa)
-            if porcupine_instance is not None:
+            if detector_instance is not None:
                 try:
-                    porcupine_instance.delete()
+                    detector_instance.delete()
                 except Exception as e:
-                    logger.warning("Failed to delete barge-in Porcupine instance: %s", e)
+                    logger.debug("Failed to delete barge-in OpenWakeWord detector instance: %s", e)

--- a/common/barge_in.py
+++ b/common/barge_in.py
@@ -3,7 +3,7 @@ import struct
 import threading
 import time
 
-from common.audio_devices import _find_hw_input_device
+from common.audio_devices import find_hw_input_device
 from common.openwakeword_detector import OpenWakeWordDetector
 import pyaudio
 
@@ -248,7 +248,7 @@ class BargeInDetector:
 
             logger.debug("Barge-in thread: Opening PyAudio stream...")
             pa = pyaudio.PyAudio()
-            input_device_index = _find_hw_input_device(pa)
+            input_device_index = find_hw_input_device(pa)
             audio_stream = pa.open(
                 rate=detector_instance.device_sample_rate,
                 channels=1,

--- a/common/barge_in.py
+++ b/common/barge_in.py
@@ -20,11 +20,14 @@ def _find_hw_input_device(pa):
     """
     if platform.system().lower() != "linux":
         return None
-    for i in range(pa.get_device_count()):
-        dev = pa.get_device_info_by_index(i)
-        if dev.get("maxInputChannels", 0) > 0 and re.search(r'hw:\d+,\d+', dev.get("name", "")):
-            logger.debug("Barge-in: selected hw input device index=%s name=%s", i, dev["name"])
-            return i
+    try:
+        for i in range(pa.get_device_count()):
+            dev = pa.get_device_info_by_index(i)
+            if dev.get("maxInputChannels", 0) > 0 and re.search(r'hw:\d+,\d+', dev.get("name", "")):
+                logger.debug("Barge-in: selected hw input device index=%s name=%s", i, dev.get("name", ""))
+                return i
+    except Exception as e:
+        logger.warning("Barge-in: failed to enumerate audio devices, using default: %s", e)
     return None
 
 # Sentinel returned by run_with_polling when barge-in interrupted the operation.

--- a/common/barge_in.py
+++ b/common/barge_in.py
@@ -1,34 +1,13 @@
 import logging
-import platform
-import re
 import struct
 import threading
 import time
 
+from common.audio_devices import _find_hw_input_device
 from common.openwakeword_detector import OpenWakeWordDetector
 import pyaudio
 
 logger = logging.getLogger(__name__)
-
-
-def _find_hw_input_device(pa):
-    """Return the index of the first real hardware input device on Linux.
-
-    Mirrors the same helper in wake_word.py. Kept separate to avoid a
-    circular import (wake_word imports barge_in).
-    Returns None on non-Linux platforms or when no hw: device is found.
-    """
-    if platform.system().lower() != "linux":
-        return None
-    try:
-        for i in range(pa.get_device_count()):
-            dev = pa.get_device_info_by_index(i)
-            if dev.get("maxInputChannels", 0) > 0 and re.search(r'hw:\d+,\d+', dev.get("name", "")):
-                logger.debug("Barge-in: selected hw input device index=%s name=%s", i, dev.get("name", ""))
-                return i
-    except Exception as e:
-        logger.warning("Barge-in: failed to enumerate audio devices, using default: %s", e)
-    return None
 
 # Sentinel returned by run_with_polling when barge-in interrupted the operation.
 _BARGE_IN = object()

--- a/common/barge_in.py
+++ b/common/barge_in.py
@@ -48,7 +48,7 @@ class BargeInDetector:
                 creating OpenWakeWordDetector instances.
         """
         self._model_name = model_name
-        self._sensitivity = threshold
+        self._threshold = threshold
         self._audio_lock = audio_lock
         self._audio = audio
         self._config = config
@@ -210,7 +210,7 @@ class BargeInDetector:
         """Create a fresh OpenWakeWordDetector for this detection thread."""
         return OpenWakeWordDetector(
             model_name=self._model_name,
-            threshold=self._sensitivity,
+            threshold=self._threshold,
             device_sample_rate=self._config.rate,
         )
 

--- a/common/barge_in.py
+++ b/common/barge_in.py
@@ -1,4 +1,6 @@
 import logging
+import platform
+import re
 import struct
 import threading
 import time
@@ -7,6 +9,23 @@ from common.openwakeword_detector import OpenWakeWordDetector
 import pyaudio
 
 logger = logging.getLogger(__name__)
+
+
+def _find_hw_input_device(pa):
+    """Return the index of the first real hardware input device on Linux.
+
+    Mirrors the same helper in wake_word.py. Kept separate to avoid a
+    circular import (wake_word imports barge_in).
+    Returns None on non-Linux platforms or when no hw: device is found.
+    """
+    if platform.system().lower() != "linux":
+        return None
+    for i in range(pa.get_device_count()):
+        dev = pa.get_device_info_by_index(i)
+        if dev.get("maxInputChannels", 0) > 0 and re.search(r'hw:\d+,\d+', dev.get("name", "")):
+            logger.debug("Barge-in: selected hw input device index=%s name=%s", i, dev["name"])
+            return i
+    return None
 
 # Sentinel returned by run_with_polling when barge-in interrupted the operation.
 _BARGE_IN = object()
@@ -247,12 +266,14 @@ class BargeInDetector:
 
             logger.debug("Barge-in thread: Opening PyAudio stream...")
             pa = pyaudio.PyAudio()
+            input_device_index = _find_hw_input_device(pa)
             audio_stream = pa.open(
-                rate=detector_instance.sample_rate,
+                rate=detector_instance.device_sample_rate,
                 channels=1,
                 format=pyaudio.paInt16,
                 input=True,
                 frames_per_buffer=detector_instance.frame_length,
+                input_device_index=input_device_index,
             )
 
             logger.debug("Barge-in thread: Audio stream opened, listening for wake word...")

--- a/common/configuration.py
+++ b/common/configuration.py
@@ -506,8 +506,12 @@ class Config:
 
         if not isinstance(self.openwakeword_model, str) or not self.openwakeword_model.strip():
             errors.append("openwakeword_model must be a non-empty string")
-        elif self.openwakeword_model.endswith(".onnx") and not os.path.exists(self.openwakeword_model):
-            errors.append(f"openwakeword_model path does not exist: {self.openwakeword_model}")
+        elif self.openwakeword_model.endswith(".onnx"):
+            expanded = os.path.expandvars(os.path.expanduser(self.openwakeword_model))
+            if not os.path.exists(expanded):
+                errors.append(f"openwakeword_model path does not exist: {self.openwakeword_model}")
+            else:
+                self.openwakeword_model = expanded
 
         # Validate VAD settings
         if not isinstance(self.vad_aggressiveness, int) or not (0 <= self.vad_aggressiveness <= 3):

--- a/common/configuration.py
+++ b/common/configuration.py
@@ -506,7 +506,7 @@ class Config:
 
         if not isinstance(self.openwakeword_model, str) or not self.openwakeword_model.strip():
             errors.append("openwakeword_model must be a non-empty string")
-        elif self.openwakeword_model.endswith(".onnx"):
+        elif self.openwakeword_model.lower().endswith(".onnx"):
             expanded = os.path.expandvars(os.path.expanduser(self.openwakeword_model))
             if not os.path.exists(expanded):
                 errors.append(f"openwakeword_model path does not exist: {self.openwakeword_model}")

--- a/common/configuration.py
+++ b/common/configuration.py
@@ -97,10 +97,9 @@ class Config:
             "stream_tts_first_chunk_target_s": 6,
             # Wake word mode settings (only active with --wake-word flag)
             "wake_word_enabled": "enabled",
-            "wake_phrase": "hey sandvoice",
-            "wake_word_sensitivity": 0.5,
-            "porcupine_access_key": "",
-            "porcupine_keyword_paths": None,
+            "wake_phrase": "hey jarvis",
+            "wake_word_sensitivity": 0.35,
+            "openwakeword_model": "hey_jarvis",
             # Voice Activity Detection
             "vad_enabled": "enabled",
             "vad_aggressiveness": 3,
@@ -248,8 +247,7 @@ class Config:
         self.wake_word_enabled = self.get("wake_word_enabled").lower() == "enabled"
         self.wake_phrase = self.get("wake_phrase")
         self.wake_word_sensitivity = self.get("wake_word_sensitivity")
-        self.porcupine_access_key = self.get("porcupine_access_key")
-        self.porcupine_keyword_paths = self.get("porcupine_keyword_paths")
+        self.openwakeword_model = self.get("openwakeword_model")
         # Voice Activity Detection
         self.vad_enabled = self.get("vad_enabled").lower() == "enabled"
         self.vad_aggressiveness = self.get("vad_aggressiveness")
@@ -506,8 +504,8 @@ class Config:
         if not self.wake_phrase or not isinstance(self.wake_phrase, str):
             errors.append("wake_phrase must be a non-empty string")
 
-        if not isinstance(self.porcupine_access_key, str):
-            errors.append("porcupine_access_key must be a string")
+        if not isinstance(self.openwakeword_model, str) or not self.openwakeword_model.strip():
+            errors.append("openwakeword_model must be a non-empty string")
 
         # Validate VAD settings
         if not isinstance(self.vad_aggressiveness, int) or not (0 <= self.vad_aggressiveness <= 3):

--- a/common/configuration.py
+++ b/common/configuration.py
@@ -506,12 +506,14 @@ class Config:
 
         if not isinstance(self.openwakeword_model, str) or not self.openwakeword_model.strip():
             errors.append("openwakeword_model must be a non-empty string")
-        elif self.openwakeword_model.lower().endswith(".onnx"):
-            expanded = os.path.expandvars(os.path.expanduser(self.openwakeword_model))
-            if not os.path.exists(expanded):
-                errors.append(f"openwakeword_model path does not exist: {self.openwakeword_model}")
-            else:
-                self.openwakeword_model = expanded
+        else:
+            self.openwakeword_model = self.openwakeword_model.strip()
+            if self.openwakeword_model.lower().endswith(".onnx"):
+                expanded = os.path.expandvars(os.path.expanduser(self.openwakeword_model))
+                if not os.path.exists(expanded):
+                    errors.append(f"openwakeword_model path does not exist: {self.openwakeword_model}")
+                else:
+                    self.openwakeword_model = expanded
 
         # Validate VAD settings
         if not isinstance(self.vad_aggressiveness, int) or not (0 <= self.vad_aggressiveness <= 3):

--- a/common/configuration.py
+++ b/common/configuration.py
@@ -506,6 +506,8 @@ class Config:
 
         if not isinstance(self.openwakeword_model, str) or not self.openwakeword_model.strip():
             errors.append("openwakeword_model must be a non-empty string")
+        elif self.openwakeword_model.endswith(".onnx") and not os.path.exists(self.openwakeword_model):
+            errors.append(f"openwakeword_model path does not exist: {self.openwakeword_model}")
 
         # Validate VAD settings
         if not isinstance(self.vad_aggressiveness, int) or not (0 <= self.vad_aggressiveness <= 3):

--- a/common/openwakeword_detector.py
+++ b/common/openwakeword_detector.py
@@ -79,7 +79,7 @@ class OpenWakeWordDetector:
         """Samples per frame at device_sample_rate (covers the same 80 ms window)."""
         if self._device_rate == _SAMPLE_RATE:
             return _FRAME_LENGTH
-        return int(_FRAME_LENGTH * self._device_rate / _SAMPLE_RATE)
+        return round(_FRAME_LENGTH * self._device_rate / _SAMPLE_RATE)
 
     def process(self, pcm):
         """Process one audio frame and return a detection result.
@@ -94,10 +94,15 @@ class OpenWakeWordDetector:
         audio = np.array(pcm, dtype=np.int16)
         if self._resample_up is not None:
             from scipy.signal import resample_poly
-            audio = np.clip(
+            resampled = np.clip(
                 resample_poly(audio, self._resample_up, self._resample_down),
                 -32768, 32767,
             ).astype(np.int16)
+            # Trim or zero-pad to exactly the model's expected frame length.
+            if len(resampled) >= _FRAME_LENGTH:
+                audio = resampled[:_FRAME_LENGTH]
+            else:
+                audio = np.pad(resampled, (0, _FRAME_LENGTH - len(resampled)))
 
         prediction = self._model.predict(audio)
         score = prediction.get(self._prediction_key, 0.0)

--- a/common/openwakeword_detector.py
+++ b/common/openwakeword_detector.py
@@ -94,7 +94,10 @@ class OpenWakeWordDetector:
         audio = np.array(pcm, dtype=np.int16)
         if self._resample_up is not None:
             from scipy.signal import resample_poly
-            audio = resample_poly(audio, self._resample_up, self._resample_down).astype(np.int16)
+            audio = np.clip(
+                resample_poly(audio, self._resample_up, self._resample_down),
+                -32768, 32767,
+            ).astype(np.int16)
 
         prediction = self._model.predict(audio)
         score = prediction.get(self._prediction_key, 0.0)

--- a/common/openwakeword_detector.py
+++ b/common/openwakeword_detector.py
@@ -23,8 +23,8 @@ class OpenWakeWordDetector:
         """Initialise the detector.
 
         Args:
-            model_name: Short built-in name (e.g. "hey_jarvis") or absolute
-                path to a custom .onnx file.
+            model_name: Short built-in name (e.g. "hey_jarvis") or path
+                (absolute or relative) to a custom .onnx file.
             threshold: Detection score threshold (0.0–1.0).
             device_sample_rate: Sample rate of the audio device. When it
                 differs from 16000 Hz, each frame is resampled before
@@ -46,7 +46,8 @@ class OpenWakeWordDetector:
             self._resample_down = None
 
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
+            warnings.simplefilter("ignore", DeprecationWarning)
+            warnings.simplefilter("ignore", UserWarning)
             if os.path.isabs(model_name) or model_name.endswith(".onnx"):
                 self._model = Model(wakeword_model_paths=[model_name], inference_framework="onnx")
                 self._prediction_key = os.path.splitext(os.path.basename(model_name))[0]

--- a/common/openwakeword_detector.py
+++ b/common/openwakeword_detector.py
@@ -1,0 +1,125 @@
+import logging
+import os
+import warnings
+from math import gcd
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+_SAMPLE_RATE = 16000
+_FRAME_LENGTH = 1280  # 80 ms at 16 kHz — openWakeWord's expected chunk size
+
+
+class OpenWakeWordDetector:
+    """Wraps an openWakeWord model to expose a Porcupine-compatible interface.
+
+    Provides ``sample_rate``, ``device_sample_rate``, ``frame_length``,
+    ``process(pcm)``, ``reset()``, and ``delete()`` so it can be used as a
+    drop-in replacement for Porcupine inside WakeWordMode and BargeInDetector.
+    """
+
+    def __init__(self, model_name="hey_jarvis", threshold=0.5, device_sample_rate=None):
+        """Initialise the detector.
+
+        Args:
+            model_name: Short built-in name (e.g. "hey_jarvis") or absolute
+                path to a custom .onnx file.
+            threshold: Detection score threshold (0.0–1.0).
+            device_sample_rate: Sample rate of the audio device. When it
+                differs from 16000 Hz, each frame is resampled before
+                inference. Defaults to 16000 (no resampling).
+        """
+        from openwakeword.model import Model
+
+        self._model_name = model_name
+        self._threshold = threshold
+        self._device_rate = device_sample_rate or _SAMPLE_RATE
+
+        # Precompute resampling ratio once so process() stays cheap.
+        if self._device_rate != _SAMPLE_RATE:
+            _g = gcd(self._device_rate, _SAMPLE_RATE)
+            self._resample_up = _SAMPLE_RATE // _g
+            self._resample_down = self._device_rate // _g
+        else:
+            self._resample_up = None
+            self._resample_down = None
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            if os.path.isabs(model_name) or model_name.endswith(".onnx"):
+                self._model = Model(wakeword_model_paths=[model_name], inference_framework="onnx")
+                self._prediction_key = os.path.splitext(os.path.basename(model_name))[0]
+            else:
+                self._model = Model(wakeword_models=[model_name], inference_framework="onnx")
+                self._prediction_key = model_name
+
+        # Warm up the prediction buffer so keys are initialised before first use.
+        self._model.predict(np.zeros(_FRAME_LENGTH, dtype=np.int16))
+
+        logger.debug(
+            "OpenWakeWord detector initialized: model=%s threshold=%.2f device_rate=%d",
+            model_name,
+            threshold,
+            self._device_rate,
+        )
+
+    @property
+    def sample_rate(self):
+        """Model's required sample rate (16000 Hz)."""
+        return _SAMPLE_RATE
+
+    @property
+    def device_sample_rate(self):
+        """Sample rate to open the audio device at."""
+        return self._device_rate
+
+    @property
+    def frame_length(self):
+        """Samples per frame at device_sample_rate (covers the same 80 ms window)."""
+        if self._device_rate == _SAMPLE_RATE:
+            return _FRAME_LENGTH
+        return int(_FRAME_LENGTH * self._device_rate / _SAMPLE_RATE)
+
+    def process(self, pcm):
+        """Process one audio frame and return a detection result.
+
+        Args:
+            pcm: Sequence of ``frame_length`` 16-bit signed integers recorded
+                at ``device_sample_rate``. Resampled to 16 kHz if needed.
+
+        Returns:
+            0 if the wake word score meets or exceeds the threshold, -1 otherwise.
+        """
+        audio = np.array(pcm, dtype=np.int16)
+        if self._resample_up is not None:
+            from scipy.signal import resample_poly
+            audio = resample_poly(audio, self._resample_up, self._resample_down).astype(np.int16)
+
+        prediction = self._model.predict(audio)
+        score = prediction.get(self._prediction_key, 0.0)
+        if score > 0.05:
+            logger.debug(
+                "Wake word score: model=%s score=%.3f threshold=%.2f",
+                self._model_name, score, self._threshold,
+            )
+        if score >= self._threshold:
+            logger.info("Wake word detected: model=%s score=%.3f", self._model_name, score)
+            return 0
+        return -1
+
+    def reset(self):
+        """Reset the model's internal prediction buffer.
+
+        Call before re-entering IDLE detection so audio captured during TTS
+        playback (bot's own voice heard through the mic) does not carry over
+        as a false positive on the first frame of the next cycle.
+        """
+        try:
+            self._model.reset()
+            logger.debug("OpenWakeWord model buffer reset")
+        except Exception as e:
+            logger.debug("OpenWakeWord model reset failed (non-fatal): %s", e)
+
+    def delete(self):
+        """No-op — openWakeWord holds no native resources requiring explicit release."""

--- a/common/openwakeword_detector.py
+++ b/common/openwakeword_detector.py
@@ -48,7 +48,7 @@ class OpenWakeWordDetector:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             warnings.simplefilter("ignore", UserWarning)
-            if os.path.isabs(model_name) or model_name.endswith(".onnx"):
+            if os.path.isabs(model_name) or model_name.lower().endswith(".onnx"):
                 self._model = Model(wakeword_model_paths=[model_name], inference_framework="onnx")
                 self._prediction_key = os.path.splitext(os.path.basename(model_name))[0]
             else:

--- a/common/openwakeword_detector.py
+++ b/common/openwakeword_detector.py
@@ -113,7 +113,7 @@ class OpenWakeWordDetector:
                 self._model_name, score, self._threshold,
             )
         if score >= self._threshold:
-            logger.info("Wake word detected: model=%s score=%.3f", self._model_name, score)
+            logger.debug("Wake word detected: model=%s score=%.3f", self._model_name, score)
             return 0
         return -1
 

--- a/common/vad_recorder.py
+++ b/common/vad_recorder.py
@@ -131,8 +131,14 @@ class VadRecorder:
                             if silence_duration >= self._config.vad_silence_duration:
                                 logger.debug("Silence detected (%.2fs)", silence_duration)
                                 break
+                    else:
+                        # No speech yet: bail out after vad_silence_duration of sustained
+                        # silence so a missed wake-word doesn't hold the mic for 30s.
+                        if (time.time() - recording_start) >= self._config.vad_silence_duration:
+                            logger.debug("No speech detected within %.2fs, discarding", self._config.vad_silence_duration)
+                            break
 
-            if not frames:
+            if not frames or not speech_detected:
                 return None
 
             elapsed = time.time() - recording_start

--- a/common/vad_recorder.py
+++ b/common/vad_recorder.py
@@ -80,6 +80,7 @@ class VadRecorder:
         audio_stream = None
         frames = []
         silence_start = None
+        speech_detected = False
         recording_start = time.time()
 
         try:
@@ -119,15 +120,17 @@ class VadRecorder:
                     is_speech = True  # Assume speech on error
 
                 if is_speech:
+                    speech_detected = True
                     silence_start = None
                 else:
-                    if silence_start is None:
-                        silence_start = time.time()
-                    else:
-                        silence_duration = time.time() - silence_start
-                        if silence_duration >= self._config.vad_silence_duration:
-                            logger.debug("Silence detected (%.2fs)", silence_duration)
-                            break
+                    if speech_detected:
+                        if silence_start is None:
+                            silence_start = time.time()
+                        else:
+                            silence_duration = time.time() - silence_start
+                            if silence_duration >= self._config.vad_silence_duration:
+                                logger.debug("Silence detected (%.2fs)", silence_duration)
+                                break
 
             if not frames:
                 return None

--- a/common/vad_recorder.py
+++ b/common/vad_recorder.py
@@ -132,8 +132,9 @@ class VadRecorder:
                                 logger.debug("Silence detected (%.2fs)", silence_duration)
                                 break
                     else:
-                        # No speech yet: bail out after vad_silence_duration of sustained
-                        # silence so a missed wake-word doesn't hold the mic for 30s.
+                        # No speech yet: bail out after vad_silence_duration so we don't
+                        # hold the mic for the full vad_timeout window waiting for speech
+                        # that never comes.
                         if (time.time() - recording_start) >= self._config.vad_silence_duration:
                             logger.debug("No speech detected within %.2fs, discarding", self._config.vad_silence_duration)
                             break

--- a/common/wake_word.py
+++ b/common/wake_word.py
@@ -8,6 +8,7 @@ import time
 from enum import Enum
 
 import pyaudio
+from common.audio_devices import _find_hw_input_device
 from common.openwakeword_detector import OpenWakeWordDetector
 
 from common.beep_generator import create_confirmation_beep, create_ack_earcon
@@ -19,30 +20,6 @@ from common.utils import _is_enabled_flag
 
 logger = logging.getLogger(__name__)
 
-
-def _find_hw_input_device(pa):
-    """Return the index of the first real hardware input device (name contains 'hw:N,M').
-
-    On Linux the PyAudio default input is often a virtual 'default' device that
-    may not deliver audio from the actual USB mic. Explicitly picking the first
-    hw: input device ensures we use the real hardware.
-
-    Returns None on macOS/non-Linux (let PyAudio pick the system default).
-    Returns None (and logs a warning) if device enumeration fails.
-    """
-    import re
-    import platform
-    if platform.system().lower() != "linux":
-        return None
-    try:
-        for i in range(pa.get_device_count()):
-            dev = pa.get_device_info_by_index(i)
-            if dev.get("maxInputChannels", 0) > 0 and re.search(r'hw:\d+,\d+', dev.get("name", "")):
-                logger.debug("Wake word: selected hw input device index=%s name=%s", i, dev.get("name", ""))
-                return i
-    except Exception as e:
-        logger.warning("Wake word: failed to enumerate audio devices, using default: %s", e)
-    return None
 
 
 class State(Enum):

--- a/common/wake_word.py
+++ b/common/wake_word.py
@@ -8,7 +8,7 @@ import time
 from enum import Enum
 
 import pyaudio
-from common.audio_devices import _find_hw_input_device
+from common.audio_devices import find_hw_input_device
 from common.openwakeword_detector import OpenWakeWordDetector
 
 from common.beep_generator import create_confirmation_beep, create_ack_earcon
@@ -268,7 +268,7 @@ class WakeWordMode:
 
         try:
             pa = pyaudio.PyAudio()
-            input_device_index = _find_hw_input_device(pa)
+            input_device_index = find_hw_input_device(pa)
             audio_stream = pa.open(
                 rate=self.detector.device_sample_rate,
                 channels=1,

--- a/common/wake_word.py
+++ b/common/wake_word.py
@@ -28,16 +28,20 @@ def _find_hw_input_device(pa):
     hw: input device ensures we use the real hardware.
 
     Returns None on macOS/non-Linux (let PyAudio pick the system default).
+    Returns None (and logs a warning) if device enumeration fails.
     """
     import re
     import platform
     if platform.system().lower() != "linux":
         return None
-    for i in range(pa.get_device_count()):
-        dev = pa.get_device_info_by_index(i)
-        if dev.get("maxInputChannels", 0) > 0 and re.search(r'hw:\d+,\d+', dev.get("name", "")):
-            logger.debug("Wake word: selected hw input device index=%s name=%s", i, dev["name"])
-            return i
+    try:
+        for i in range(pa.get_device_count()):
+            dev = pa.get_device_info_by_index(i)
+            if dev.get("maxInputChannels", 0) > 0 and re.search(r'hw:\d+,\d+', dev.get("name", "")):
+                logger.debug("Wake word: selected hw input device index=%s name=%s", i, dev.get("name", ""))
+                return i
+    except Exception as e:
+        logger.warning("Wake word: failed to enumerate audio devices, using default: %s", e)
     return None
 
 

--- a/common/wake_word.py
+++ b/common/wake_word.py
@@ -7,8 +7,8 @@ import threading
 import time
 from enum import Enum
 
-import pvporcupine
 import pyaudio
+from common.openwakeword_detector import OpenWakeWordDetector
 
 from common.beep_generator import create_confirmation_beep, create_ack_earcon
 from common.ai import pop_streaming_chunk
@@ -18,6 +18,27 @@ from common.vad_recorder import VadRecorder
 from common.utils import _is_enabled_flag
 
 logger = logging.getLogger(__name__)
+
+
+def _find_hw_input_device(pa):
+    """Return the index of the first real hardware input device (name contains 'hw:N,M').
+
+    On Linux the PyAudio default input is often a virtual 'default' device that
+    may not deliver audio from the actual USB mic. Explicitly picking the first
+    hw: input device ensures we use the real hardware.
+
+    Returns None on macOS/non-Linux (let PyAudio pick the system default).
+    """
+    import re
+    import platform
+    if platform.system().lower() != "linux":
+        return None
+    for i in range(pa.get_device_count()):
+        dev = pa.get_device_info_by_index(i)
+        if dev.get("maxInputChannels", 0) > 0 and re.search(r'hw:\d+,\d+', dev.get("name", "")):
+            logger.debug("Wake word: selected hw input device index=%s name=%s", i, dev["name"])
+            return i
+    return None
 
 
 class State(Enum):
@@ -32,7 +53,7 @@ class WakeWordMode:
     """Wake word mode with state machine for hands-free interaction.
 
     States:
-    - IDLE: Listening for wake word using Porcupine
+    - IDLE: Listening for wake word using OpenWakeWord
     - LISTENING: Recording user command with VAD
     - PROCESSING: Transcribing and routing to plugin
     - RESPONDING: Playing TTS response
@@ -79,7 +100,7 @@ class WakeWordMode:
         self.state = State.IDLE
         self.running = False
 
-        self.porcupine = None
+        self.detector = None
         self.confirmation_beep_path = None
         self.ack_earcon_path = None
         self.recorded_audio_path = None
@@ -138,23 +159,14 @@ class WakeWordMode:
             self._cleanup()
 
     def _initialize(self):
-        """Initialize Porcupine, VAD, and confirmation beep.
+        """Initialize wake word detector, VAD, and confirmation beep.
 
         Raises:
-            RuntimeError: If Porcupine access key is missing or invalid; if any of
-                vad_enabled, bot_voice, stream_responses, or stream_tts is
-                disabled; or if the Porcupine instance cannot be created.
+            RuntimeError: If any of vad_enabled, bot_voice, stream_responses,
+                or stream_tts is disabled; or if the detector instance cannot
+                be created.
         """
         logger.debug("Initializing wake word detection and VAD")
-
-        if not self.config.porcupine_access_key:
-            error_msg = (
-                "Porcupine access key is required for wake word mode. "
-                "Get your free key at https://console.picovoice.ai/ and add it to your config: "
-                "porcupine_access_key: YOUR_KEY_HERE"
-            )
-            print(f"Error: {error_msg}")
-            raise RuntimeError(error_msg)
 
         self._require_config_enabled(
             getattr(self.config, "vad_enabled", False),
@@ -178,39 +190,14 @@ class WakeWordMode:
         )
 
         try:
-            keyword_paths = getattr(self.config, "porcupine_keyword_paths", None)
-
-            if not keyword_paths:
-                wake_keyword = self.config.wake_phrase.lower()
-
-                if hasattr(pvporcupine, "KEYWORDS") and wake_keyword not in pvporcupine.KEYWORDS:
-                    supported = ", ".join(sorted(pvporcupine.KEYWORDS)) if hasattr(pvporcupine, "KEYWORDS") else "unknown"
-                    error_msg = (
-                        f"Invalid Porcupine wake phrase '{self.config.wake_phrase}'. "
-                        f"When using built-in keywords, wake_phrase must be one of: {supported}. "
-                        "For a custom wake phrase, create a .ppn model at https://console.picovoice.ai/ "
-                        "and configure its path via 'porcupine_keyword_paths' in your config."
-                    )
-                    logger.error(error_msg)
-                    print(f"Error: {error_msg}")
-                    raise RuntimeError(error_msg)
-
-            # Create main Porcupine instance
-            self.porcupine = self._create_porcupine_instance()
-
-            if keyword_paths:
-                logger.debug("Porcupine initialized with custom keyword paths: %s", keyword_paths)
-            else:
-                logger.debug("Porcupine initialized with built-in wake phrase: '%s'", self.config.wake_phrase)
-
-            logger.debug("Porcupine sample rate: %s", self.porcupine.sample_rate)
-            logger.debug("Porcupine frame length: %s", self.porcupine.frame_length)
+            self.detector = self._create_detector_instance()
+            logger.debug("Wake word detector sample rate: %s", self.detector.sample_rate)
+            logger.debug("Wake word detector frame length: %s", self.detector.frame_length)
 
             # Create barge-in detector now that config is validated.
             self.barge_in = BargeInDetector(
-                access_key=self.config.porcupine_access_key,
-                keyword_paths=getattr(self.config, "porcupine_keyword_paths", None),
-                sensitivity=self.config.wake_word_sensitivity,
+                model_name=getattr(self.config, "openwakeword_model", "hey_jarvis"),
+                threshold=self.config.wake_word_sensitivity,
                 audio_lock=self._audio_lock,
                 audio=self.audio,
                 config=self.config,
@@ -258,37 +245,13 @@ class WakeWordMode:
             pop_streaming_chunk, self.config, ui=self.ui,
         )
 
-    def _create_porcupine_instance(self):
-        """Create a new Porcupine instance with current config.
-
-        Returns:
-            Porcupine instance
-
-        Raises:
-            RuntimeError: If initialization fails
-        """
-        keyword_paths = getattr(self.config, "porcupine_keyword_paths", None)
-
-        if keyword_paths:
-            if not isinstance(keyword_paths, (list, tuple)):
-                keyword_paths = [keyword_paths]
-
-            base_sensitivity = self.config.wake_word_sensitivity
-            sensitivities = [base_sensitivity] * len(keyword_paths)
-
-            return pvporcupine.create(
-                access_key=self.config.porcupine_access_key,
-                keyword_paths=keyword_paths,
-                sensitivities=sensitivities
-            )
-        else:
-            wake_keyword = self.config.wake_phrase.lower()
-
-            return pvporcupine.create(
-                access_key=self.config.porcupine_access_key,
-                keywords=[wake_keyword],
-                sensitivities=[self.config.wake_word_sensitivity]
-            )
+    def _create_detector_instance(self):
+        """Create a new OpenWakeWordDetector with current config."""
+        return OpenWakeWordDetector(
+            model_name=getattr(self.config, "openwakeword_model", "hey_jarvis"),
+            threshold=self.config.wake_word_sensitivity,
+            device_sample_rate=self.config.rate,
+        )
 
     def _require_config_enabled(self, flag_value, error_msg):
         """Raise RuntimeError if flag_value is not considered enabled by _is_enabled_flag()."""
@@ -308,7 +271,7 @@ class WakeWordMode:
         self.recorded_audio_path = None
 
     def _state_idle(self):
-        """IDLE state: Listen for wake word using Porcupine.
+        """IDLE state: Listen for wake word using OpenWakeWord.
 
         Listens for wake word in a blocking loop until detected.
         Plays confirmation beep and transitions to LISTENING.
@@ -318,24 +281,27 @@ class WakeWordMode:
         elif self.config.visual_state_indicator:
             print(f"⏸️  Waiting for wake word ('{self.config.wake_phrase}')...")
 
+        self.detector.reset()
         pa = None
         audio_stream = None
 
         try:
             pa = pyaudio.PyAudio()
+            input_device_index = _find_hw_input_device(pa)
             audio_stream = pa.open(
-                rate=self.porcupine.sample_rate,
+                rate=self.detector.device_sample_rate,
                 channels=1,
                 format=pyaudio.paInt16,
                 input=True,
-                frames_per_buffer=self.porcupine.frame_length
+                frames_per_buffer=self.detector.frame_length,
+                input_device_index=input_device_index,
             )
 
             while self.running and self.state == State.IDLE:
-                pcm = audio_stream.read(self.porcupine.frame_length, exception_on_overflow=False)
-                pcm = struct.unpack_from("h" * self.porcupine.frame_length, pcm)
+                pcm = audio_stream.read(self.detector.frame_length, exception_on_overflow=False)
+                pcm = struct.unpack_from("h" * self.detector.frame_length, pcm)
 
-                keyword_index = self.porcupine.process(pcm)
+                keyword_index = self.detector.process(pcm)
 
                 if keyword_index >= 0:
                     logger.info("Wake word detected: '%s'", self.config.wake_phrase)
@@ -343,8 +309,6 @@ class WakeWordMode:
                         self._req_seq += 1
                         self._req_filler_s = None
                     self._req_t_start = time.monotonic()
-
-                    self._play_confirmation_beep()
 
                     self.state = State.LISTENING
                     break
@@ -356,6 +320,10 @@ class WakeWordMode:
             self.running = False
         finally:
             self._cleanup_pyaudio(audio_stream, pa)
+
+        # Play beep after PyAudio stream is closed so both don't compete for the device
+        if self.state == State.LISTENING:
+            self._play_confirmation_beep()
 
     def _state_listening(self):
         """LISTENING state: Record audio with VAD until silence detected.
@@ -785,18 +753,18 @@ class WakeWordMode:
         logger.info(" ".join(parts))
 
     def _cleanup(self):
-        """Clean up Porcupine, VAD, barge-in thread, and audio resources."""
+        """Clean up wake word detector, VAD, barge-in thread, and audio resources."""
         logger.info("Cleaning up wake word mode")
 
         # Clean up barge-in thread if running
         self._cleanup_barge_in(timeout=0.5)
 
-        if self.porcupine is not None:
+        if self.detector is not None:
             try:
-                self.porcupine.delete()
+                self.detector.delete()
             except Exception as e:
-                logger.warning("Failed to delete Porcupine instance: %s", e)
+                logger.debug("Failed to delete wake word detector instance: %s", e)
             finally:
-                self.porcupine = None
+                self.detector = None
 
         self.running = False

--- a/docs/CUSTOM_WAKE_WORDS.md
+++ b/docs/CUSTOM_WAKE_WORDS.md
@@ -1,199 +1,100 @@
 # Custom Wake Words Guide
 
-This guide shows you how to create and use custom wake words like "hey sandvoice" instead of built-in keywords.
+This guide shows you how to create and use custom wake words like "hey sandvoice" with openWakeWord.
 
 ## Overview
 
-SandVoice supports two types of wake words:
-1. **Built-in Keywords**: Pre-trained words like "computer", "jarvis", "porcupine"
-2. **Custom Wake Words**: Your own phrases trained on Picovoice Console
+SandVoice uses [openWakeWord](https://github.com/dscripka/openWakeWord) (MIT-licensed, no API key required).
+You can use any of the built-in models or train your own custom `.onnx` model.
 
-## Built-in Wake Words
+## Built-in Models
 
-Available without any setup:
-- alexa
-- americano
-- blueberry
-- bumblebee
-- computer
-- grapefruit
-- grasshopper
-- hey barista
-- hey google
-- hey siri
-- jarvis
-- ok google
-- pico clock
-- picovoice
-- porcupine
-- terminator
-
-**Quick Start with Built-in:**
-```yaml
-# ~/.sandvoice/config.yaml
-wake_phrase: "computer"
-porcupine_access_key: "YOUR_ACCESS_KEY"
-```
-
-## Creating Custom Wake Words
-
-### Step 1: Get Picovoice Access Key
-
-1. Visit [Picovoice Console](https://console.picovoice.ai/)
-2. Sign up (free tier available)
-3. Copy your **Access Key** from the dashboard
-
-**Free Tier Limits:**
-- ✅ 3 custom wake words
-- ✅ Unlimited API calls
-- ✅ Works offline after first download
-
-### Step 2: Train Your Custom Wake Word
-
-1. Go to **Porcupine Wake Word** section
-2. Click **"Train Custom Wake Word"**
-3. Enter your phrase (e.g., "hey sandvoice", "sand voice")
-4. Select **Language**: English
-5. Select **Platform(s)**:
-   - **macOS (x86_64)** for Intel Macs
-   - **macOS (arm64)** for M1/M2 Macs
-   - **Linux (ARM Cortex-A)** for Raspberry Pi
-   - You can train multiple platforms at once
-6. Click **"Train"** (takes 2-5 minutes)
-7. Download the `.ppn` file(s)
-
-### Step 3: Install the .ppn File
-
-```bash
-# Create directory for wake word models
-mkdir -p ~/.sandvoice/wake-words/
-
-# Move your downloaded .ppn file
-mv ~/Downloads/Sand-voice_en_mac_v4_0_0.ppn ~/.sandvoice/wake-words/
-```
-
-### Step 4: Configure SandVoice
-
-Edit `~/.sandvoice/config.yaml`:
+openWakeWord ships with a small set of pre-trained models. The default is `hey_jarvis`.
+Set `openwakeword_model` in `~/.sandvoice/config.yaml` to use one:
 
 ```yaml
-wake_phrase: "sand voice"
-porcupine_access_key: "YOUR_ACCESS_KEY_HERE"
-porcupine_keyword_paths: "/Users/username/.sandvoice/wake-words/Sand-voice_en_mac_v4_0_0.ppn"
+openwakeword_model: hey_jarvis   # default
+wake_phrase: "hey jarvis"
+wake_word_sensitivity: 0.35
+```
 
-# Optional: Adjust sensitivity (0.0 - 1.0)
+Other available built-in names (pass exact string as `openwakeword_model`):
+- `hey_jarvis`
+- `alexa`
+- `hey_mycroft`
+
+## Training a Custom Wake Word
+
+Custom models are `.onnx` files you train yourself. The easiest way is
+[openWakeWord's Colab notebook](https://github.com/dscripka/openWakeWord#training-new-models).
+
+### Quick Steps
+
+1. Open the openWakeWord training notebook in Google Colab (link in the repo above).
+2. In the **Target phrase** cell, enter your phrase (e.g. `hey sandvoice`).
+3. Run all cells. Training takes ~10–20 minutes on a free Colab GPU.
+4. Download the generated `.onnx` file from the Colab session.
+5. Copy it to your machine, e.g. `~/.sandvoice/wake-words/hey_sandvoice.onnx`.
+6. Point SandVoice at it:
+
+```yaml
+openwakeword_model: "/home/user/.sandvoice/wake-words/hey_sandvoice.onnx"
+wake_phrase: "hey sandvoice"
 wake_word_sensitivity: 0.5
 ```
 
-**Important:**
-- Use **absolute path** for `porcupine_keyword_paths`
-- Don't use `~` shorthand - use full `/Users/username/...` path
-- `wake_phrase` is for display only - actual detection uses the .ppn file
+**Notes:**
+- Use an absolute path for `openwakeword_model` when pointing to a custom `.onnx` file.
+- `wake_phrase` is for display/logging only; actual detection uses the model.
+- Train separate models per platform if needed — openWakeWord models are architecture-independent (ONNX), so the same file works on macOS M1 and Raspberry Pi.
 
-### Step 5: Test It
-
-```bash
-cd ~/path/to/sandvoice
-source env/bin/activate
-python sandvoice.py --wake-word
-```
-
-Say your custom phrase to activate!
-
-## Multi-Platform Setup
-
-If you use SandVoice on multiple devices, train separate models:
-
-**macOS Config:**
-```yaml
-porcupine_keyword_paths: "/Users/username/.sandvoice/wake-words/Sand-voice_en_mac_v4_0_0.ppn"
-```
-
-**Raspberry Pi Config:**
-```yaml
-porcupine_keyword_paths: "/home/pi/.sandvoice/wake-words/Sand-voice_en_linux_v4_0_0.ppn"
-```
-
-## Configuration Examples
-
-### Example 1: Single Custom Wake Word (TXT format)
-```yaml
-wake_phrase: "hey assistant"
-porcupine_access_key: "REDACTED"
-porcupine_keyword_paths: "/Users/john/.sandvoice/wake-words/hey-assistant_en_mac_v4_0_0.ppn"
-wake_word_sensitivity: 0.5
-```
-
-### Example 2: Single Custom Wake Word (JSON format)
-```yaml
-wake_phrase: "sand voice"
-porcupine_access_key: "REDACTED"
-porcupine_keyword_paths: "/Users/john/.sandvoice/wake-words/Sand-voice_en_mac_v4_0_0.ppn"
-wake_word_sensitivity: 0.7
-```
-
-### Example 3: Built-in Wake Word
-```yaml
-wake_phrase: "jarvis"
-porcupine_access_key: "REDACTED"
-# No porcupine_keyword_paths needed for built-in keywords
-wake_word_sensitivity: 0.5
-```
-
-## Troubleshooting
-
-For troubleshooting wake word detection issues, see the [official Porcupine documentation](https://picovoice.ai/docs/porcupine/).
-
-## Advanced Configuration
-
-### Adjusting VAD (Voice Activity Detection)
-
-Control how long SandVoice listens after wake word:
+## Configuration Reference
 
 ```yaml
-# How long to wait for silence before processing (seconds)
-vad_silence_duration: 1.5
+# Wake word settings
+openwakeword_model: hey_jarvis          # built-in name or absolute path to .onnx
+wake_phrase: "hey jarvis"               # display name shown in logs/terminal
+wake_word_sensitivity: 0.35            # detection threshold (0.0–1.0)
 
-# VAD aggressiveness (0-3, higher = more aggressive silence detection)
-vad_aggressiveness: 3
+# VAD settings (control how long to listen after wake word)
+vad_silence_duration: 1.5              # seconds of silence = end of utterance
+vad_aggressiveness: 3                  # 0–3, higher = more aggressive silence detection
+vad_timeout: 30                        # max recording length (seconds)
 
-# Maximum continuous speech duration (seconds)
-vad_timeout: 30
-```
-
-### Audio Feedback
-
-```yaml
-# Play beep when wake word detected
+# Audio feedback
 wake_confirmation_beep: enabled
-wake_confirmation_beep_freq: 800  # Hz
-wake_confirmation_beep_duration: 0.1  # seconds
-
-# Show visual state indicators in terminal
+wake_confirmation_beep_freq: 800       # Hz
+wake_confirmation_beep_duration: 0.1   # seconds
 visual_state_indicator: enabled
 ```
 
+## Raspberry Pi / Linux Install
+
+openWakeWord uses ONNX Runtime, not tflite. Install:
+
+```bash
+pip install openwakeword>=0.6.0 --no-deps
+pip install scipy
+```
+
+If `onnxruntime` is not already installed, add it:
+
+```bash
+pip install onnxruntime==1.20.0
+```
+
+(Pin to 1.20.0 — later versions have known issues on aarch64 Pi.)
+
 ## Tips for Best Results
 
-1. **Train with natural voice**: Say the phrase naturally, not robotically
-2. **Quiet environment**: Train in a quiet room
-3. **Unique phrases**: Avoid common words to reduce false positives
-4. **Repeat training**: If detection is poor, re-train the model
-5. **Test distances**: Test from 1m, 2m, 3m away to find optimal sensitivity
+1. **Train with natural voice**: Say the phrase naturally, not robotically.
+2. **Unique phrases**: Avoid common words to reduce false positives.
+3. **Adjust sensitivity**: Lower `wake_word_sensitivity` (e.g. 0.3) to catch more detections; raise it (e.g. 0.7) to reduce false positives.
+4. **Test distances**: Test from 1 m, 2 m, 3 m to find optimal placement.
 
-## Getting Help
+## Troubleshooting
 
-If you're still having issues:
-1. Enable debug mode: `debug: enabled` in config
-2. Check logs for error messages
-3. Report issues: https://github.com/spideyz0r/sandvoice/issues
-4. Include:
-   - Platform (macOS/Linux/Pi)
-   - Config file (remove access key)
-   - Error messages
-
-## References
-
-- [Picovoice Console](https://console.picovoice.ai/)
-- [Porcupine Documentation](https://picovoice.ai/docs/porcupine/)
-- [SandVoice GitHub](https://github.com/spideyz0r/sandvoice)
+1. Enable debug mode: `debug: enabled` in config.
+2. Check logs for `Wake word score:` lines to see raw scores for your phrase.
+3. If scores never reach threshold, lower `wake_word_sensitivity` or retrain.
+4. Report issues: https://github.com/spideyz0r/sandvoice/issues

--- a/plan/backlog/52-replace-porcupine-with-openwakeword.md
+++ b/plan/backlog/52-replace-porcupine-with-openwakeword.md
@@ -1,6 +1,6 @@
 # Replace Porcupine with openWakeWord
 
-**Status**: 📋 Backlog
+**Status**: 🚧 In Progress
 **Priority**: 52
 **Platforms**: macOS M1, Raspberry Pi 3B
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,16 @@ Jinja2
 lameenc
 numpy
 openai
-pvporcupine==4.0.1
+# onnxruntime: hard-pinned — 1.21+ crashes on Pi 3B (aarch64 STL vector assertion).
+# Do not bump without testing on Pi 3B first.
+onnxruntime==1.20.0
+# openwakeword: on Raspberry Pi install with --no-deps before this file (tflite-runtime
+# has no aarch64 wheel for Python 3.13): pip install openwakeword>=0.6.0 --no-deps && pip install scipy
+openwakeword>=0.6.0
 PyAudio
 pygame
 pynput
 PyYAML
 Requests
+scipy
 webrtcvad==2.0.10

--- a/sandvoice.py
+++ b/sandvoice.py
@@ -937,7 +937,7 @@ if __name__ == "__main__":
         except ImportError as e:
             print("Error: Wake word mode failed to import one or more required packages.")
             print("Please ensure all project dependencies are installed (e.g., 'pip install -r requirements.txt'),")
-            print("including pvporcupine==4.0.1, webrtcvad==2.0.10, and PyAudio. Details:")
+            print("including openwakeword, onnxruntime==1.20.0, webrtcvad==2.0.10, and PyAudio. Details:")
             print(f"  {e}")
             sys.exit(1)
 

--- a/sandvoice.py
+++ b/sandvoice.py
@@ -937,7 +937,7 @@ if __name__ == "__main__":
         except ImportError as e:
             print("Error: Wake word mode failed to import one or more required packages.")
             print("Please ensure all project dependencies are installed (e.g., 'pip install -r requirements.txt'),")
-            print("including openwakeword, onnxruntime==1.20.0, webrtcvad==2.0.10, and PyAudio. Details:")
+            print("including openwakeword, onnxruntime==1.20.0, scipy, webrtcvad==2.0.10, and PyAudio. Details:")
             print(f"  {e}")
             sys.exit(1)
 

--- a/tests/test_barge_in.py
+++ b/tests/test_barge_in.py
@@ -35,7 +35,7 @@ class TestBargeInDetectorInit(unittest.TestCase):
         mock_audio = Mock()
         d = self._make_detector(model_name="alexa", threshold=0.7, audio_lock=lock, audio=mock_audio)
         self.assertEqual(d._model_name, "alexa")
-        self.assertEqual(d._sensitivity, 0.7)
+        self.assertEqual(d._threshold, 0.7)
         self.assertIs(d._audio_lock, lock)
         self.assertIs(d._audio, mock_audio)
 

--- a/tests/test_barge_in.py
+++ b/tests/test_barge_in.py
@@ -11,19 +11,18 @@ class TestBargeInDetectorInit(unittest.TestCase):
     def setUp(self):
         logging.disable(logging.CRITICAL)
         self.mock_config = Mock()
-        self.mock_config.wake_phrase = "porcupine"
-        self.mock_config.porcupine_access_key = "test-key"
-        self.mock_config.porcupine_keyword_paths = None
+        self.mock_config.wake_phrase = "hey jarvis"
         self.mock_config.wake_word_sensitivity = 0.5
+        self.mock_config.openwakeword_model = "hey_jarvis"
+        self.mock_config.rate = 16000
 
     def tearDown(self):
         logging.disable(logging.NOTSET)
 
     def _make_detector(self, **kwargs):
         defaults = dict(
-            access_key="test-key",
-            keyword_paths=None,
-            sensitivity=0.5,
+            model_name="hey_jarvis",
+            threshold=0.5,
             audio_lock=None,
             audio=Mock(),
             config=self.mock_config,
@@ -34,9 +33,8 @@ class TestBargeInDetectorInit(unittest.TestCase):
     def test_init_stores_params(self):
         lock = threading.Lock()
         mock_audio = Mock()
-        d = self._make_detector(access_key="key123", sensitivity=0.7, audio_lock=lock, audio=mock_audio)
-        self.assertEqual(d._access_key, "key123")
-        self.assertIsNone(d._keyword_paths)
+        d = self._make_detector(model_name="alexa", threshold=0.7, audio_lock=lock, audio=mock_audio)
+        self.assertEqual(d._model_name, "alexa")
         self.assertEqual(d._sensitivity, 0.7)
         self.assertIs(d._audio_lock, lock)
         self.assertIs(d._audio, mock_audio)
@@ -60,16 +58,16 @@ class TestBargeInDetectorStartStop(unittest.TestCase):
     def setUp(self):
         logging.disable(logging.CRITICAL)
         self.mock_config = Mock()
-        self.mock_config.wake_phrase = "porcupine"
+        self.mock_config.wake_phrase = "hey jarvis"
+        self.mock_config.rate = 16000
 
     def tearDown(self):
         logging.disable(logging.NOTSET)
 
     def _make_detector(self, **kwargs):
         defaults = dict(
-            access_key="test-key",
-            keyword_paths=None,
-            sensitivity=0.5,
+            model_name="hey_jarvis",
+            threshold=0.5,
             audio_lock=None,
             audio=Mock(),
             config=self.mock_config,
@@ -77,18 +75,16 @@ class TestBargeInDetectorStartStop(unittest.TestCase):
         defaults.update(kwargs)
         return BargeInDetector(**defaults)
 
-    @patch('common.barge_in.pvporcupine.create')
+    @patch('common.barge_in.OpenWakeWordDetector')
     @patch('common.barge_in.pyaudio.PyAudio')
-    def test_start_creates_and_starts_thread(self, mock_pyaudio_class, mock_porcupine_create):
-        mock_porcupine = Mock()
-        mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 512
-        # Keep thread blocked until we stop it
-        mock_porcupine.process.return_value = -1
-        mock_porcupine_create.return_value = mock_porcupine
+    def test_start_creates_and_starts_thread(self, mock_pyaudio_class, mock_detector_class):
+        mock_detector = Mock()
+        mock_detector.sample_rate = 16000
+        mock_detector.frame_length = 1280
+        mock_detector.process.return_value = -1
+        mock_detector_class.return_value = mock_detector
 
         mock_stream = Mock()
-        # Block on read so thread stays alive
         stop_event = threading.Event()
         def blocking_read(n, exception_on_overflow=False):
             stop_event.wait(timeout=5)
@@ -116,13 +112,11 @@ class TestBargeInDetectorStartStop(unittest.TestCase):
 
         d.start()
 
-        # Should not replace the existing thread
         self.assertIs(d._thread, mock_thread)
 
     def test_stop_signals_thread_and_clears_state(self):
         d = self._make_detector()
         mock_thread = Mock()
-        # Simulate thread alive before join, dead after join
         mock_thread.is_alive.side_effect = [True, False]
         d._thread = mock_thread
         d._event.set()
@@ -135,8 +129,6 @@ class TestBargeInDetectorStartStop(unittest.TestCase):
         self.assertFalse(d._event.is_set())
 
     def test_stop_nonblocking_when_timeout_zero(self):
-        # timeout=0 signals the stop flag but does not join; since the thread
-        # is still alive, internal state is NOT reset (prevents duplicate threads).
         d = self._make_detector()
         mock_thread = Mock()
         mock_thread.is_alive.return_value = True
@@ -145,26 +137,21 @@ class TestBargeInDetectorStartStop(unittest.TestCase):
         d.stop(timeout=0)
 
         mock_thread.join.assert_not_called()
-        self.assertIsNotNone(d._thread)  # thread ref kept until it actually exits
-        self.assertTrue(d._stop_flag.is_set())  # stop was signaled
+        self.assertIsNotNone(d._thread)
+        self.assertTrue(d._stop_flag.is_set())
 
     def test_stop_suppresses_runtime_error_on_join(self):
-        # RuntimeError from join() is suppressed; since the thread is still alive
-        # after the failed join, internal state is not reset.
         d = self._make_detector()
         mock_thread = Mock()
         mock_thread.is_alive.return_value = True
         mock_thread.join.side_effect = RuntimeError("cannot join")
         d._thread = mock_thread
-        # Should not raise
         d.stop(timeout=0.1)
-        # Thread still alive after failed join — ref and stop flag kept set
         self.assertIsNotNone(d._thread)
         self.assertTrue(d._stop_flag.is_set())
 
     def test_stop_before_start_does_not_crash(self):
         d = self._make_detector()
-        # Should not raise
         d.stop()
 
     def test_double_start_does_not_spawn_extra_threads(self):
@@ -184,16 +171,15 @@ class TestBargeInDetectorIsTriggered(unittest.TestCase):
     def setUp(self):
         logging.disable(logging.CRITICAL)
         self.mock_config = Mock()
-        self.mock_config.wake_phrase = "porcupine"
+        self.mock_config.rate = 16000
 
     def tearDown(self):
         logging.disable(logging.NOTSET)
 
     def _make_detector(self):
         return BargeInDetector(
-            access_key="test-key",
-            keyword_paths=None,
-            sensitivity=0.5,
+            model_name="hey_jarvis",
+            threshold=0.5,
             audio_lock=None,
             audio=Mock(),
             config=self.mock_config,
@@ -220,16 +206,15 @@ class TestBargeInDetectorRunWithPolling(unittest.TestCase):
     def setUp(self):
         logging.disable(logging.CRITICAL)
         self.mock_config = Mock()
-        self.mock_config.wake_phrase = "porcupine"
+        self.mock_config.rate = 16000
 
     def tearDown(self):
         logging.disable(logging.NOTSET)
 
     def _make_detector(self):
         return BargeInDetector(
-            access_key="test-key",
-            keyword_paths=None,
-            sensitivity=0.5,
+            model_name="hey_jarvis",
+            threshold=0.5,
             audio_lock=None,
             audio=Mock(),
             config=self.mock_config,
@@ -279,26 +264,22 @@ class TestBargeInDetectorRunWithPolling(unittest.TestCase):
         polling_thread = threading.Thread(target=run_polling)
         polling_thread.start()
 
-        # Wait for operation to start, then trigger barge-in
         operation_started.wait(timeout=2.0)
         d._event.set()
 
-        # Polling should return quickly (not wait for the slow operation)
         polling_thread.join(timeout=1.0)
         self.assertFalse(polling_thread.is_alive(), "Polling should exit quickly on barge-in")
         self.assertIs(result_holder[0], _BARGE_IN)
 
-        # Clean up slow operation
         operation_completed.wait(timeout=1.0)
 
     def test_barge_in_sentinel_is_unique_object(self):
         from common.barge_in import _BARGE_IN as sentinel
-        # Sentinel must be a distinct object — not None, True, False, 0, or any other singleton
         self.assertIsNot(sentinel, None)
         self.assertIsNot(sentinel, True)
         self.assertIsNot(sentinel, False)
         self.assertIsNot(sentinel, 0)
-        self.assertIs(sentinel, _BARGE_IN)  # identity is stable
+        self.assertIs(sentinel, _BARGE_IN)
 
     def test_lead_fn_fires_after_delay_when_operation_slow(self):
         """lead_fn is called once the delay elapses while operation is still running."""
@@ -343,7 +324,6 @@ class TestBargeInDetectorRunWithPolling(unittest.TestCase):
             return "done"
 
         d.run_with_polling(slow_op, "test", lead_delay_s=0.05, lead_fn=lead)
-        # Give the lead thread a moment to finish
         time.sleep(0.1)
         with lock:
             self.assertEqual(call_count[0], 1)
@@ -359,7 +339,6 @@ class TestBargeInDetectorRunWithPolling(unittest.TestCase):
             time.sleep(0.2)
             return "result"
 
-        # Should not raise, and should return the operation result
         result = d.run_with_polling(slow_op, "test", lead_delay_s=0.05, lead_fn=bad_lead)
         self.assertEqual(result, "result")
 
@@ -368,33 +347,29 @@ class TestBargeInDetectorDetectionLoop(unittest.TestCase):
     def setUp(self):
         logging.disable(logging.CRITICAL)
         self.mock_config = Mock()
-        self.mock_config.wake_phrase = "porcupine"
-        self.mock_config.porcupine_access_key = "test-key"
-        self.mock_config.porcupine_keyword_paths = None
-        self.mock_config.wake_word_sensitivity = 0.5
+        self.mock_config.rate = 16000
 
     def tearDown(self):
         logging.disable(logging.NOTSET)
 
     def _make_detector(self):
         return BargeInDetector(
-            access_key="test-key",
-            keyword_paths=None,
-            sensitivity=0.5,
+            model_name="hey_jarvis",
+            threshold=0.5,
             audio_lock=None,
             audio=Mock(),
             config=self.mock_config,
         )
 
-    @patch('common.barge_in.pvporcupine.create')
+    @patch('common.barge_in.OpenWakeWordDetector')
     @patch('common.barge_in.pyaudio.PyAudio')
-    def test_detection_loop_sets_event_on_wake_word(self, mock_pyaudio_class, mock_porcupine_create):
-        """When Porcupine detects the wake word, _event is set."""
-        mock_porcupine = Mock()
-        mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 512
-        mock_porcupine.process.side_effect = [-1, -1, 0]  # wake word on 3rd call
-        mock_porcupine_create.return_value = mock_porcupine
+    def test_detection_loop_sets_event_on_wake_word(self, mock_pyaudio_class, mock_detector_class):
+        """When OpenWakeWord detects the wake word, _event is set."""
+        mock_detector = Mock()
+        mock_detector.sample_rate = 16000
+        mock_detector.frame_length = 1280
+        mock_detector.process.side_effect = [-1, -1, 0]  # wake word on 3rd call
+        mock_detector_class.return_value = mock_detector
 
         def fake_read(n, exception_on_overflow=False):
             return b'\x00' * (n * 2)
@@ -402,30 +377,28 @@ class TestBargeInDetectorDetectionLoop(unittest.TestCase):
         mock_stream.read = fake_read
 
         import struct
-        with patch('common.barge_in.struct.unpack_from', return_value=[0] * 512):
+        with patch('common.barge_in.struct.unpack_from', return_value=[0] * 1280):
             mock_pa = Mock()
             mock_pa.open.return_value = mock_stream
             mock_pyaudio_class.return_value = mock_pa
 
             d = self._make_detector()
             d.start()
-            # Wait for the event to be set
             detected = d._event.wait(timeout=2.0)
             d.stop(timeout=0.5)
 
         self.assertTrue(detected, "Expected wake word to be detected and event set")
 
-    @patch('common.barge_in.pvporcupine.create')
+    @patch('common.barge_in.OpenWakeWordDetector')
     @patch('common.barge_in.pyaudio.PyAudio')
-    def test_detection_loop_stops_on_stop_flag(self, mock_pyaudio_class, mock_porcupine_create):
+    def test_detection_loop_stops_on_stop_flag(self, mock_pyaudio_class, mock_detector_class):
         """When stop_flag is set, the detection loop exits without triggering barge-in."""
-        mock_porcupine = Mock()
-        mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 512
-        mock_porcupine.process.return_value = -1  # never detect
-        mock_porcupine_create.return_value = mock_porcupine
+        mock_detector = Mock()
+        mock_detector.sample_rate = 16000
+        mock_detector.frame_length = 1280
+        mock_detector.process.return_value = -1
+        mock_detector_class.return_value = mock_detector
 
-        # Block on read until stop_flag is set
         stop_read = threading.Event()
         def blocking_read(n, exception_on_overflow=False):
             stop_read.wait(timeout=5)
@@ -441,104 +414,33 @@ class TestBargeInDetectorDetectionLoop(unittest.TestCase):
         d.start()
         self.assertTrue(d._thread.is_alive())
 
-        # Signal stop and unblock read
         stop_read.set()
         d.stop(timeout=1.0)
 
         self.assertIsNone(d._thread)
         self.assertFalse(d.is_triggered)
 
-    @patch('common.barge_in.pvporcupine.create')
+    @patch('common.barge_in.OpenWakeWordDetector')
     @patch('common.barge_in.pyaudio.PyAudio')
-    def test_detection_loop_handles_porcupine_init_error(self, mock_pyaudio_class, mock_porcupine_create):
-        """If Porcupine cannot be created, the thread logs an error and exits cleanly."""
-        mock_porcupine_create.side_effect = Exception("Porcupine init failed")
+    def test_detection_loop_handles_detector_init_error(self, mock_pyaudio_class, mock_detector_class):
+        """If OpenWakeWordDetector cannot be created, the thread logs an error and exits cleanly."""
+        mock_detector_class.side_effect = Exception("detector init failed")
 
         d = self._make_detector()
         d.start()
-        # Thread should exit quickly after the error
         if d._thread is not None:
             d._thread.join(timeout=2.0)
 
         self.assertFalse(d.is_triggered)
 
-    @patch('common.barge_in.pvporcupine.create')
+    @patch('common.barge_in.OpenWakeWordDetector')
     @patch('common.barge_in.pyaudio.PyAudio')
-    def test_detection_loop_uses_built_in_keyword_when_no_paths(self, mock_pyaudio_class, mock_porcupine_create):
-        """Without keyword_paths, Porcupine is created with keywords=[wake_phrase]."""
-        mock_porcupine = Mock()
-        mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 512
-        mock_porcupine.process.return_value = -1
-        mock_porcupine_create.return_value = mock_porcupine
-
-        stop_read = threading.Event()
-        def blocking_read(n, exception_on_overflow=False):
-            stop_read.wait(timeout=2)
-            raise Exception("done")
-        mock_stream = Mock()
-        mock_stream.read = blocking_read
-        mock_pa = Mock()
-        mock_pa.open.return_value = mock_stream
-        mock_pyaudio_class.return_value = mock_pa
-
-        d = self._make_detector()
-        d.start()
-        stop_read.set()
-        d.stop(timeout=1.0)
-
-        mock_porcupine_create.assert_called_with(
-            access_key="test-key",
-            keywords=["porcupine"],
-            sensitivities=[0.5],
-        )
-
-    @patch('common.barge_in.pvporcupine.create')
-    @patch('common.barge_in.pyaudio.PyAudio')
-    def test_detection_loop_uses_keyword_paths_when_provided(self, mock_pyaudio_class, mock_porcupine_create):
-        """With keyword_paths, Porcupine is created with keyword_paths and sensitivities."""
-        mock_porcupine = Mock()
-        mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 512
-        mock_porcupine.process.return_value = -1
-        mock_porcupine_create.return_value = mock_porcupine
-
-        stop_read = threading.Event()
-        def blocking_read(n, exception_on_overflow=False):
-            stop_read.wait(timeout=2)
-            raise Exception("done")
-        mock_stream = Mock()
-        mock_stream.read = blocking_read
-        mock_pa = Mock()
-        mock_pa.open.return_value = mock_stream
-        mock_pyaudio_class.return_value = mock_pa
-
-        d = BargeInDetector(
-            access_key="test-key",
-            keyword_paths=["/path/to/model.ppn"],
-            sensitivity=0.6,
-            audio_lock=None,
-            audio=Mock(),
-            config=self.mock_config,
-        )
-        d.start()
-        stop_read.set()
-        d.stop(timeout=1.0)
-
-        mock_porcupine_create.assert_called_with(
-            access_key="test-key",
-            keyword_paths=["/path/to/model.ppn"],
-            sensitivities=[0.6],
-        )
-
-    @patch('common.barge_in.pvporcupine.create')
-    @patch('common.barge_in.pyaudio.PyAudio')
-    def test_detection_loop_handles_audio_read_error(self, mock_pyaudio_class, mock_porcupine_create):
+    def test_detection_loop_handles_audio_read_error(self, mock_pyaudio_class, mock_detector_class):
         """An error reading audio is caught and the loop exits cleanly."""
-        mock_porcupine = Mock()
-        mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 512
-        mock_porcupine_create.return_value = mock_porcupine
+        mock_detector = Mock()
+        mock_detector.sample_rate = 16000
+        mock_detector.frame_length = 1280
+        mock_detector_class.return_value = mock_detector
 
         mock_stream = Mock()
         mock_stream.read.side_effect = Exception("hw error")
@@ -551,19 +453,18 @@ class TestBargeInDetectorDetectionLoop(unittest.TestCase):
         if d._thread is not None:
             d._thread.join(timeout=2.0)
 
-        # Event should not be set (error before detection)
         self.assertFalse(d.is_triggered)
 
-    @patch('common.barge_in.pvporcupine.create')
+    @patch('common.barge_in.OpenWakeWordDetector')
     @patch('common.barge_in.pyaudio.PyAudio')
     def test_detection_loop_audio_read_error_during_shutdown_logs_debug(
-        self, mock_pyaudio_class, mock_porcupine_create
+        self, mock_pyaudio_class, mock_detector_class
     ):
         """Audio read error during shutdown (stop_flag set) is logged at DEBUG, not WARNING."""
-        mock_porcupine = Mock()
-        mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 512
-        mock_porcupine_create.return_value = mock_porcupine
+        mock_detector = Mock()
+        mock_detector.sample_rate = 16000
+        mock_detector.frame_length = 1280
+        mock_detector_class.return_value = mock_detector
 
         mock_stream = Mock()
         mock_stream.read.side_effect = Exception("stream closed")
@@ -572,7 +473,7 @@ class TestBargeInDetectorDetectionLoop(unittest.TestCase):
         mock_pyaudio_class.return_value = mock_pa
 
         d = self._make_detector()
-        d._stop_flag.set()  # simulate shutdown in progress
+        d._stop_flag.set()
         d._thread = threading.Thread(target=d._detection_loop, daemon=True)
         d._thread.start()
         d._thread.join(timeout=2.0)
@@ -586,16 +487,15 @@ class TestBargeInCleanupPyAudio(unittest.TestCase):
     def setUp(self):
         logging.disable(logging.CRITICAL)
         self.mock_config = Mock()
-        self.mock_config.wake_phrase = "porcupine"
+        self.mock_config.rate = 16000
 
     def tearDown(self):
         logging.disable(logging.NOTSET)
 
     def _make_detector(self):
         return BargeInDetector(
-            access_key="test-key",
-            keyword_paths=None,
-            sensitivity=0.5,
+            model_name="hey_jarvis",
+            threshold=0.5,
             audio_lock=None,
             audio=Mock(),
             config=self.mock_config,
@@ -606,7 +506,6 @@ class TestBargeInCleanupPyAudio(unittest.TestCase):
         mock_stream = Mock()
         mock_stream.stop_stream.side_effect = Exception("hw error")
         mock_pa = Mock()
-        # Should not raise; close() and pa.terminate() must still be called
         d._cleanup_pyaudio(mock_stream, mock_pa)
         mock_stream.close.assert_called_once()
         mock_pa.terminate.assert_called_once()
@@ -624,104 +523,17 @@ class TestBargeInCleanupPyAudio(unittest.TestCase):
         mock_stream = Mock()
         mock_pa = Mock()
         mock_pa.terminate.side_effect = Exception("terminate error")
-        # Should not raise
         d._cleanup_pyaudio(mock_stream, mock_pa)
 
     def test_cleanup_pyaudio_handles_both_none(self):
         d = self._make_detector()
-        # Should not raise
         d._cleanup_pyaudio(None, None)
-
-
-class TestBargeInKeywordPaths(unittest.TestCase):
-    """Tests for keyword_paths handling in _create_porcupine_instance."""
-
-    def setUp(self):
-        logging.disable(logging.CRITICAL)
-        self.mock_config = Mock()
-        self.mock_config.wake_phrase = "porcupine"
-
-    def tearDown(self):
-        logging.disable(logging.NOTSET)
-
-    @patch('common.barge_in.pvporcupine.create')
-    @patch('common.barge_in.pyaudio.PyAudio')
-    def test_single_string_keyword_path_wrapped_in_list(self, mock_pyaudio_class, mock_porcupine_create):
-        """A string keyword_path (not a list) should be wrapped in a list."""
-        mock_porcupine = Mock()
-        mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 512
-        mock_porcupine.process.return_value = -1
-        mock_porcupine_create.return_value = mock_porcupine
-
-        stop_read = threading.Event()
-        def blocking_read(n, exception_on_overflow=False):
-            stop_read.wait(timeout=2)
-            raise Exception("done")
-        mock_stream = Mock()
-        mock_stream.read = blocking_read
-        mock_pa = Mock()
-        mock_pa.open.return_value = mock_stream
-        mock_pyaudio_class.return_value = mock_pa
-
-        d = BargeInDetector(
-            access_key="test-key",
-            keyword_paths="/path/to/model.ppn",  # string, not list
-            sensitivity=0.6,
-            audio_lock=None,
-            audio=Mock(),
-            config=self.mock_config,
-        )
-        d.start()
-        stop_read.set()
-        d.stop(timeout=1.0)
-
-        mock_porcupine_create.assert_called_with(
-            access_key="test-key",
-            keyword_paths=["/path/to/model.ppn"],
-            sensitivities=[0.6],
-        )
-
-    @patch('common.barge_in.pvporcupine.create')
-    @patch('common.barge_in.pyaudio.PyAudio')
-    def test_porcupine_delete_exception_suppressed(self, mock_pyaudio_class, mock_porcupine_create):
-        """If porcupine_instance.delete() raises, the exception is suppressed."""
-        mock_porcupine = Mock()
-        mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 512
-        mock_porcupine.process.return_value = -1
-        mock_porcupine.delete.side_effect = Exception("delete error")
-        mock_porcupine_create.return_value = mock_porcupine
-
-        stop_read = threading.Event()
-        def blocking_read(n, exception_on_overflow=False):
-            stop_read.wait(timeout=2)
-            raise Exception("done")
-        mock_stream = Mock()
-        mock_stream.read = blocking_read
-        mock_pa = Mock()
-        mock_pa.open.return_value = mock_stream
-        mock_pyaudio_class.return_value = mock_pa
-
-        d = BargeInDetector(
-            access_key="test-key",
-            keyword_paths=None,
-            sensitivity=0.5,
-            audio_lock=None,
-            audio=Mock(),
-            config=self.mock_config,
-        )
-        d.start()
-        stop_read.set()
-        # Should not raise even though delete() fails
-        d.stop(timeout=1.0)
 
 
 class TestBargeInSentinel(unittest.TestCase):
     """Tests for the _BARGE_IN sentinel object."""
 
     def test_barge_in_sentinel_is_unique(self):
-        """_BARGE_IN is a unique object identity sentinel."""
         from common.barge_in import _BARGE_IN as s1
         from common.barge_in import _BARGE_IN as s2
         self.assertIs(s1, s2)
@@ -733,7 +545,6 @@ class TestBargeInSentinel(unittest.TestCase):
         self.assertIsNot(_BARGE_IN, False)
 
     def test_barge_in_sentinel_identity_check(self):
-        """Confirm identity semantics (not equality)."""
         self.assertIs(_BARGE_IN, _BARGE_IN)
         self.assertIsNot(_BARGE_IN, object())
 

--- a/tests/test_barge_in.py
+++ b/tests/test_barge_in.py
@@ -92,6 +92,7 @@ class TestBargeInDetectorStartStop(unittest.TestCase):
         mock_stream.read = blocking_read
 
         mock_pa = Mock()
+        mock_pa.get_device_count.return_value = 0
         mock_pa.open.return_value = mock_stream
         mock_pyaudio_class.return_value = mock_pa
 
@@ -379,6 +380,7 @@ class TestBargeInDetectorDetectionLoop(unittest.TestCase):
         import struct
         with patch('common.barge_in.struct.unpack_from', return_value=[0] * 1280):
             mock_pa = Mock()
+            mock_pa.get_device_count.return_value = 0
             mock_pa.open.return_value = mock_stream
             mock_pyaudio_class.return_value = mock_pa
 
@@ -407,6 +409,7 @@ class TestBargeInDetectorDetectionLoop(unittest.TestCase):
         mock_stream = Mock()
         mock_stream.read = blocking_read
         mock_pa = Mock()
+        mock_pa.get_device_count.return_value = 0
         mock_pa.open.return_value = mock_stream
         mock_pyaudio_class.return_value = mock_pa
 
@@ -445,6 +448,7 @@ class TestBargeInDetectorDetectionLoop(unittest.TestCase):
         mock_stream = Mock()
         mock_stream.read.side_effect = Exception("hw error")
         mock_pa = Mock()
+        mock_pa.get_device_count.return_value = 0
         mock_pa.open.return_value = mock_stream
         mock_pyaudio_class.return_value = mock_pa
 
@@ -469,6 +473,7 @@ class TestBargeInDetectorDetectionLoop(unittest.TestCase):
         mock_stream = Mock()
         mock_stream.read.side_effect = Exception("stream closed")
         mock_pa = Mock()
+        mock_pa.get_device_count.return_value = 0
         mock_pa.open.return_value = mock_stream
         mock_pyaudio_class.return_value = mock_pa
 

--- a/tests/test_barge_in.py
+++ b/tests/test_barge_in.py
@@ -80,6 +80,7 @@ class TestBargeInDetectorStartStop(unittest.TestCase):
     def test_start_creates_and_starts_thread(self, mock_pyaudio_class, mock_detector_class):
         mock_detector = Mock()
         mock_detector.sample_rate = 16000
+        mock_detector.device_sample_rate = 16000
         mock_detector.frame_length = 1280
         mock_detector.process.return_value = -1
         mock_detector_class.return_value = mock_detector
@@ -368,6 +369,7 @@ class TestBargeInDetectorDetectionLoop(unittest.TestCase):
         """When OpenWakeWord detects the wake word, _event is set."""
         mock_detector = Mock()
         mock_detector.sample_rate = 16000
+        mock_detector.device_sample_rate = 16000
         mock_detector.frame_length = 1280
         mock_detector.process.side_effect = [-1, -1, 0]  # wake word on 3rd call
         mock_detector_class.return_value = mock_detector
@@ -397,6 +399,7 @@ class TestBargeInDetectorDetectionLoop(unittest.TestCase):
         """When stop_flag is set, the detection loop exits without triggering barge-in."""
         mock_detector = Mock()
         mock_detector.sample_rate = 16000
+        mock_detector.device_sample_rate = 16000
         mock_detector.frame_length = 1280
         mock_detector.process.return_value = -1
         mock_detector_class.return_value = mock_detector
@@ -442,6 +445,7 @@ class TestBargeInDetectorDetectionLoop(unittest.TestCase):
         """An error reading audio is caught and the loop exits cleanly."""
         mock_detector = Mock()
         mock_detector.sample_rate = 16000
+        mock_detector.device_sample_rate = 16000
         mock_detector.frame_length = 1280
         mock_detector_class.return_value = mock_detector
 
@@ -467,6 +471,7 @@ class TestBargeInDetectorDetectionLoop(unittest.TestCase):
         """Audio read error during shutdown (stop_flag set) is logged at DEBUG, not WARNING."""
         mock_detector = Mock()
         mock_detector.sample_rate = 16000
+        mock_detector.device_sample_rate = 16000
         mock_detector.frame_length = 1280
         mock_detector_class.return_value = mock_detector
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -395,9 +395,9 @@ class TestConfigurationValidation(unittest.TestCase):
         config = Config()
 
         self.assertTrue(config.wake_word_enabled)
-        self.assertEqual(config.wake_phrase, "hey sandvoice")
-        self.assertEqual(config.wake_word_sensitivity, 0.5)
-        self.assertEqual(config.porcupine_access_key, "")
+        self.assertEqual(config.wake_phrase, "hey jarvis")
+        self.assertEqual(config.wake_word_sensitivity, 0.35)
+        self.assertEqual(config.openwakeword_model, "hey_jarvis")
         self.assertTrue(config.vad_enabled)
         self.assertEqual(config.vad_aggressiveness, 3)
         self.assertEqual(config.vad_silence_duration, 1.5)
@@ -494,7 +494,7 @@ class TestConfigurationValidation(unittest.TestCase):
             "wake_word_enabled": "enabled",
             "wake_phrase": "hey assistant",
             "wake_word_sensitivity": 0.7,
-            "porcupine_access_key": "test_key_123",
+            "openwakeword_model": "alexa",
             "vad_enabled": "disabled",
             "vad_aggressiveness": 1,
             "vad_silence_duration": 2.0,
@@ -510,7 +510,7 @@ class TestConfigurationValidation(unittest.TestCase):
         self.assertTrue(config.wake_word_enabled)
         self.assertEqual(config.wake_phrase, "hey assistant")
         self.assertEqual(config.wake_word_sensitivity, 0.7)
-        self.assertEqual(config.porcupine_access_key, "test_key_123")
+        self.assertEqual(config.openwakeword_model, "alexa")
         self.assertFalse(config.vad_enabled)
         self.assertEqual(config.vad_aggressiveness, 1)
         self.assertEqual(config.vad_silence_duration, 2.0)

--- a/tests/test_openwakeword_detector.py
+++ b/tests/test_openwakeword_detector.py
@@ -1,0 +1,292 @@
+import logging
+import unittest
+from math import gcd
+from unittest.mock import MagicMock, Mock, patch
+
+import numpy as np
+
+
+class TestOpenWakeWordDetectorInit(unittest.TestCase):
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+
+    def _make_mock_model(self):
+        mock_model = Mock()
+        mock_model.predict.return_value = {"hey_jarvis": 0.0}
+        return mock_model
+
+    @patch('common.openwakeword_detector.OpenWakeWordDetector.__init__', return_value=None)
+    def test_import_succeeds(self, _):
+        from common.openwakeword_detector import OpenWakeWordDetector
+        self.assertTrue(True)
+
+    def test_sample_rate_constant(self):
+        from common.openwakeword_detector import _SAMPLE_RATE
+        self.assertEqual(_SAMPLE_RATE, 16000)
+
+    def test_frame_length_constant(self):
+        from common.openwakeword_detector import _FRAME_LENGTH
+        self.assertEqual(_FRAME_LENGTH, 1280)
+
+    @patch('openwakeword.model.Model')
+    def test_init_stores_model_name_and_threshold(self, mock_model_class):
+        mock_model = self._make_mock_model()
+        mock_model_class.return_value = mock_model
+
+        from common.openwakeword_detector import OpenWakeWordDetector
+        d = OpenWakeWordDetector(model_name="hey_jarvis", threshold=0.5)
+
+        self.assertEqual(d._model_name, "hey_jarvis")
+        self.assertEqual(d._threshold, 0.5)
+
+    @patch('openwakeword.model.Model')
+    def test_init_default_device_rate_is_16000(self, mock_model_class):
+        mock_model = self._make_mock_model()
+        mock_model_class.return_value = mock_model
+
+        from common.openwakeword_detector import OpenWakeWordDetector
+        d = OpenWakeWordDetector(model_name="hey_jarvis", threshold=0.5)
+
+        from common.openwakeword_detector import _SAMPLE_RATE
+        self.assertEqual(d._device_rate, _SAMPLE_RATE)
+
+    @patch('openwakeword.model.Model')
+    def test_init_custom_device_rate_stored(self, mock_model_class):
+        mock_model = Mock()
+        mock_model.predict.return_value = {"hey_jarvis": 0.0}
+        mock_model_class.return_value = mock_model
+
+        from common.openwakeword_detector import OpenWakeWordDetector
+        d = OpenWakeWordDetector(model_name="hey_jarvis", threshold=0.5, device_sample_rate=48000)
+
+        self.assertEqual(d._device_rate, 48000)
+
+    @patch('openwakeword.model.Model')
+    def test_init_computes_resample_ratio_when_rate_differs(self, mock_model_class):
+        mock_model = Mock()
+        mock_model.predict.return_value = {"hey_jarvis": 0.0}
+        mock_model_class.return_value = mock_model
+
+        from common.openwakeword_detector import OpenWakeWordDetector
+        d = OpenWakeWordDetector(model_name="hey_jarvis", threshold=0.5, device_sample_rate=48000)
+
+        _g = gcd(48000, 16000)
+        self.assertEqual(d._resample_up, 16000 // _g)
+        self.assertEqual(d._resample_down, 48000 // _g)
+
+    @patch('openwakeword.model.Model')
+    def test_init_no_resample_when_rate_matches(self, mock_model_class):
+        mock_model = Mock()
+        mock_model.predict.return_value = {"hey_jarvis": 0.0}
+        mock_model_class.return_value = mock_model
+
+        from common.openwakeword_detector import OpenWakeWordDetector
+        d = OpenWakeWordDetector(model_name="hey_jarvis", threshold=0.5, device_sample_rate=16000)
+
+        self.assertIsNone(d._resample_up)
+        self.assertIsNone(d._resample_down)
+
+    @patch('openwakeword.model.Model')
+    def test_init_warms_up_model(self, mock_model_class):
+        mock_model = Mock()
+        mock_model.predict.return_value = {"hey_jarvis": 0.0}
+        mock_model_class.return_value = mock_model
+
+        from common.openwakeword_detector import OpenWakeWordDetector
+        OpenWakeWordDetector(model_name="hey_jarvis", threshold=0.5)
+
+        # predict should be called once with zeros during warmup
+        mock_model.predict.assert_called_once()
+        warmup_arg = mock_model.predict.call_args[0][0]
+        self.assertEqual(warmup_arg.dtype, np.int16)
+        from common.openwakeword_detector import _FRAME_LENGTH
+        self.assertEqual(len(warmup_arg), _FRAME_LENGTH)
+        self.assertTrue(np.all(warmup_arg == 0))
+
+    @patch('openwakeword.model.Model')
+    def test_init_onnx_path_uses_wakeword_model_paths(self, mock_model_class):
+        mock_model = Mock()
+        mock_model.predict.return_value = {"my_model": 0.0}
+        mock_model_class.return_value = mock_model
+
+        from common.openwakeword_detector import OpenWakeWordDetector
+        d = OpenWakeWordDetector(model_name="/path/to/my_model.onnx", threshold=0.5)
+
+        mock_model_class.assert_called_once_with(
+            wakeword_model_paths=["/path/to/my_model.onnx"],
+            inference_framework="onnx",
+        )
+        self.assertEqual(d._prediction_key, "my_model")
+
+    @patch('openwakeword.model.Model')
+    def test_init_named_model_uses_wakeword_models(self, mock_model_class):
+        mock_model = Mock()
+        mock_model.predict.return_value = {"hey_jarvis": 0.0}
+        mock_model_class.return_value = mock_model
+
+        from common.openwakeword_detector import OpenWakeWordDetector
+        d = OpenWakeWordDetector(model_name="hey_jarvis", threshold=0.5)
+
+        mock_model_class.assert_called_once_with(
+            wakeword_models=["hey_jarvis"],
+            inference_framework="onnx",
+        )
+        self.assertEqual(d._prediction_key, "hey_jarvis")
+
+
+class TestOpenWakeWordDetectorProperties(unittest.TestCase):
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+
+    def _make_detector(self, device_sample_rate=16000):
+        with patch('openwakeword.model.Model') as mock_model_class:
+            mock_model = Mock()
+            mock_model.predict.return_value = {"hey_jarvis": 0.0}
+            mock_model_class.return_value = mock_model
+            from common.openwakeword_detector import OpenWakeWordDetector
+            return OpenWakeWordDetector(
+                model_name="hey_jarvis",
+                threshold=0.5,
+                device_sample_rate=device_sample_rate,
+            )
+
+    def test_sample_rate_property(self):
+        d = self._make_detector()
+        from common.openwakeword_detector import _SAMPLE_RATE
+        self.assertEqual(d.sample_rate, _SAMPLE_RATE)
+
+    def test_device_sample_rate_property(self):
+        d = self._make_detector(device_sample_rate=48000)
+        self.assertEqual(d.device_sample_rate, 48000)
+
+    def test_frame_length_no_resample(self):
+        d = self._make_detector(device_sample_rate=16000)
+        from common.openwakeword_detector import _FRAME_LENGTH
+        self.assertEqual(d.frame_length, _FRAME_LENGTH)
+
+    def test_frame_length_with_resample(self):
+        d = self._make_detector(device_sample_rate=48000)
+        from common.openwakeword_detector import _FRAME_LENGTH, _SAMPLE_RATE
+        expected = int(_FRAME_LENGTH * 48000 / _SAMPLE_RATE)
+        self.assertEqual(d.frame_length, expected)
+
+
+class TestOpenWakeWordDetectorProcess(unittest.TestCase):
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+
+    def _make_detector(self, device_sample_rate=16000, threshold=0.5):
+        with patch('openwakeword.model.Model') as mock_model_class:
+            mock_model = Mock()
+            mock_model.predict.return_value = {"hey_jarvis": 0.0}
+            mock_model_class.return_value = mock_model
+            from common.openwakeword_detector import OpenWakeWordDetector
+            return OpenWakeWordDetector(
+                model_name="hey_jarvis",
+                threshold=threshold,
+                device_sample_rate=device_sample_rate,
+            )
+
+    def test_process_returns_minus_one_below_threshold(self):
+        d = self._make_detector()
+        d._model.predict.return_value = {"hey_jarvis": 0.1}
+        from common.openwakeword_detector import _FRAME_LENGTH
+        pcm = [0] * _FRAME_LENGTH
+        result = d.process(pcm)
+        self.assertEqual(result, -1)
+
+    def test_process_returns_zero_at_threshold(self):
+        d = self._make_detector(threshold=0.5)
+        d._model.predict.return_value = {"hey_jarvis": 0.5}
+        from common.openwakeword_detector import _FRAME_LENGTH
+        pcm = [0] * _FRAME_LENGTH
+        result = d.process(pcm)
+        self.assertEqual(result, 0)
+
+    def test_process_returns_zero_above_threshold(self):
+        d = self._make_detector(threshold=0.5)
+        d._model.predict.return_value = {"hey_jarvis": 0.9}
+        from common.openwakeword_detector import _FRAME_LENGTH
+        pcm = [0] * _FRAME_LENGTH
+        result = d.process(pcm)
+        self.assertEqual(result, 0)
+
+    def test_process_no_resample_passes_int16_array(self):
+        d = self._make_detector(device_sample_rate=16000)
+        d._model.predict.return_value = {"hey_jarvis": 0.0}
+        from common.openwakeword_detector import _FRAME_LENGTH
+        pcm = [100] * _FRAME_LENGTH
+        d.process(pcm)
+        call_arg = d._model.predict.call_args[0][0]
+        self.assertEqual(call_arg.dtype, np.int16)
+        self.assertEqual(len(call_arg), _FRAME_LENGTH)
+
+    @patch('scipy.signal.resample_poly')
+    def test_process_resamples_when_device_rate_differs(self, mock_resample):
+        mock_resample.return_value = np.zeros(1280, dtype=np.float64)
+        d = self._make_detector(device_sample_rate=48000)
+        d._model.predict.return_value = {"hey_jarvis": 0.0}
+
+        # frame_length at 48kHz = 3840
+        pcm = [0] * d.frame_length
+        d.process(pcm)
+
+        mock_resample.assert_called_once()
+        args = mock_resample.call_args[0]
+        self.assertEqual(args[1], d._resample_up)
+        self.assertEqual(args[2], d._resample_down)
+
+    def test_process_missing_key_returns_minus_one(self):
+        d = self._make_detector()
+        d._model.predict.return_value = {}  # key not present
+        from common.openwakeword_detector import _FRAME_LENGTH
+        pcm = [0] * _FRAME_LENGTH
+        result = d.process(pcm)
+        self.assertEqual(result, -1)
+
+
+class TestOpenWakeWordDetectorResetDelete(unittest.TestCase):
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+
+    def _make_detector(self):
+        with patch('openwakeword.model.Model') as mock_model_class:
+            mock_model = Mock()
+            mock_model.predict.return_value = {"hey_jarvis": 0.0}
+            mock_model_class.return_value = mock_model
+            from common.openwakeword_detector import OpenWakeWordDetector
+            return OpenWakeWordDetector(model_name="hey_jarvis", threshold=0.5)
+
+    def test_reset_calls_model_reset(self):
+        d = self._make_detector()
+        d._model.reset = Mock()
+        d.reset()
+        d._model.reset.assert_called_once()
+
+    def test_reset_suppresses_exception(self):
+        d = self._make_detector()
+        d._model.reset = Mock(side_effect=Exception("reset failed"))
+        # Should not raise
+        d.reset()
+
+    def test_delete_is_noop(self):
+        d = self._make_detector()
+        # Should not raise and return None
+        result = d.delete()
+        self.assertIsNone(result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_openwakeword_detector.py
+++ b/tests/test_openwakeword_detector.py
@@ -18,10 +18,9 @@ class TestOpenWakeWordDetectorInit(unittest.TestCase):
         mock_model.predict.return_value = {"hey_jarvis": 0.0}
         return mock_model
 
-    @patch('common.openwakeword_detector.OpenWakeWordDetector.__init__', return_value=None)
-    def test_import_succeeds(self, _):
+    def test_import_succeeds(self):
         from common.openwakeword_detector import OpenWakeWordDetector
-        self.assertTrue(True)
+        self.assertIsNotNone(OpenWakeWordDetector)
 
     def test_sample_rate_constant(self):
         from common.openwakeword_detector import _SAMPLE_RATE

--- a/tests/test_openwakeword_detector.py
+++ b/tests/test_openwakeword_detector.py
@@ -1,7 +1,7 @@
 import logging
 import unittest
 from math import gcd
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import numpy as np
 

--- a/tests/test_wake_word.py
+++ b/tests/test_wake_word.py
@@ -256,6 +256,7 @@ class TestWakeWordModeStateIdle(unittest.TestCase):
         mock_unpack.return_value = [0] * 1280
 
         mock_pa = Mock()
+        mock_pa.get_device_count.return_value = 0  # avoid Linux hw: scan on Mock
         mock_pa.open.return_value = mock_stream
         mock_pyaudio_class.return_value = mock_pa
 
@@ -289,6 +290,7 @@ class TestWakeWordModeStateIdle(unittest.TestCase):
         mock_unpack.return_value = [0] * 1280
 
         mock_pa = Mock()
+        mock_pa.get_device_count.return_value = 0  # avoid Linux hw: scan on Mock
         mock_pa.open.return_value = mock_stream
         mock_pyaudio_class.return_value = mock_pa
 
@@ -313,6 +315,7 @@ class TestWakeWordModeStateIdle(unittest.TestCase):
         mock_stream.read.side_effect = Exception("Stream error")
 
         mock_pa = Mock()
+        mock_pa.get_device_count.return_value = 0  # avoid Linux hw: scan on Mock
         mock_pa.open.return_value = mock_stream
         mock_pyaudio_class.return_value = mock_pa
 
@@ -1444,6 +1447,7 @@ class TestRequestTimingSummary(unittest.TestCase):
 
         with patch("common.wake_word.pyaudio.PyAudio") as mock_pa_cls:
             mock_pa = Mock()
+            mock_pa.get_device_count.return_value = 0  # avoid Linux hw: scan on Mock
             mock_pa_cls.return_value = mock_pa
             mock_stream = Mock()
             mock_pa.open.return_value = mock_stream
@@ -1555,6 +1559,7 @@ class TestTerminalUIIntegration(unittest.TestCase):
         mock_stream = Mock()
         mock_stream.read.return_value = b"\x00" * 2560
         mock_pa = Mock()
+        mock_pa.get_device_count.return_value = 0  # avoid Linux hw: scan on Mock
         mock_pa.open.return_value = mock_stream
 
         with patch("common.wake_word.pyaudio.PyAudio", return_value=mock_pa):

--- a/tests/test_wake_word.py
+++ b/tests/test_wake_word.py
@@ -246,10 +246,10 @@ class TestWakeWordModeStateIdle(unittest.TestCase):
     @patch('common.wake_word.pyaudio.PyAudio')
     @patch('common.wake_word.struct.unpack_from')
     def test_state_idle_detects_wake_word(self, mock_unpack, mock_pyaudio_class):
-        mock_porcupine = Mock()
-        mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 1280
-        mock_porcupine.process.side_effect = [-1, -1, 0]
+        mock_detector = Mock()
+        mock_detector.sample_rate = 16000
+        mock_detector.frame_length = 1280
+        mock_detector.process.side_effect = [-1, -1, 0]
 
         mock_stream = Mock()
         mock_stream.read.return_value = b'\x00' * 2560
@@ -261,7 +261,7 @@ class TestWakeWordModeStateIdle(unittest.TestCase):
         mock_pyaudio_class.return_value = mock_pa
 
         mode = WakeWordMode(self.mock_config, self.mock_ai, self.mock_audio, route_message=self.mock_route_message)
-        mode.detector = mock_porcupine
+        mode.detector = mock_detector
         mode.confirmation_beep_path = "/tmp/beep.mp3"
         mode.running = True
         mode.state = State.IDLE
@@ -269,7 +269,7 @@ class TestWakeWordModeStateIdle(unittest.TestCase):
         mode._state_idle()
 
         self.assertEqual(mode.state, State.LISTENING)
-        self.assertEqual(mock_porcupine.process.call_count, 3)
+        self.assertEqual(mock_detector.process.call_count, 3)
         mock_stream.stop_stream.assert_called_once()
         mock_stream.close.assert_called_once()
         mock_pa.terminate.assert_called_once()
@@ -280,10 +280,10 @@ class TestWakeWordModeStateIdle(unittest.TestCase):
     def test_state_idle_plays_confirmation_beep(self, mock_unpack, mock_pyaudio_class, mock_exists):
         mock_exists.return_value = True
 
-        mock_porcupine = Mock()
-        mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 1280
-        mock_porcupine.process.return_value = 0
+        mock_detector = Mock()
+        mock_detector.sample_rate = 16000
+        mock_detector.frame_length = 1280
+        mock_detector.process.return_value = 0
 
         mock_stream = Mock()
         mock_stream.read.return_value = b'\x00' * 2560
@@ -295,7 +295,7 @@ class TestWakeWordModeStateIdle(unittest.TestCase):
         mock_pyaudio_class.return_value = mock_pa
 
         mode = WakeWordMode(self.mock_config, self.mock_ai, self.mock_audio, route_message=self.mock_route_message)
-        mode.detector = mock_porcupine
+        mode.detector = mock_detector
         mode.confirmation_beep_path = "/tmp/beep.mp3"
         mode.running = True
         mode.state = State.IDLE
@@ -307,9 +307,9 @@ class TestWakeWordModeStateIdle(unittest.TestCase):
     @patch('common.wake_word.pyaudio.PyAudio')
     @patch('common.wake_word.struct.unpack_from')
     def test_state_idle_handles_stream_error(self, mock_unpack, mock_pyaudio_class):
-        mock_porcupine = Mock()
-        mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 1280
+        mock_detector = Mock()
+        mock_detector.sample_rate = 16000
+        mock_detector.frame_length = 1280
 
         mock_stream = Mock()
         mock_stream.read.side_effect = Exception("Stream error")
@@ -320,7 +320,7 @@ class TestWakeWordModeStateIdle(unittest.TestCase):
         mock_pyaudio_class.return_value = mock_pa
 
         mode = WakeWordMode(self.mock_config, self.mock_ai, self.mock_audio, route_message=self.mock_route_message)
-        mode.detector = mock_porcupine
+        mode.detector = mock_detector
         mode.running = True
         mode.state = State.IDLE
 

--- a/tests/test_wake_word.py
+++ b/tests/test_wake_word.py
@@ -68,6 +68,7 @@ class TestWakeWordModeInitialize(unittest.TestCase):
 
         self.mock_config = Mock()
         self.mock_config.debug = False
+        self.mock_config.rate = 16000
         self.mock_config.wake_phrase = "hey jarvis"
         self.mock_config.wake_word_sensitivity = 0.5
         self.mock_config.openwakeword_model = "hey_jarvis"
@@ -93,6 +94,7 @@ class TestWakeWordModeInitialize(unittest.TestCase):
         mock_detector = Mock()
         mock_detector.sample_rate = 16000
         mock_detector.frame_length = 1280
+        mock_detector.device_sample_rate = 16000
         mock_detector_class.return_value = mock_detector
         mock_beep.return_value = "/tmp/test/beep.mp3"
 
@@ -112,6 +114,7 @@ class TestWakeWordModeInitialize(unittest.TestCase):
         mock_detector = Mock()
         mock_detector.sample_rate = 16000
         mock_detector.frame_length = 1280
+        mock_detector.device_sample_rate = 16000
         mock_detector_class.return_value = mock_detector
         mock_beep.return_value = "/tmp/test/beep.mp3"
 
@@ -137,6 +140,7 @@ class TestWakeWordModeInitialize(unittest.TestCase):
         mock_detector = Mock()
         mock_detector.sample_rate = 16000
         mock_detector.frame_length = 1280
+        mock_detector.device_sample_rate = 16000
         mock_detector_class.return_value = mock_detector
         mock_beep.return_value = "/tmp/test/beep.mp3"
         mock_ack.return_value = "/tmp/test/ack.mp3"
@@ -205,6 +209,7 @@ class TestWakeWordModeInitialize(unittest.TestCase):
         mock_detector = Mock()
         mock_detector.sample_rate = 16000
         mock_detector.frame_length = 1280
+        mock_detector.device_sample_rate = 16000
         mock_detector_class.return_value = mock_detector
         mock_beep.side_effect = Exception("Beep creation failed")
 
@@ -249,6 +254,7 @@ class TestWakeWordModeStateIdle(unittest.TestCase):
         mock_detector = Mock()
         mock_detector.sample_rate = 16000
         mock_detector.frame_length = 1280
+        mock_detector.device_sample_rate = 16000
         mock_detector.process.side_effect = [-1, -1, 0]
 
         mock_stream = Mock()
@@ -283,6 +289,7 @@ class TestWakeWordModeStateIdle(unittest.TestCase):
         mock_detector = Mock()
         mock_detector.sample_rate = 16000
         mock_detector.frame_length = 1280
+        mock_detector.device_sample_rate = 16000
         mock_detector.process.return_value = 0
 
         mock_stream = Mock()
@@ -310,6 +317,7 @@ class TestWakeWordModeStateIdle(unittest.TestCase):
         mock_detector = Mock()
         mock_detector.sample_rate = 16000
         mock_detector.frame_length = 1280
+        mock_detector.device_sample_rate = 16000
 
         mock_stream = Mock()
         mock_stream.read.side_effect = Exception("Stream error")
@@ -357,6 +365,7 @@ class TestWakeWordModeRun(unittest.TestCase):
         mock_detector = Mock()
         mock_detector.sample_rate = 16000
         mock_detector.frame_length = 1280
+        mock_detector.device_sample_rate = 16000
         mock_detector_class.return_value = mock_detector
         mock_beep.return_value = "/tmp/beep.mp3"
 
@@ -403,6 +412,7 @@ class TestWakeWordModeRun(unittest.TestCase):
         mock_detector = Mock()
         mock_detector.sample_rate = 16000
         mock_detector.frame_length = 1280
+        mock_detector.device_sample_rate = 16000
         mock_detector_class.return_value = mock_detector
         mock_beep.return_value = "/tmp/beep.mp3"
 

--- a/tests/test_wake_word.py
+++ b/tests/test_wake_word.py
@@ -17,7 +17,7 @@ class TestWakeWordModeInitialization(unittest.TestCase):
         self.mock_config.wake_word_enabled = True
         self.mock_config.wake_phrase = "hey sandvoice"
         self.mock_config.wake_word_sensitivity = 0.5
-        self.mock_config.porcupine_access_key = "test-key-123"
+        self.mock_config.openwakeword_model = "hey_jarvis"
         self.mock_config.wake_confirmation_beep = True
         self.mock_config.wake_confirmation_beep_freq = 800
         self.mock_config.wake_confirmation_beep_duration = 0.1
@@ -36,7 +36,7 @@ class TestWakeWordModeInitialization(unittest.TestCase):
 
         self.assertEqual(mode.state, State.IDLE)
         self.assertFalse(mode.running)
-        self.assertIsNone(mode.porcupine)
+        self.assertIsNone(mode.detector)
         self.assertIsNone(mode.confirmation_beep_path)
 
     def test_init_stores_dependencies(self):
@@ -68,10 +68,9 @@ class TestWakeWordModeInitialize(unittest.TestCase):
 
         self.mock_config = Mock()
         self.mock_config.debug = False
-        self.mock_config.wake_phrase = "porcupine"
+        self.mock_config.wake_phrase = "hey jarvis"
         self.mock_config.wake_word_sensitivity = 0.5
-        self.mock_config.porcupine_access_key = "test-key-123"
-        self.mock_config.porcupine_keyword_paths = None
+        self.mock_config.openwakeword_model = "hey_jarvis"
         self.mock_config.wake_confirmation_beep = True
         self.mock_config.wake_confirmation_beep_freq = 800
         self.mock_config.wake_confirmation_beep_duration = 0.1
@@ -88,32 +87,32 @@ class TestWakeWordModeInitialize(unittest.TestCase):
     def tearDown(self):
         logging.disable(logging.NOTSET)
 
-    @patch('common.wake_word.pvporcupine.create')
+    @patch('common.wake_word.OpenWakeWordDetector')
     @patch('common.wake_word.create_confirmation_beep')
-    def test_initialize_creates_porcupine(self, mock_beep, mock_porcupine_create):
-        mock_porcupine = Mock()
-        mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 512
-        mock_porcupine_create.return_value = mock_porcupine
+    def test_initialize_creates_detector(self, mock_beep, mock_detector_class):
+        mock_detector = Mock()
+        mock_detector.sample_rate = 16000
+        mock_detector.frame_length = 1280
+        mock_detector_class.return_value = mock_detector
         mock_beep.return_value = "/tmp/test/beep.mp3"
 
         mode = WakeWordMode(self.mock_config, self.mock_ai, self.mock_audio, route_message=self.mock_route_message)
         mode._initialize()
 
-        mock_porcupine_create.assert_called_once_with(
-            access_key="test-key-123",
-            keywords=["porcupine"],
-            sensitivities=[0.5]
+        mock_detector_class.assert_called_once_with(
+            model_name="hey_jarvis",
+            threshold=0.5,
+            device_sample_rate=self.mock_config.rate,
         )
-        self.assertEqual(mode.porcupine, mock_porcupine)
+        self.assertEqual(mode.detector, mock_detector)
 
-    @patch('common.wake_word.pvporcupine.create')
+    @patch('common.wake_word.OpenWakeWordDetector')
     @patch('common.wake_word.create_confirmation_beep')
-    def test_initialize_creates_confirmation_beep(self, mock_beep, mock_porcupine_create):
-        mock_porcupine = Mock()
-        mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 512
-        mock_porcupine_create.return_value = mock_porcupine
+    def test_initialize_creates_confirmation_beep(self, mock_beep, mock_detector_class):
+        mock_detector = Mock()
+        mock_detector.sample_rate = 16000
+        mock_detector.frame_length = 1280
+        mock_detector_class.return_value = mock_detector
         mock_beep.return_value = "/tmp/test/beep.mp3"
 
         mode = WakeWordMode(self.mock_config, self.mock_ai, self.mock_audio, route_message=self.mock_route_message)
@@ -126,19 +125,19 @@ class TestWakeWordModeInitialize(unittest.TestCase):
         )
         self.assertEqual(mode.confirmation_beep_path, "/tmp/test/beep.mp3")
 
-    @patch('common.wake_word.pvporcupine.create')
+    @patch('common.wake_word.OpenWakeWordDetector')
     @patch('common.wake_word.create_ack_earcon')
     @patch('common.wake_word.create_confirmation_beep')
-    def test_initialize_creates_ack_earcon_when_enabled(self, mock_beep, mock_ack, mock_porcupine_create):
+    def test_initialize_creates_ack_earcon_when_enabled(self, mock_beep, mock_ack, mock_detector_class):
         self.mock_config.bot_voice = True
         self.mock_config.voice_ack_earcon = True
         self.mock_config.voice_ack_earcon_freq = 600
         self.mock_config.voice_ack_earcon_duration = 0.06
 
-        mock_porcupine = Mock()
-        mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 512
-        mock_porcupine_create.return_value = mock_porcupine
+        mock_detector = Mock()
+        mock_detector.sample_rate = 16000
+        mock_detector.frame_length = 1280
+        mock_detector_class.return_value = mock_detector
         mock_beep.return_value = "/tmp/test/beep.mp3"
         mock_ack.return_value = "/tmp/test/ack.mp3"
 
@@ -188,21 +187,10 @@ class TestWakeWordModeInitialize(unittest.TestCase):
 
         self.assertIn("stream_tts", str(context.exception))
 
-    @patch('common.wake_word.pvporcupine.create')
-    def test_initialize_raises_on_missing_access_key(self, mock_porcupine_create):
-        self.mock_config.porcupine_access_key = ""
-
-        mode = WakeWordMode(self.mock_config, self.mock_ai, self.mock_audio, route_message=self.mock_route_message)
-
-        with self.assertRaises(RuntimeError) as context:
-            mode._initialize()
-
-        self.assertIn("access key is required", str(context.exception).lower())
-
-    @patch('common.wake_word.pvporcupine.create')
+    @patch('common.wake_word.OpenWakeWordDetector')
     @patch('common.wake_word.create_confirmation_beep')
-    def test_initialize_handles_porcupine_error(self, mock_beep, mock_porcupine_create):
-        mock_porcupine_create.side_effect = Exception("Porcupine init failed")
+    def test_initialize_handles_detector_error(self, mock_beep, mock_detector_class):
+        mock_detector_class.side_effect = Exception("detector init failed")
 
         mode = WakeWordMode(self.mock_config, self.mock_ai, self.mock_audio, route_message=self.mock_route_message)
 
@@ -211,13 +199,13 @@ class TestWakeWordModeInitialize(unittest.TestCase):
 
         self.assertIn("Failed to initialize wake-word mode", str(context.exception))
 
-    @patch('common.wake_word.pvporcupine.create')
+    @patch('common.wake_word.OpenWakeWordDetector')
     @patch('common.wake_word.create_confirmation_beep')
-    def test_initialize_handles_beep_creation_error(self, mock_beep, mock_porcupine_create):
-        mock_porcupine = Mock()
-        mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 512
-        mock_porcupine_create.return_value = mock_porcupine
+    def test_initialize_handles_beep_creation_error(self, mock_beep, mock_detector_class):
+        mock_detector = Mock()
+        mock_detector.sample_rate = 16000
+        mock_detector.frame_length = 1280
+        mock_detector_class.return_value = mock_detector
         mock_beep.side_effect = Exception("Beep creation failed")
 
         mode = WakeWordMode(self.mock_config, self.mock_ai, self.mock_audio, route_message=self.mock_route_message)
@@ -260,19 +248,19 @@ class TestWakeWordModeStateIdle(unittest.TestCase):
     def test_state_idle_detects_wake_word(self, mock_unpack, mock_pyaudio_class):
         mock_porcupine = Mock()
         mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 512
+        mock_porcupine.frame_length = 1280
         mock_porcupine.process.side_effect = [-1, -1, 0]
 
         mock_stream = Mock()
-        mock_stream.read.return_value = b'\x00' * 1024
-        mock_unpack.return_value = [0] * 512
+        mock_stream.read.return_value = b'\x00' * 2560
+        mock_unpack.return_value = [0] * 1280
 
         mock_pa = Mock()
         mock_pa.open.return_value = mock_stream
         mock_pyaudio_class.return_value = mock_pa
 
         mode = WakeWordMode(self.mock_config, self.mock_ai, self.mock_audio, route_message=self.mock_route_message)
-        mode.porcupine = mock_porcupine
+        mode.detector = mock_porcupine
         mode.confirmation_beep_path = "/tmp/beep.mp3"
         mode.running = True
         mode.state = State.IDLE
@@ -293,19 +281,19 @@ class TestWakeWordModeStateIdle(unittest.TestCase):
 
         mock_porcupine = Mock()
         mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 512
+        mock_porcupine.frame_length = 1280
         mock_porcupine.process.return_value = 0
 
         mock_stream = Mock()
-        mock_stream.read.return_value = b'\x00' * 1024
-        mock_unpack.return_value = [0] * 512
+        mock_stream.read.return_value = b'\x00' * 2560
+        mock_unpack.return_value = [0] * 1280
 
         mock_pa = Mock()
         mock_pa.open.return_value = mock_stream
         mock_pyaudio_class.return_value = mock_pa
 
         mode = WakeWordMode(self.mock_config, self.mock_ai, self.mock_audio, route_message=self.mock_route_message)
-        mode.porcupine = mock_porcupine
+        mode.detector = mock_porcupine
         mode.confirmation_beep_path = "/tmp/beep.mp3"
         mode.running = True
         mode.state = State.IDLE
@@ -319,7 +307,7 @@ class TestWakeWordModeStateIdle(unittest.TestCase):
     def test_state_idle_handles_stream_error(self, mock_unpack, mock_pyaudio_class):
         mock_porcupine = Mock()
         mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 512
+        mock_porcupine.frame_length = 1280
 
         mock_stream = Mock()
         mock_stream.read.side_effect = Exception("Stream error")
@@ -329,7 +317,7 @@ class TestWakeWordModeStateIdle(unittest.TestCase):
         mock_pyaudio_class.return_value = mock_pa
 
         mode = WakeWordMode(self.mock_config, self.mock_ai, self.mock_audio, route_message=self.mock_route_message)
-        mode.porcupine = mock_porcupine
+        mode.detector = mock_porcupine
         mode.running = True
         mode.state = State.IDLE
 
@@ -360,17 +348,17 @@ class TestWakeWordModeRun(unittest.TestCase):
     def tearDown(self):
         logging.disable(logging.NOTSET)
 
-    @patch('common.wake_word.pvporcupine.create')
+    @patch('common.wake_word.OpenWakeWordDetector')
     @patch('common.wake_word.create_confirmation_beep')
-    def test_run_transitions_through_states(self, mock_beep, mock_porcupine_create):
-        mock_porcupine = Mock()
-        mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 512
-        mock_porcupine_create.return_value = mock_porcupine
+    def test_run_transitions_through_states(self, mock_beep, mock_detector_class):
+        mock_detector = Mock()
+        mock_detector.sample_rate = 16000
+        mock_detector.frame_length = 1280
+        mock_detector_class.return_value = mock_detector
         mock_beep.return_value = "/tmp/beep.mp3"
 
-        self.mock_config.porcupine_access_key = "test-key"
-        self.mock_config.wake_phrase = "porcupine"
+        self.mock_config.openwakeword_model = "hey_jarvis"
+        self.mock_config.wake_phrase = "hey jarvis"
         self.mock_config.wake_word_sensitivity = 0.5
         self.mock_config.wake_confirmation_beep = True
 
@@ -406,17 +394,17 @@ class TestWakeWordModeRun(unittest.TestCase):
         self.assertEqual(call_count['idle'], 2)
         self.assertFalse(mode.running)
 
-    @patch('common.wake_word.pvporcupine.create')
+    @patch('common.wake_word.OpenWakeWordDetector')
     @patch('common.wake_word.create_confirmation_beep')
-    def test_run_handles_keyboard_interrupt(self, mock_beep, mock_porcupine_create):
-        mock_porcupine = Mock()
-        mock_porcupine.sample_rate = 16000
-        mock_porcupine.frame_length = 512
-        mock_porcupine_create.return_value = mock_porcupine
+    def test_run_handles_keyboard_interrupt(self, mock_beep, mock_detector_class):
+        mock_detector = Mock()
+        mock_detector.sample_rate = 16000
+        mock_detector.frame_length = 1280
+        mock_detector_class.return_value = mock_detector
         mock_beep.return_value = "/tmp/beep.mp3"
 
-        self.mock_config.porcupine_access_key = "test-key"
-        self.mock_config.wake_phrase = "porcupine"
+        self.mock_config.openwakeword_model = "hey_jarvis"
+        self.mock_config.wake_phrase = "hey jarvis"
         self.mock_config.wake_word_sensitivity = 0.5
         self.mock_config.wake_confirmation_beep = True
 
@@ -431,7 +419,7 @@ class TestWakeWordModeRun(unittest.TestCase):
         mode.run()
 
         # Cleanup should have been called
-        self.assertIsNone(mode.porcupine)
+        self.assertIsNone(mode.detector)
         self.assertFalse(mode.running)
 
 
@@ -516,22 +504,22 @@ class TestWakeWordModeCleanup(unittest.TestCase):
     def tearDown(self):
         logging.disable(logging.NOTSET)
 
-    def test_cleanup_deletes_porcupine(self):
-        mock_porcupine = Mock()
+    def test_cleanup_deletes_detector(self):
+        mock_detector = Mock()
 
         mode = WakeWordMode(self.mock_config, self.mock_ai, self.mock_audio, route_message=self.mock_route_message)
-        mode.porcupine = mock_porcupine
+        mode.detector = mock_detector
         mode.running = True
 
         mode._cleanup()
 
-        mock_porcupine.delete.assert_called_once()
-        self.assertIsNone(mode.porcupine)
+        mock_detector.delete.assert_called_once()
+        self.assertIsNone(mode.detector)
         self.assertFalse(mode.running)
 
-    def test_cleanup_handles_none_porcupine(self):
+    def test_cleanup_handles_none_detector(self):
         mode = WakeWordMode(self.mock_config, self.mock_ai, self.mock_audio, route_message=self.mock_route_message)
-        mode.porcupine = None
+        mode.detector = None
         mode.running = True
 
         mode._cleanup()
@@ -902,7 +890,7 @@ class TestBargeIn(unittest.TestCase):
 
         self.mock_ai = Mock()
         self.mock_audio = Mock()
-        self.mock_porcupine = Mock()  # Mock porcupine for consistency
+        self.mock_detector = Mock()  # Mock detector for consistency
         self.mock_route_message = Mock()
 
     def tearDown(self):
@@ -1438,20 +1426,20 @@ class TestRequestTimingSummary(unittest.TestCase):
     def test_state_idle_sets_req_t_start_on_wake_word(self):
         """_req_t_start is set when wake word is detected."""
         mode = self._make_mode()
-        mode.porcupine = Mock()
-        mode.porcupine.sample_rate = 16000
-        mode.porcupine.frame_length = 512
+        mode.detector = Mock()
+        mode.detector.sample_rate = 16000
+        mode.detector.frame_length = 1280
         mode.running = True
         mode.state = State.IDLE
 
         # Simulate: first frame no wake word, second frame detects wake word
         call_count = [0]
 
-        def porcupine_process(pcm):
+        def detector_process(pcm):
             call_count[0] += 1
             return 0 if call_count[0] >= 2 else -1
 
-        mode.porcupine.process.side_effect = porcupine_process
+        mode.detector.process.side_effect = detector_process
         mode._play_confirmation_beep = Mock()
 
         with patch("common.wake_word.pyaudio.PyAudio") as mock_pa_cls:
@@ -1459,7 +1447,7 @@ class TestRequestTimingSummary(unittest.TestCase):
             mock_pa_cls.return_value = mock_pa
             mock_stream = Mock()
             mock_pa.open.return_value = mock_stream
-            mock_stream.read.return_value = b"\x00" * (512 * 2)  # 512 int16 samples
+            mock_stream.read.return_value = b"\x00" * (1280 * 2)  # 1280 int16 samples
             mode._state_idle()
 
         self.assertIsNotNone(mode._req_t_start)
@@ -1552,20 +1540,20 @@ class TestTerminalUIIntegration(unittest.TestCase):
     def test_state_idle_calls_ui_set_state_waiting(self):
         mode = _build_mode_for_idle(self.mock_config, self.mock_ai, self.mock_audio,
                                      self.mock_route_message, self.mock_ui)
-        # Simulate one idle cycle by calling _state_idle with a mocked porcupine
-        mode.porcupine = Mock()
-        mode.porcupine.frame_length = 512
-        mode.porcupine.sample_rate = 16000
-        mode.porcupine.process.return_value = -1  # no keyword
+        # Simulate one idle cycle by calling _state_idle with a mocked detector
+        mode.detector = Mock()
+        mode.detector.frame_length = 1280
+        mode.detector.sample_rate = 16000
+        mode.detector.process.return_value = -1  # no keyword
         mode.running = True
         # Force state to leave IDLE after one iteration while returning "no keyword"
         def stop_after_one(*args, **kwargs):
             mode.running = False
             return -1
-        mode.porcupine.process.side_effect = stop_after_one
+        mode.detector.process.side_effect = stop_after_one
 
         mock_stream = Mock()
-        mock_stream.read.return_value = b"\x00" * 1024
+        mock_stream.read.return_value = b"\x00" * 2560
         mock_pa = Mock()
         mock_pa.open.return_value = mock_stream
 


### PR DESCRIPTION
## Summary
- Replaces pvporcupine with openWakeWord (MIT-licensed, ONNX-based, no API key required)
- New `common/openwakeword_detector.py`: thin wrapper with Porcupine-compatible interface — `process(pcm)`, `reset()`, `delete()`, `frame_length`/`sample_rate` properties
- Handles resampling (48 kHz Pi → 16 kHz model) using precomputed gcd-based ratios via `scipy.signal.resample_poly`
- Adds `_find_hw_input_device()` in wake_word.py for correct Linux hw: device selection
- Fixes VAD grace period in vad_recorder.py: silence timer only starts after speech is detected
- Adds SDL ALSA output device detection in audio.py for correct Linux audio routing

## Planning Document
Implements plan/backlog/52-replace-porcupine-with-openwakeword.md

## Changes
- `common/openwakeword_detector.py` — new detector class
- `common/wake_word.py` — switch from pvporcupine to OpenWakeWordDetector; add hw input device selection; beep after stream close
- `common/barge_in.py` — same swap; update signature to `model_name`/`threshold`
- `common/vad_recorder.py` — VAD grace period (Plan 55 feature)
- `common/audio.py` — SDL ALSA device detection on Linux
- `common/configuration.py` — drop porcupine_access_key/keyword_paths, add openwakeword_model
- `requirements.txt` — remove pvporcupine, add openwakeword>=0.6.0, onnxruntime==1.20.0, scipy
- `sandvoice.py` — update import error message
- `README.md` — remove Porcupine config keys, document new config
- `tests/test_openwakeword_detector.py` — new tests (>80% coverage)
- `tests/test_barge_in.py`, `tests/test_wake_word.py`, `tests/test_configuration.py` — updated for new interfaces

## Testing
- [x] All 1056 tests pass
- [x] Coverage >80% for new code
- [x] Tested on Mac M1
- [ ] Tested on Pi 3B

## Configuration Changes
- `openwakeword_model: hey_jarvis` — model name or absolute path to `.onnx` file
- `wake_phrase: hey jarvis` — updated default
- `wake_word_sensitivity: 0.35` — updated default (openWakeWord range)
- Removed: `porcupine_access_key`, `porcupine_keyword_paths`

## Pi 3B Install Note
`pip install openwakeword>=0.6.0 --no-deps && pip install scipy`
(tflite-runtime has no aarch64 wheel for Python 3.13; onnxruntime pinned to 1.20.0 — 1.21+ crashes with STL vector assertion)