### PR TITLE
Fix deprecated wakeword_model_paths kwarg

### DIFF
--- a/common/openwakeword_detector.py
+++ b/common/openwakeword_detector.py
@@ -45,15 +45,15 @@ class OpenWakeWordDetector:
             self._resample_up = None
             self._resample_down = None
 
+        if os.path.isabs(model_name) or model_name.lower().endswith(".onnx"):
+            self._prediction_key = os.path.splitext(os.path.basename(model_name))[0]
+        else:
+            self._prediction_key = model_name
+
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             warnings.simplefilter("ignore", UserWarning)
-            if os.path.isabs(model_name) or model_name.lower().endswith(".onnx"):
-                self._model = Model(wakeword_models=[model_name], inference_framework="onnx")
-                self._prediction_key = os.path.splitext(os.path.basename(model_name))[0]
-            else:
-                self._model = Model(wakeword_models=[model_name], inference_framework="onnx")
-                self._prediction_key = model_name
+            self._model = Model(wakeword_models=[model_name], inference_framework="onnx")
 
         # Warm up the prediction buffer so keys are initialised before first use.
         self._model.predict(np.zeros(_FRAME_LENGTH, dtype=np.int16))

--- a/common/openwakeword_detector.py
+++ b/common/openwakeword_detector.py
@@ -49,7 +49,7 @@ class OpenWakeWordDetector:
             warnings.simplefilter("ignore", DeprecationWarning)
             warnings.simplefilter("ignore", UserWarning)
             if os.path.isabs(model_name) or model_name.lower().endswith(".onnx"):
-                self._model = Model(wakeword_model_paths=[model_name], inference_framework="onnx")
+                self._model = Model(wakeword_models=[model_name], inference_framework="onnx")
                 self._prediction_key = os.path.splitext(os.path.basename(model_name))[0]
             else:
                 self._model = Model(wakeword_models=[model_name], inference_framework="onnx")

--- a/tests/test_openwakeword_detector.py
+++ b/tests/test_openwakeword_detector.py
@@ -106,7 +106,7 @@ class TestOpenWakeWordDetectorInit(unittest.TestCase):
         self.assertTrue(np.all(warmup_arg == 0))
 
     @patch('openwakeword.model.Model')
-    def test_init_onnx_path_uses_wakeword_model_paths(self, mock_model_class):
+    def test_init_onnx_path_uses_wakeword_models(self, mock_model_class):
         mock_model = Mock()
         mock_model.predict.return_value = {"my_model": 0.0}
         mock_model_class.return_value = mock_model
@@ -115,7 +115,7 @@ class TestOpenWakeWordDetectorInit(unittest.TestCase):
         d = OpenWakeWordDetector(model_name="/path/to/my_model.onnx", threshold=0.5)
 
         mock_model_class.assert_called_once_with(
-            wakeword_model_paths=["/path/to/my_model.onnx"],
+            wakeword_models=["/path/to/my_model.onnx"],
             inference_framework="onnx",
         )
         self.assertEqual(d._prediction_key, "my_model")


### PR DESCRIPTION
## Summary
- Replace `wakeword_model_paths=` with `wakeword_models=` in the `Model()` call in `common/openwakeword_detector.py`

## Problem
Every startup printed:
```
WARNING root: DEPRECATION: keyword argument 'wakeword_model_paths' is no longer valid and will be removed in future releases. Use 'wakeword_models' instead.
```

The deprecated kwarg was used for `.onnx` file path models; built-in named models already used `wakeword_models`. Both branches now use the current API.

## Changes
- `common/openwakeword_detector.py`: one-line kwarg rename