### PR TITLE
Plan 59: Drop Python <3.9 zoneinfo fallback

### DIFF
--- a/common/scheduler.py
+++ b/common/scheduler.py
@@ -4,10 +4,7 @@ import threading
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Iterable, Optional
 
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    ZoneInfo = None  # Python < 3.9 fallback; times will print in UTC
+from zoneinfo import ZoneInfo
 
 from common.db import SchedulerDB, ScheduledTask
 
@@ -77,13 +74,6 @@ class TaskScheduler:
     def _resolve_tz(tz_name: Optional[str]):
         """Return a ZoneInfo object for tz_name, or None if unavailable/invalid."""
         if not tz_name:
-            return None
-        if ZoneInfo is None:
-            logger.warning(
-                "TaskScheduler: timezone %r requested but zoneinfo is unavailable "
-                "(Python < 3.9); timestamps will display in UTC.",
-                tz_name,
-            )
             return None
         try:
             return ZoneInfo(tz_name)

--- a/plugins/greeting/plugin.py
+++ b/plugins/greeting/plugin.py
@@ -1,10 +1,7 @@
 import logging
 from datetime import datetime
 
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    ZoneInfo = None  # Python < 3.9 fallback; local time will be used
+from zoneinfo import ZoneInfo
 
 from common.plugin_loader import build_extra_routes_text
 
@@ -18,7 +15,7 @@ _TZ_CACHE = {}  # tz_name → ZoneInfo or None; avoids repeated resolution and d
 def _resolve_tz(config):
     """Return a ZoneInfo for config.timezone, or None to fall back to local time."""
     tz_name = getattr(config, 'timezone', None)
-    if not isinstance(tz_name, str) or not tz_name.strip() or ZoneInfo is None:
+    if not isinstance(tz_name, str) or not tz_name.strip():
         return None
     tz_name = tz_name.strip()
     if tz_name in _TZ_CACHE:

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -5,10 +5,7 @@ import os
 
 import requests
 
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    ZoneInfo = None  # Python < 3.9 fallback
+from zoneinfo import ZoneInfo
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +14,7 @@ _TZ_CACHE = {}  # tz_name → ZoneInfo or None; avoids repeated resolution and d
 
 def _resolve_tz(tz_name):
     """Return a ZoneInfo for tz_name, or None if unavailable or invalid."""
-    if not isinstance(tz_name, str) or not tz_name.strip() or ZoneInfo is None:
+    if not isinstance(tz_name, str) or not tz_name.strip():
         return None
     tz_name = tz_name.strip()
     if tz_name in _TZ_CACHE:


### PR DESCRIPTION
## Summary
- Replace `try/except ImportError` around `from zoneinfo import ZoneInfo` with a direct import in `plugins/weather/plugin.py`, `plugins/greeting/plugin.py`, and `common/scheduler.py`
- Remove the `ZoneInfo is None` guard from `_resolve_tz()` in all three files

`zoneinfo` is in the stdlib since Python 3.9 (Oct 2020). Both target platforms exceed this: macOS M1 runs 3.14, Raspberry Pi OS Bullseye ships 3.9+. The fallback was dead code that silently degraded — if triggered, `ZoneInfo = None` would break cache key rotation and timezone display without any error.

## Test plan
- [x] 187 weather, greeting, and scheduler tests pass
- [x] No `ZoneInfo is None` code paths remain in any file