### PR TITLE
Add plans 60 and 61: pygame import fix and miniaudio replacement

### DIFF
--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -263,6 +263,14 @@ plan/
 **Document**: [backlog/59-drop-zoneinfo-fallback.md](./backlog/59-drop-zoneinfo-fallback.md)
 **Description**: Remove the `try/except ImportError` guard around `from zoneinfo import ZoneInfo` in `plugins/weather/plugin.py` and `plugins/greeting/plugin.py`. Both target platforms (macOS M1, Raspberry Pi OS Bullseye+) ship Python 3.9+; the fallback is dead code that adds noise and a silent failure mode.
 
+### Priority 60: Lazy pygame Import
+**Document**: [backlog/60-lazy-pygame-import.md](./backlog/60-lazy-pygame-import.md)
+**Description**: Move `import pygame` and the SDL/ALSA device probe from module level into `Audio.initialize_audio()`. Eliminates import-time PyAudio enumeration and ALSA warnings by ensuring `_suppress_alsa_errors()` runs before any PyAudio or SDL initialization. Minimal-change alternative to Plan 61.
+
+### Priority 61: Replace pygame with miniaudio
+**Document**: [backlog/61-replace-pygame-with-miniaudio.md](./backlog/61-replace-pygame-with-miniaudio.md)
+**Description**: Replace `pygame.mixer` with the `miniaudio` library for TTS MP3 playback. Eliminates the SDL layer, env-var ordering constraints, ALSA suppression, and all import-time side effects in `common/audio.py`. Supersedes Plan 60 if implemented.
+
 ### Future Enhancements
 **Document**: [backlog/FUTURE.md](./backlog/FUTURE.md)
 **Description**: Long-term feature ideas: alternative providers (Anthropic, Ollama, Piper), local offline mode, conversation history truncation, user-triggered timers, conversation memory, export, plugin hot-reload, API cost tracking, music control, smart home, calendar, todo lists, multi-user support.

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -265,11 +265,11 @@ plan/
 
 ### Priority 60: Lazy pygame Import
 **Document**: [backlog/60-lazy-pygame-import.md](./backlog/60-lazy-pygame-import.md)
-**Description**: Move `import pygame` and the SDL/ALSA device probe from module level into `Audio.initialize_audio()`. Eliminates import-time PyAudio enumeration and ALSA warnings by ensuring `_suppress_alsa_errors()` runs before any PyAudio or SDL initialization. Minimal-change alternative to Plan 61.
+**Description**: Move `import pygame` from module level into `Audio.initialize_audio()`, and move the SDL probe logic (added by Plan 54) there too. Ensures `_suppress_alsa_errors()` runs before any PyAudio or SDL initialization, eliminating import-time side effects. Minimal-change alternative to Plan 61.
 
 ### Priority 61: Replace pygame with miniaudio
 **Document**: [backlog/61-replace-pygame-with-miniaudio.md](./backlog/61-replace-pygame-with-miniaudio.md)
-**Description**: Replace `pygame.mixer` with the `miniaudio` library for TTS MP3 playback. Eliminates the SDL layer, env-var ordering constraints, ALSA suppression, and all import-time side effects in `common/audio.py`. Supersedes Plan 60 if implemented.
+**Description**: Replace `pygame.mixer` with the `miniaudio` library for TTS MP3 playback. Eliminates the SDL layer and its env-var ordering constraints. Removes SDL-specific ALSA suppression (PyAudio mic suppression may remain). Supersedes Plan 60 if implemented.
 
 ### Future Enhancements
 **Document**: [backlog/FUTURE.md](./backlog/FUTURE.md)

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -265,7 +265,7 @@ plan/
 
 ### Priority 60: Lazy pygame Import
 **Document**: [backlog/60-lazy-pygame-import.md](./backlog/60-lazy-pygame-import.md)
-**Description**: Move `import pygame` from module level into `Audio.initialize_audio()`, and move the SDL probe logic (added by Plan 54) there too. Ensures `_suppress_alsa_errors()` runs before any PyAudio or SDL initialization, eliminating import-time side effects. Minimal-change alternative to Plan 61.
+**Description**: Move `import pygame` and the existing module-level SDL output device probe into `Audio.initialize_audio()`. Ensures `_suppress_alsa_errors()` runs before any PyAudio or SDL initialization, eliminating import-time side effects. Minimal-change alternative to Plan 61.
 
 ### Priority 61: Replace pygame with miniaudio
 **Document**: [backlog/61-replace-pygame-with-miniaudio.md](./backlog/61-replace-pygame-with-miniaudio.md)

--- a/plan/backlog/60-lazy-pygame-import.md
+++ b/plan/backlog/60-lazy-pygame-import.md
@@ -1,0 +1,127 @@
+# Lazy pygame Import — Eliminate Import-Time Audio Side Effects
+
+**Status**: 📋 Backlog
+**Priority**: 60
+**Platforms**: Linux (Raspberry Pi 3B). Neutral on macOS.
+
+---
+
+## Dependencies
+
+- None — this is a self-contained `audio.py` change.
+- Plan 54 (Linux audio output device auto-detection) is already implemented in PR #148 and is the direct motivation for this plan.
+
+---
+
+## Overview
+
+`common/audio.py` currently runs a PyAudio device enumeration block at module
+import time in order to set `SDL_AUDIODRIVER` and `AUDIODEV` before
+`import pygame` executes (also at module level). This causes three problems:
+
+1. **ALSA warnings on stderr** — `pyaudio.PyAudio()` is constructed before
+   `_suppress_alsa_errors()` is ever called, so the noise-suppression hook is not
+   yet installed when PortAudio enumerates ALSA devices.
+
+2. **Import-time side effects** — Any code path that imports `common.audio`
+   (including CLI mode, tests, and the scheduler thread) triggers a PyAudio
+   device enumeration whether or not audio will ever be played.
+
+3. **Fragile ordering constraint** — `_suppress_alsa_errors()` cannot be called
+   inside the SDL probe block without triggering a segfault on CI runners (hit in
+   PR #148 Round 4), so the warnings cannot be suppressed in the current design.
+
+The root cause: `import pygame` is at module level, forcing the SDL env-var setup
+to also be at module level, which forces the PyAudio probe to be at module level.
+
+**This plan breaks that chain by making `import pygame` lazy.**
+
+---
+
+## Proposed Solution
+
+Move `import pygame` from module level into `Audio.initialize_audio()`. The SDL
+probe and `_suppress_alsa_errors()` call move there too, running in the correct
+order — suppression first, then probe, then pygame import — all inside the method
+that actually needs audio.
+
+### Before (simplified)
+
+```python
+# Module level — runs at import time
+if platform.system() == "linux" ...:
+    _pa = pyaudio.PyAudio()          # ← ALSA warnings, no suppression yet
+    ...set SDL_AUDIODRIVER / AUDIODEV...
+    _pa.terminate()
+
+import pygame                         # ← module level
+
+class Audio:
+    def initialize_audio(self):
+        _suppress_alsa_errors()       # ← too late; SDL already imported
+        self.audio = pyaudio.PyAudio()
+```
+
+### After
+
+```python
+# No module-level pygame import, no module-level PyAudio probe
+
+class Audio:
+    def initialize_audio(self):
+        _suppress_alsa_errors()       # 1. suppress ALSA noise first
+        _detect_sdl_audio_device()    # 2. probe + set SDL env vars (Linux only)
+        import pygame                 # 3. NOW import pygame — env vars already set
+        self.audio = pyaudio.PyAudio()
+```
+
+`_detect_sdl_audio_device()` is a new module-level helper (no side effects until
+called) that encapsulates the existing SDL probe logic. It is idempotent: if
+`SDL_AUDIODRIVER` / `AUDIODEV` are already set (user override or already called),
+it returns immediately without creating a PyAudio instance.
+
+### Changes required
+
+- Remove module-level `import pygame` from `audio.py`.
+- Remove module-level SDL probe block from `audio.py`.
+- Extract probe logic into `_detect_sdl_audio_device()` module-level function.
+- Call `_suppress_alsa_errors()`, then `_detect_sdl_audio_device()`, then
+  `import pygame` inside `Audio.initialize_audio()`.
+- All other `pygame.*` references inside `Audio` methods are already inside
+  method bodies — they will still work because `initialize_audio()` is always
+  called before any playback method.
+- Update tests that patch `pygame` at module level to patch at the correct
+  location (`common.audio.pygame` will no longer exist; patch the import in
+  `initialize_audio` instead, or call `initialize_audio()` with a mocked pygame
+  loaded via `sys.modules`).
+
+---
+
+## Files to Touch
+
+| File | Change |
+|------|--------|
+| `common/audio.py` | Lazy pygame import; extract `_detect_sdl_audio_device()`; call in correct order inside `initialize_audio()` |
+| `tests/test_audio_playback.py` | Update pygame patch locations |
+| `tests/test_audio_device_detection.py` | Update probe-logic test to call helper directly |
+
+---
+
+## Out of Scope
+
+- Replacing pygame with a different audio library (that is Plan 61).
+- Any change to playback logic, queue handling, or barge-in.
+
+---
+
+## Acceptance Criteria
+
+- [ ] No PyAudio device enumeration occurs at `import common.audio` time
+- [ ] No `import pygame` occurs at `import common.audio` time
+- [ ] `_suppress_alsa_errors()` is called before any PyAudio or pygame initialization
+- [ ] SDL env vars are set before `pygame` is imported
+- [ ] `AUDIODEV` / `SDL_AUDIODRIVER` not overwritten if already set by user
+- [ ] `_detect_sdl_audio_device()` is idempotent (safe to call more than once)
+- [ ] Playback behavior unchanged on macOS and Linux
+- [ ] All tests pass on macOS M1
+- [ ] No ALSA warnings on stderr during import on Raspberry Pi 3B

--- a/plan/backlog/60-lazy-pygame-import.md
+++ b/plan/backlog/60-lazy-pygame-import.md
@@ -39,10 +39,10 @@ forcing the PyAudio enumeration to run before `_suppress_alsa_errors()` can be c
 
 ## Proposed Solution
 
-Move `import pygame` from module level into `Audio.initialize_audio()`. The SDL
-probe and `_suppress_alsa_errors()` call move there too, running in the correct
-order — suppression first, then probe, then pygame import — all inside the method
-that actually needs audio.
+Move `import pygame` and the SDL probe from module level into
+`Audio.initialize_audio()`. `_suppress_alsa_errors()` is already called at the
+top of `initialize_audio()` today — the key fix is ensuring the SDL probe and
+`import pygame` run after it, inside the method that actually needs audio.
 
 ### Before (simplified)
 

--- a/plan/backlog/60-lazy-pygame-import.md
+++ b/plan/backlog/60-lazy-pygame-import.md
@@ -88,10 +88,9 @@ it returns immediately without creating a PyAudio instance.
 - Remove module-level SDL probe block from `audio.py`.
 - Extract probe logic into `_detect_sdl_audio_device()` module-level function.
 - Call `_suppress_alsa_errors()`, then `_detect_sdl_audio_device()`, then
-  `import pygame` inside `Audio.initialize_audio()`.
-- All other `pygame.*` references inside `Audio` methods are already inside
-  method bodies — they will still work because `initialize_audio()` is always
-  called before any playback method.
+  `import pygame` inside `Audio.initialize_audio()`. Use `global pygame` so the
+  name is bound at module scope and accessible to all other `Audio` methods
+  without re-importing in each one.
 - Update tests that patch `pygame` at module level to patch at the correct
   location (`common.audio.pygame` will no longer exist; patch the import in
   `initialize_audio` instead, or call `initialize_audio()` with a mocked pygame
@@ -104,7 +103,6 @@ it returns immediately without creating a PyAudio instance.
 | File | Change |
 |------|--------|
 | `common/audio.py` | Lazy pygame import; extract `_detect_sdl_audio_device()`; call in correct order inside `initialize_audio()` |
-| `tests/test_audio_playback.py` | Update pygame patch locations |
 | `tests/test_audio_playback.py` | Update pygame patch locations; add test that calls `_detect_sdl_audio_device()` directly |
 
 ---

--- a/plan/backlog/60-lazy-pygame-import.md
+++ b/plan/backlog/60-lazy-pygame-import.md
@@ -9,17 +9,14 @@
 ## Dependencies
 
 - None — this is a self-contained `audio.py` change.
-- Plan 54 (Linux audio output device auto-detection, still in backlog) will add a module-level SDL probe that amplifies the import-time side effects. Plan 60 should be implemented alongside or after Plan 54.
 
 ---
 
 ## Overview
 
-`common/audio.py` currently has `import pygame` at module level, causing
-import-time side effects today. Once Plan 54 is implemented it will also run a
-PyAudio device enumeration block at module import time to set `SDL_AUDIODRIVER`
-and `AUDIODEV` before pygame initialises, further amplifying the problem.
-This design causes three problems:
+`common/audio.py` currently has both `import pygame` and a module-level SDL
+output device probe (PyAudio enumeration that sets `SDL_AUDIODRIVER` and
+`AUDIODEV`) running at import time. This design causes three problems:
 
 1. **ALSA warnings on stderr** — `pyaudio.PyAudio()` is constructed before
    `_suppress_alsa_errors()` is ever called, so the noise-suppression hook is not
@@ -33,8 +30,8 @@ This design causes three problems:
    inside the SDL probe block without triggering a segfault on CI runners (hit in
    PR #148 Round 4), so the warnings cannot be suppressed in the current design.
 
-The root cause: `import pygame` is at module level, forcing the SDL env-var setup
-to also be at module level, which forces the PyAudio probe to be at module level.
+The root cause: `import pygame` and the SDL probe are both at module level,
+forcing the PyAudio enumeration to run before `_suppress_alsa_errors()` can be called.
 
 **This plan breaks that chain by making `import pygame` lazy.**
 

--- a/plan/backlog/60-lazy-pygame-import.md
+++ b/plan/backlog/60-lazy-pygame-import.md
@@ -9,15 +9,16 @@
 ## Dependencies
 
 - None — this is a self-contained `audio.py` change.
-- Plan 54 (Linux audio output device auto-detection) is already implemented in PR #148 and is the direct motivation for this plan.
+- Plan 54 (Linux audio output device auto-detection, still in backlog) is the direct motivation: once Plan 54 is implemented, its module-level SDL probe will introduce the import-time side effects this plan resolves.
 
 ---
 
 ## Overview
 
-`common/audio.py` currently runs a PyAudio device enumeration block at module
-import time in order to set `SDL_AUDIODRIVER` and `AUDIODEV` before
-`import pygame` executes (also at module level). This causes three problems:
+`common/audio.py` currently has `import pygame` at module level. Once Plan 54
+is implemented it will also run a PyAudio device enumeration block at module
+import time to set `SDL_AUDIODRIVER` and `AUDIODEV` before pygame initialises.
+This design causes three problems:
 
 1. **ALSA warnings on stderr** — `pyaudio.PyAudio()` is constructed before
    `_suppress_alsa_errors()` is ever called, so the noise-suppression hook is not

--- a/plan/backlog/60-lazy-pygame-import.md
+++ b/plan/backlog/60-lazy-pygame-import.md
@@ -9,15 +9,16 @@
 ## Dependencies
 
 - None — this is a self-contained `audio.py` change.
-- Plan 54 (Linux audio output device auto-detection, still in backlog) is the direct motivation: once Plan 54 is implemented, its module-level SDL probe will introduce the import-time side effects this plan resolves.
+- Plan 54 (Linux audio output device auto-detection, still in backlog) will add a module-level SDL probe that amplifies the import-time side effects. Plan 60 should be implemented alongside or after Plan 54.
 
 ---
 
 ## Overview
 
-`common/audio.py` currently has `import pygame` at module level. Once Plan 54
-is implemented it will also run a PyAudio device enumeration block at module
-import time to set `SDL_AUDIODRIVER` and `AUDIODEV` before pygame initialises.
+`common/audio.py` currently has `import pygame` at module level, causing
+import-time side effects today. Once Plan 54 is implemented it will also run a
+PyAudio device enumeration block at module import time to set `SDL_AUDIODRIVER`
+and `AUDIODEV` before pygame initialises, further amplifying the problem.
 This design causes three problems:
 
 1. **ALSA warnings on stderr** — `pyaudio.PyAudio()` is constructed before

--- a/plan/backlog/60-lazy-pygame-import.md
+++ b/plan/backlog/60-lazy-pygame-import.md
@@ -50,7 +50,7 @@ that actually needs audio.
 
 ```python
 # Module level — runs at import time
-if platform.system() == "linux" ...:
+if platform.system() == "Linux" ...:
     _pa = pyaudio.PyAudio()          # ← ALSA warnings, no suppression yet
     ...set SDL_AUDIODRIVER / AUDIODEV...
     _pa.terminate()

--- a/plan/backlog/60-lazy-pygame-import.md
+++ b/plan/backlog/60-lazy-pygame-import.md
@@ -105,7 +105,7 @@ it returns immediately without creating a PyAudio instance.
 |------|--------|
 | `common/audio.py` | Lazy pygame import; extract `_detect_sdl_audio_device()`; call in correct order inside `initialize_audio()` |
 | `tests/test_audio_playback.py` | Update pygame patch locations |
-| `tests/test_audio_device_detection.py` | Update probe-logic test to call helper directly |
+| `tests/test_audio_playback.py` | Update pygame patch locations; add test that calls `_detect_sdl_audio_device()` directly |
 
 ---
 

--- a/plan/backlog/61-replace-pygame-with-miniaudio.md
+++ b/plan/backlog/61-replace-pygame-with-miniaudio.md
@@ -1,0 +1,134 @@
+# Replace pygame with miniaudio for TTS Playback
+
+**Status**: 📋 Backlog
+**Priority**: 61
+**Platforms**: macOS M1 + Raspberry Pi 3B (Linux).
+
+---
+
+## Dependencies
+
+- Plan 60 (lazy pygame import) is NOT a prerequisite — this plan supersedes it.
+  If Plan 61 is implemented, Plan 60 can be dropped.
+
+---
+
+## Overview
+
+SandVoice uses `pygame.mixer` exclusively for audio playback (TTS MP3 files).
+pygame is a game framework; its audio subsystem sits on top of SDL2, which on
+Linux requires manual ALSA device configuration via environment variables
+(`SDL_AUDIODRIVER`, `AUDIODEV`) that must be set before `import pygame` — causing
+the import-time side effects documented in Plan 60.
+
+[miniaudio](https://github.com/irmen/pyminiaudio) (`pip install miniaudio`) is a
+thin Python wrapper around the miniaudio C library. It handles MP3/WAV/FLAC/OGG
+playback natively across platforms, with no SDL layer, no env-var setup, and no
+import-time side effects. On Linux it talks directly to ALSA or PulseAudio; on
+macOS it uses CoreAudio.
+
+**This plan replaces the entire pygame audio subsystem with miniaudio**, removing
+the SDL probe block, ALSA suppression, and env-var ordering constraints entirely.
+
+---
+
+## Why miniaudio
+
+| Concern | pygame | miniaudio |
+|---------|--------|-----------|
+| SDL env-var setup required on Linux | Yes | No |
+| Import-time side effects | Yes | No |
+| ALSA noise suppression required | Yes | No |
+| Plays MP3 natively | Yes | Yes |
+| Supports stop mid-playback | Yes | Yes |
+| Blocking playback loop | Yes | Yes |
+| ARM / Pi 3B support | Yes | Yes |
+| Dependency footprint | Heavy (game framework) | Light (single C lib wrapper) |
+| Already used for input | No | No (PyAudio still used for mic) |
+
+---
+
+## Proposed Solution
+
+### New playback helper
+
+```python
+import miniaudio
+
+def _play_mp3_blocking(file_path, stop_event=None):
+    """Play an MP3 file synchronously; return when done or stop_event is set."""
+    stream = miniaudio.stream_file(file_path)
+    with miniaudio.PlaybackDevice() as device:
+        device.start(stream)
+        while device.running:
+            if stop_event and stop_event.is_set():
+                device.stop()
+                break
+            time.sleep(0.01)
+```
+
+This replaces the `pygame.mixer.music.load / play / get_busy` loop in
+`Audio.play_audio_file()`.
+
+### Changes required
+
+- Remove `import pygame` (module level and inside methods).
+- Remove SDL probe block (`_detect_sdl_audio_device` / `_suppress_alsa_errors`
+  for SDL purposes — ALSA suppression for PyAudio mic use can remain if needed).
+- Remove `Audio.stop_playback()` pygame-specific logic; replace with miniaudio
+  device stop.
+- Remove `Audio.is_playing()` pygame-specific logic; replace with
+  `device.running`.
+- Remove `Audio.log_mixer_state()` (pygame mixer debug helper; not applicable).
+- Replace `play_audio_file()` internals with `_play_mp3_blocking()`.
+- `play_audio_queue()` and `play_audio_files()` remain structurally unchanged —
+  they call `play_audio_file()` internally.
+- Add `miniaudio` to `requirements.txt`.
+- Remove `pygame` from `requirements.txt`.
+
+### Config changes
+
+None. The playback API surface (`play_audio_file`, `play_audio_queue`,
+`stop_playback`, `is_playing`) is unchanged from the caller's perspective.
+
+---
+
+## Files to Touch
+
+| File | Change |
+|------|--------|
+| `common/audio.py` | Replace pygame with miniaudio; remove SDL probe and ALSA suppression |
+| `requirements.txt` | Remove `pygame`; add `miniaudio` |
+| `tests/test_audio_playback.py` | Update mocks from `pygame.mixer` to `miniaudio` |
+
+---
+
+## Out of Scope
+
+- PyAudio (mic recording) is unchanged.
+- Barge-in detection is unchanged.
+- TTS generation (OpenAI API) is unchanged.
+- Any change to the streaming pipeline — `play_audio_queue` contract is preserved.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| miniaudio not packaged for Pi aarch64 | Test `pip install miniaudio` on Pi 3B before implementing; it ships a pure-C extension with no extra system deps beyond libasound |
+| Latency difference | miniaudio decodes inline; profile against pygame on Pi if needed |
+| Stop-event latency | 10 ms poll loop vs pygame's 100 ms tick — equal or better |
+
+---
+
+## Acceptance Criteria
+
+- [ ] `import common.audio` has no import-time side effects on any platform
+- [ ] TTS MP3 playback works on macOS M1
+- [ ] TTS MP3 playback works on Raspberry Pi 3B (correct USB output device)
+- [ ] `stop_playback()` stops audio within ~50 ms
+- [ ] `play_audio_queue()` with `stop_event` interrupts cleanly (barge-in path)
+- [ ] `pygame` removed from `requirements.txt`
+- [ ] All tests pass with >80% coverage on new playback code
+- [ ] No ALSA warnings on stderr on Pi during startup or playback

--- a/plan/backlog/61-replace-pygame-with-miniaudio.md
+++ b/plan/backlog/61-replace-pygame-with-miniaudio.md
@@ -90,6 +90,10 @@ This replaces the `pygame.mixer.music.load / play / get_busy` loop in
 - Replace `play_audio_file()` internals with `_play_mp3_blocking()`.
 - `play_audio_queue()` and `play_audio_files()` remain structurally unchanged —
   they call `play_audio_file()` internally.
+- Remove the `try: import pygame` debug block inside `BargeIn._poll_op()`
+  (`common/barge_in.py`) — this import exists solely to check pygame mixer state
+  for debugging and must be removed (or replaced with a miniaudio equivalent) when
+  pygame is dropped.
 - Add `miniaudio` to `requirements.txt`.
 - Remove `pygame` from `requirements.txt`.
 
@@ -105,6 +109,7 @@ None. The playback API surface (`play_audio_file`, `play_audio_queue`,
 | File | Change |
 |------|--------|
 | `common/audio.py` | Replace pygame with miniaudio; remove SDL probe and ALSA suppression |
+| `common/barge_in.py` | Remove `try: import pygame` debug block in `_poll_op()` |
 | `requirements.txt` | Remove `pygame`; add `miniaudio` |
 | `tests/test_audio_playback.py` | Update mocks from `pygame.mixer` to `miniaudio` |
 

--- a/plan/backlog/61-replace-pygame-with-miniaudio.md
+++ b/plan/backlog/61-replace-pygame-with-miniaudio.md
@@ -79,10 +79,13 @@ This replaces the `pygame.mixer.music.load / play / get_busy` loop in
   ALSA interactions. If PyAudio mic initialization still produces ALSA warnings on
   Linux, a separate `_suppress_alsa_errors()` call scoped to the PyAudio context
   may be retained.
-- Remove `Audio.stop_playback()` pygame-specific logic; replace with miniaudio
-  device stop.
-- Remove `Audio.is_playing()` pygame-specific logic; replace with
-  `device.running`.
+- Replace `Audio.stop_playback()` and `Audio.is_playing()`: since
+  `_play_mp3_blocking()` creates `device` as a local context-managed variable,
+  stop/is_playing cannot access it directly. Instead, store a shared
+  `threading.Event` (e.g. `self._stop_event`) that `_play_mp3_blocking()` polls
+  and that `stop_playback()` sets. Track playback state with a boolean flag (e.g.
+  `self._playing`) set/cleared around the `device.start()` call. `is_playing()`
+  returns that flag.
 - Remove `Audio.log_mixer_state()` (pygame mixer debug helper; not applicable).
 - Replace `play_audio_file()` internals with `_play_mp3_blocking()`.
 - `play_audio_queue()` and `play_audio_files()` remain structurally unchanged —

--- a/plan/backlog/61-replace-pygame-with-miniaudio.md
+++ b/plan/backlog/61-replace-pygame-with-miniaudio.md
@@ -28,7 +28,8 @@ import-time side effects. On Linux it talks directly to ALSA or PulseAudio; on
 macOS it uses CoreAudio.
 
 **This plan replaces the entire pygame audio subsystem with miniaudio**, removing
-the SDL probe block, ALSA suppression, and env-var ordering constraints entirely.
+the SDL probe block and env-var ordering constraints. `_suppress_alsa_errors()`
+is retained for PyAudio mic enumeration (unrelated to pygame).
 
 ---
 
@@ -111,7 +112,7 @@ None. The playback API surface (`play_audio_file`, `play_audio_queue`,
 
 | File | Change |
 |------|--------|
-| `common/audio.py` | Replace pygame with miniaudio; remove SDL probe and ALSA suppression |
+| `common/audio.py` | Replace pygame with miniaudio; remove SDL probe; retain `_suppress_alsa_errors()` for PyAudio mic |
 | `common/barge_in.py` | Remove `try: import pygame` debug block in `_poll_op()` |
 | `requirements.txt` | Remove `pygame`; add `miniaudio` |
 | `tests/test_audio_playback.py` | Update mocks from `pygame.mixer` to `miniaudio` |

--- a/plan/backlog/61-replace-pygame-with-miniaudio.md
+++ b/plan/backlog/61-replace-pygame-with-miniaudio.md
@@ -53,6 +53,7 @@ the SDL probe block, ALSA suppression, and env-var ordering constraints entirely
 ### New playback helper
 
 ```python
+import time
 import miniaudio
 
 def _play_mp3_blocking(file_path, stop_event=None):
@@ -73,8 +74,11 @@ This replaces the `pygame.mixer.music.load / play / get_busy` loop in
 ### Changes required
 
 - Remove `import pygame` (module level and inside methods).
-- Remove SDL probe block (`_detect_sdl_audio_device` / `_suppress_alsa_errors`
-  for SDL purposes — ALSA suppression for PyAudio mic use can remain if needed).
+- Remove SDL probe block (`_detect_sdl_audio_device`) and the SDL-specific
+  `_suppress_alsa_errors()` call — these are only needed to work around SDL/pygame
+  ALSA interactions. If PyAudio mic initialization still produces ALSA warnings on
+  Linux, a separate `_suppress_alsa_errors()` call scoped to the PyAudio context
+  may be retained.
 - Remove `Audio.stop_playback()` pygame-specific logic; replace with miniaudio
   device stop.
 - Remove `Audio.is_playing()` pygame-specific logic; replace with

--- a/plan/backlog/61-replace-pygame-with-miniaudio.md
+++ b/plan/backlog/61-replace-pygame-with-miniaudio.md
@@ -81,9 +81,11 @@ This replaces the `pygame.mixer.music.load / play / get_busy` loop in
   may be retained.
 - Replace `Audio.stop_playback()` and `Audio.is_playing()`: since
   `_play_mp3_blocking()` creates `device` as a local context-managed variable,
-  stop/is_playing cannot access it directly. Instead, store a shared
-  `threading.Event` (e.g. `self._stop_event`) that `_play_mp3_blocking()` polls
-  and that `stop_playback()` sets. Track playback state with a boolean flag (e.g.
+  stop/is_playing cannot access it directly. The shared stop mechanism is
+  `self._stop_event` (a `threading.Event`): `play_audio_file()` clears it and
+  passes it as the `stop_event` argument to `_play_mp3_blocking()`; `stop_playback()`
+  sets it. The `stop_event` parameter in the helper is thus always `self._stop_event`
+  — there is no second event. Track playback state with a boolean flag (e.g.
   `self._playing`) set/cleared around the `device.start()` call. `is_playing()`
   returns that flag.
 - Remove `Audio.log_mixer_state()` (pygame mixer debug helper; not applicable).

--- a/plan/backlog/61-replace-pygame-with-miniaudio.md
+++ b/plan/backlog/61-replace-pygame-with-miniaudio.md
@@ -75,9 +75,12 @@ This replaces the `pygame.mixer.music.load / play / get_busy` loop in
 ### Changes required
 
 - Remove `import pygame` (module level and inside methods).
-- Remove the SDL probe block (`_detect_sdl_audio_device` / module-level env-var
-  setup) — it exists solely to configure SDL/pygame output routing and is not
-  needed by miniaudio.
+- Remove the module-level SDL probe block in `common/audio.py` (the inline
+  `if platform.system().lower() == "linux"` block that constructs `pyaudio.PyAudio()`
+  and sets `SDL_AUDIODRIVER` / `AUDIODEV`) — it exists solely to configure SDL/pygame
+  output routing and is not needed by miniaudio. Note: if Plan 60 is implemented
+  first, this block will have been extracted into `_detect_sdl_audio_device()`;
+  in that case, remove that helper instead.
 - Retain `_suppress_alsa_errors()` in `initialize_audio()`: it suppresses
   PortAudio/ALSA stderr noise that occurs when `pyaudio.PyAudio()` enumerates
   devices for mic input, which is unrelated to pygame and still needed on Linux.
@@ -94,10 +97,10 @@ This replaces the `pygame.mixer.music.load / play / get_busy` loop in
 - Replace `play_audio_file()` internals with `_play_mp3_blocking()`.
 - `play_audio_queue()` and `play_audio_files()` remain structurally unchanged —
   they call `play_audio_file()` internally.
-- Remove the `try: import pygame` debug block inside `BargeIn._poll_op()`
-  (`common/barge_in.py`) — this import exists solely to check pygame mixer state
-  for debugging and must be removed (or replaced with a miniaudio equivalent) when
-  pygame is dropped.
+- Remove the `try: import pygame` debug block inside
+  `BargeInDetector.run_with_polling()` (`common/barge_in.py`, around the polling
+  loop) — this import exists solely to check pygame mixer state for debugging and
+  must be removed (or replaced with a miniaudio equivalent) when pygame is dropped.
 - Add `miniaudio` to `requirements.txt`.
 - Remove `pygame` from `requirements.txt`.
 

--- a/plan/backlog/61-replace-pygame-with-miniaudio.md
+++ b/plan/backlog/61-replace-pygame-with-miniaudio.md
@@ -140,7 +140,7 @@ None. The playback API surface (`play_audio_file`, `play_audio_queue`,
 
 ## Acceptance Criteria
 
-- [ ] `import common.audio` has no import-time side effects on any platform
+- [ ] `import common.audio` does not construct `pyaudio.PyAudio()`, probe audio devices, or initialize any playback subsystem at import time on any platform
 - [ ] TTS MP3 playback works on macOS M1
 - [ ] TTS MP3 playback works on Raspberry Pi 3B (correct USB output device)
 - [ ] `stop_playback()` stops audio within ~50 ms

--- a/plan/backlog/61-replace-pygame-with-miniaudio.md
+++ b/plan/backlog/61-replace-pygame-with-miniaudio.md
@@ -116,7 +116,7 @@ None. The playback API surface (`play_audio_file`, `play_audio_queue`,
 | File | Change |
 |------|--------|
 | `common/audio.py` | Replace pygame with miniaudio; remove SDL probe; retain `_suppress_alsa_errors()` for PyAudio mic |
-| `common/barge_in.py` | Remove `try: import pygame` debug block in `_poll_op()` |
+| `common/barge_in.py` | Remove `try: import pygame` debug block in `BargeInDetector.run_with_polling()` |
 | `requirements.txt` | Remove `pygame`; add `miniaudio` |
 | `tests/test_audio_playback.py` | Update mocks from `pygame.mixer` to `miniaudio` |
 

--- a/plan/backlog/61-replace-pygame-with-miniaudio.md
+++ b/plan/backlog/61-replace-pygame-with-miniaudio.md
@@ -74,11 +74,12 @@ This replaces the `pygame.mixer.music.load / play / get_busy` loop in
 ### Changes required
 
 - Remove `import pygame` (module level and inside methods).
-- Remove SDL probe block (`_detect_sdl_audio_device`) and the SDL-specific
-  `_suppress_alsa_errors()` call — these are only needed to work around SDL/pygame
-  ALSA interactions. If PyAudio mic initialization still produces ALSA warnings on
-  Linux, a separate `_suppress_alsa_errors()` call scoped to the PyAudio context
-  may be retained.
+- Remove the SDL probe block (`_detect_sdl_audio_device` / module-level env-var
+  setup) — it exists solely to configure SDL/pygame output routing and is not
+  needed by miniaudio.
+- Retain `_suppress_alsa_errors()` in `initialize_audio()`: it suppresses
+  PortAudio/ALSA stderr noise that occurs when `pyaudio.PyAudio()` enumerates
+  devices for mic input, which is unrelated to pygame and still needed on Linux.
 - Replace `Audio.stop_playback()` and `Audio.is_playing()`: since
   `_play_mp3_blocking()` creates `device` as a local context-managed variable,
   stop/is_playing cannot access it directly. The shared stop mechanism is
@@ -130,7 +131,7 @@ None. The playback API surface (`play_audio_file`, `play_audio_queue`,
 
 | Risk | Mitigation |
 |------|------------|
-| miniaudio not packaged for Pi aarch64 | Test `pip install miniaudio` on Pi 3B before implementing; it ships a pure-C extension with no extra system deps beyond libasound |
+| miniaudio not packaged for Pi armv7l/arm64 | Test `pip install miniaudio` on Pi 3B before implementing; it ships a pure-C extension with no extra system deps beyond libasound. Pi 3B typically runs armv7l (32-bit Raspberry Pi OS). |
 | Latency difference | miniaudio decodes inline; profile against pygame on Pi if needed |
 | Stop-event latency | 10 ms poll loop vs pygame's 100 ms tick — equal or better |
 

--- a/plan/backlog/61-replace-pygame-with-miniaudio.md
+++ b/plan/backlog/61-replace-pygame-with-miniaudio.md
@@ -2,7 +2,7 @@
 
 **Status**: 📋 Backlog
 **Priority**: 61
-**Platforms**: macOS M1 + Raspberry Pi 3B (Linux).
+**Platforms**: macOS M1, Raspberry Pi 3B (Linux).
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds Plan 60: Lazy pygame import — minimal fix to eliminate import-time ALSA warnings and PyAudio side effects by deferring `import pygame` and the SDL probe into `Audio.initialize_audio()`
- Adds Plan 61: Replace pygame with miniaudio — eliminates the SDL layer entirely by swapping `pygame.mixer` for the `miniaudio` library; supersedes Plan 60 if implemented
- Updates `plan/INDEX.md` with both entries

## Motivation
The SDL/ALSA device probe in `common/audio.py` runs at import time before `_suppress_alsa_errors()` is called, causing ALSA warnings on stderr on Linux/Pi. Copilot flagged this across 9 review rounds on PR #148. These plans document the two viable paths to resolve it.

## No code changes
Planning documents only — no production code modified.

## Planning Document
Addresses the recurring `common/audio.py` import-time side effect issue identified during PR #148 review rounds 5–13.