### PR TITLE
Remove echo plugin and route

### DIFF
--- a/plugins/echo.py
+++ b/plugins/echo.py
@@ -1,6 +1,0 @@
-class Echo:
-	def echo_back(self, user_input):
-		return user_input
-def process(user_input, route_data, s):
-	e = Echo()
-	return e.echo_back(user_input)

--- a/routes.yaml
+++ b/routes.yaml
@@ -12,4 +12,3 @@ route_role: |
 
             technical: This is for general technical knowledge that does not depend on real time. Most technical questions should go here.
 
-            echo: This is a route for testing the bot. The bot is going to repeat what the user said. For example: "Repeat this message."


### PR DESCRIPTION
## Summary
- Delete `plugins/echo.py` — dev-only test plugin with no production value
- Remove the `echo` route entry from `routes.yaml`

The echo plugin was polluting route matching and interfering with unrelated tests.

## Test plan
- [x] 1059 tests passing