### PR TITLE
Plan 5: Raspberry Pi setup guide

### DIFF
--- a/docs/raspberry-pi-setup.md
+++ b/docs/raspberry-pi-setup.md
@@ -38,7 +38,7 @@ python3 -m venv env
 source env/bin/activate
 ```
 
-`tflite-runtime` (a transitive dependency of openWakeWord) has no compatible wheels for current Python versions on Linux. Install a no-op stub first, then the rest:
+`tflite-runtime` (a transitive dependency of openWakeWord) has no compatible wheels for Python 3.12+ on Linux/aarch64. Install a no-op stub first, then the rest:
 
 ```bash
 TD=$(mktemp -d) && echo "from setuptools import setup; setup(name='tflite-runtime', version='2.14.0', packages=[])" > $TD/setup.py && pip install $TD
@@ -49,7 +49,13 @@ pip install -r requirements.txt
 
 ## Configuration
 
-Create `~/.sandvoice/config.yaml`. Minimum working config:
+Create the config directory and file:
+
+```bash
+mkdir -p ~/.sandvoice
+```
+
+Minimum working config (`~/.sandvoice/config.yaml`):
 
 ```yaml
 botname: Sandbot
@@ -123,7 +129,7 @@ echo 'export AUDIODEV=plughw:0,0' >> ~/.bashrc
 source ~/.bashrc
 ```
 
-To use a USB headset for both input and output, leave `AUDIODEV` unset — auto-detection will pick it up.
+To use a USB headset for both input and output, leave both `SDL_AUDIODRIVER` and `AUDIODEV` unset — auto-detection will pick it up.
 
 ### Test audio
 

--- a/docs/raspberry-pi-setup.md
+++ b/docs/raspberry-pi-setup.md
@@ -113,7 +113,7 @@ SandVoice automatically selects the first hardware `hw:N,M` input device on Linu
 
 ### Output (speaker)
 
-On Linux, when `SDL_AUDIODRIVER` is not set, SandVoice scans ALSA hardware devices, finds the first device whose name contains `hw:N,M`, and sets `SDL_AUDIODRIVER=alsa` and `AUDIODEV=plughw:N,M` (using ALSA's plug layer for format conversion). It prefers a combined in+out device over output-only. If `AUDIODEV` is already set, it is used as-is. If you override `SDL_AUDIODRIVER` manually, you should also set `AUDIODEV` explicitly — the auto-detection will be skipped. To force a specific output device (e.g. 3.5mm jack), set both before launching:
+On Linux, when `SDL_AUDIODRIVER` is not set, SandVoice uses PyAudio to enumerate devices and picks the first one whose name contains `hw:N,M`, preferring a combined input+output device (e.g. a USB headset) over output-only. It sets `SDL_AUDIODRIVER=alsa` and `AUDIODEV=plughw:N,M` (ALSA's plug layer for format conversion); falls back to `AUDIODEV=default` if no hardware device is found. If `AUDIODEV` is already set, it is used as-is. If you override `SDL_AUDIODRIVER` manually, you should also set `AUDIODEV` explicitly — the auto-detection will be skipped. To force a specific output device (e.g. 3.5mm jack), set both before launching:
 
 ```bash
 # Use 3.5mm jack (card 0)

--- a/docs/raspberry-pi-setup.md
+++ b/docs/raspberry-pi-setup.md
@@ -1,0 +1,161 @@
+# SandVoice on Raspberry Pi
+
+This guide covers installing and running SandVoice on a Raspberry Pi 3B. It assumes your Pi is already running Raspberry Pi OS Lite 64-bit, is accessible over SSH, and has internet access.
+
+---
+
+## Tested Hardware
+
+| Component | Model |
+|-----------|-------|
+| Board | Raspberry Pi 3 Model B (1 GB RAM) |
+| OS | Raspberry Pi OS Lite 64-bit (Trixie / Debian 13) |
+| Microphone | USB mic (PCM2902-based or similar) |
+| Speaker | 3.5mm jack or USB headset |
+
+---
+
+## System Dependencies
+
+```bash
+sudo apt-get update && sudo apt-get upgrade -y
+sudo apt-get install -y \
+    python3-dev python3-venv python3-pip \
+    portaudio19-dev libasound2-dev \
+    libopenblas-dev libatlas-base-dev \
+    git
+```
+
+---
+
+## Installation
+
+```bash
+git clone https://github.com/spideyz0r/sandvoice.git
+cd sandvoice
+python3 -m venv env
+source env/bin/activate
+```
+
+Install `openwakeword` first with `--no-deps` to skip `tflite-runtime` (no wheel available for Python 3.13 on aarch64), then install the rest:
+
+```bash
+pip install openwakeword>=0.6.0 --no-deps
+pip install scipy
+pip install -r requirements.txt
+```
+
+---
+
+## Configuration
+
+Create `~/.sandvoice/config.yaml`. Minimum working config:
+
+```yaml
+botname: Sandbot
+language: English
+timezone: America/Toronto
+location: Toronto, Ontario, Canada
+verbosity: brief
+
+openwakeword_model: ~/sandvoice/models/sand_voice.onnx
+wake_phrase: sand voice
+wake_word_sensitivity: 0.5
+
+log_level: info
+
+stream_responses: enabled
+stream_tts: enabled
+
+text_to_speech_model: tts-1
+bot_voice_model: nova
+speech_to_text_model: gpt-4o-mini-transcribe
+speech_to_text_task: transcribe
+speech_to_text_language: en
+```
+
+Adjust `timezone`, `location`, `language`, and `speech_to_text_language` to your locale.
+
+---
+
+## Audio Setup
+
+### Check available devices
+
+```bash
+# Playback devices
+aplay -l
+
+# Capture (input) devices
+arecord -l
+```
+
+Example output with a USB mic and 3.5mm speaker:
+
+```
+**** List of PLAYBACK Hardware Devices ****
+card 0: Headphones [bcm2835 Headphones], device 0: ...   ← 3.5mm jack
+card 1: vc4hdmi [vc4-hdmi], device 0: ...               ← HDMI (ignore)
+
+**** List of CAPTURE Hardware Devices ****
+card 1: Device [USB PnP Sound Device], device 0: ...     ← USB mic
+```
+
+### Input (microphone)
+
+SandVoice automatically selects the first `hw:N,M` USB input device on Linux — no configuration needed. If you have multiple USB audio devices, the first one found is used.
+
+### Output (speaker)
+
+SandVoice automatically detects USB output devices and sets `AUDIODEV` accordingly. If you want to force a specific output device (e.g. 3.5mm jack instead of USB), set `AUDIODEV` in your shell before launching:
+
+```bash
+# Use 3.5mm jack (card 0)
+export AUDIODEV=plughw:0,0
+```
+
+To make this permanent, add it to `~/.bashrc`:
+
+```bash
+echo 'export AUDIODEV=plughw:0,0' >> ~/.bashrc
+source ~/.bashrc
+```
+
+To use a USB headset for both input and output, leave `AUDIODEV` unset — auto-detection will pick it up.
+
+### Test audio
+
+Test speaker output:
+
+```bash
+speaker-test -D plughw:0,0 -t sine -f 440 -l 1   # 3.5mm
+speaker-test -D plughw:2,0 -t sine -f 440 -l 1   # USB (adjust card number)
+```
+
+Test mic input (record 3 seconds, play back):
+
+```bash
+arecord -D hw:1,0 -f cd -d 3 /tmp/test.wav && aplay /tmp/test.wav
+```
+
+---
+
+## Running SandVoice
+
+```bash
+cd ~/sandvoice
+OPENAI_API_KEY=your_key OPENWEATHERMAP_API_KEY=your_key env/bin/python3 sandvoice.py --wake-word
+```
+
+Say the wake phrase (`sand voice` by default) to activate. SandVoice will beep, listen, transcribe, and respond via TTS.
+
+---
+
+## Wake Word Model
+
+The repo ships with `models/sand_voice.onnx` — a custom model for the phrase "sand voice". To use a different wake word, see [CUSTOM_WAKE_WORDS.md](./CUSTOM_WAKE_WORDS.md) or use one of the built-in openWakeWord models:
+
+```yaml
+openwakeword_model: hey_jarvis    # built-in, no file path needed
+wake_phrase: hey jarvis
+```

--- a/docs/raspberry-pi-setup.md
+++ b/docs/raspberry-pi-setup.md
@@ -23,6 +23,7 @@ sudo apt-get install -y \
     python3-dev python3-venv python3-pip \
     portaudio19-dev libasound2-dev \
     libopenblas-dev libatlas-base-dev \
+    alsa-utils \
     git
 ```
 
@@ -106,7 +107,7 @@ SandVoice automatically selects the first hardware `hw:N,M` input device on Linu
 
 ### Output (speaker)
 
-On Linux, when `SDL_AUDIODRIVER` is not set, SandVoice scans ALSA hardware devices and sets `SDL_AUDIODRIVER=alsa` and `AUDIODEV` to the first `hw:N,M` output device found (preferring a combined in+out device). If `AUDIODEV` is already set, it is used as-is. If you override `SDL_AUDIODRIVER` manually, you should also set `AUDIODEV` explicitly — the auto-detection will be skipped. To force a specific output device (e.g. 3.5mm jack), set both before launching:
+On Linux, when `SDL_AUDIODRIVER` is not set, SandVoice scans ALSA hardware devices, finds the first device whose name contains `hw:N,M`, and sets `SDL_AUDIODRIVER=alsa` and `AUDIODEV=plughw:N,M` (using ALSA's plug layer for format conversion). It prefers a combined in+out device over output-only. If `AUDIODEV` is already set, it is used as-is. If you override `SDL_AUDIODRIVER` manually, you should also set `AUDIODEV` explicitly — the auto-detection will be skipped. To force a specific output device (e.g. 3.5mm jack), set both before launching:
 
 ```bash
 # Use 3.5mm jack (card 0)

--- a/docs/raspberry-pi-setup.md
+++ b/docs/raspberry-pi-setup.md
@@ -38,7 +38,7 @@ python3 -m venv env
 source env/bin/activate
 ```
 
-`tflite-runtime` (a transitive dependency of openWakeWord) has no compatible wheels for Python 3.12+ on Linux/aarch64. Install a no-op stub first, then the rest:
+`tflite-runtime` (a transitive dependency of openWakeWord) has no compatible wheels for current Python versions on Linux. Install a no-op stub first, then the rest:
 
 ```bash
 TD=$(mktemp -d) && echo "from setuptools import setup; setup(name='tflite-runtime', version='2.14.0', packages=[])" > $TD/setup.py && pip install $TD
@@ -152,7 +152,9 @@ arecord -D hw:1,0 -f cd -d 3 /tmp/test.wav && aplay /tmp/test.wav
 
 ```bash
 cd ~/sandvoice
-OPENAI_API_KEY=your_key OPENWEATHERMAP_API_KEY=your_key env/bin/python3 sandvoice.py --wake-word
+export OPENAI_API_KEY=your_key
+export OPENWEATHERMAP_API_KEY=your_key
+env/bin/python3 sandvoice.py --wake-word
 ```
 
 Say the wake phrase (`sand voice` by default) to activate. SandVoice will beep, listen, transcribe, and respond via TTS.

--- a/docs/raspberry-pi-setup.md
+++ b/docs/raspberry-pi-setup.md
@@ -106,16 +106,18 @@ SandVoice automatically selects the first hardware `hw:N,M` input device on Linu
 
 ### Output (speaker)
 
-On Linux, SandVoice scans ALSA hardware devices and sets `SDL_AUDIODRIVER=alsa` and `AUDIODEV` to the first `hw:N,M` output device found (preferring a combined in+out device). If `AUDIODEV` is already set in your environment, it is used as-is. To force a specific output device (e.g. 3.5mm jack), set `AUDIODEV` before launching:
+On Linux, when `SDL_AUDIODRIVER` is not set, SandVoice scans ALSA hardware devices and sets `SDL_AUDIODRIVER=alsa` and `AUDIODEV` to the first `hw:N,M` output device found (preferring a combined in+out device). If `AUDIODEV` is already set, it is used as-is. If you override `SDL_AUDIODRIVER` manually, you should also set `AUDIODEV` explicitly — the auto-detection will be skipped. To force a specific output device (e.g. 3.5mm jack), set both before launching:
 
 ```bash
 # Use 3.5mm jack (card 0)
+export SDL_AUDIODRIVER=alsa
 export AUDIODEV=plughw:0,0
 ```
 
 To make this permanent, add it to `~/.bashrc`:
 
 ```bash
+echo 'export SDL_AUDIODRIVER=alsa' >> ~/.bashrc
 echo 'export AUDIODEV=plughw:0,0' >> ~/.bashrc
 source ~/.bashrc
 ```

--- a/docs/raspberry-pi-setup.md
+++ b/docs/raspberry-pi-setup.md
@@ -31,17 +31,16 @@ sudo apt-get install -y \
 ## Installation
 
 ```bash
-git clone https://github.com/spideyz0r/sandvoice.git
-cd sandvoice
+git clone https://github.com/spideyz0r/sandvoice.git ~/sandvoice
+cd ~/sandvoice
 python3 -m venv env
 source env/bin/activate
 ```
 
-Install `openwakeword` first with `--no-deps` to skip `tflite-runtime` (no wheel available for Python 3.13 on aarch64), then install the rest:
+`tflite-runtime` (a transitive dependency of openWakeWord) has no compatible wheels for current Python versions on Linux. Install a no-op stub first, then the rest:
 
 ```bash
-pip install openwakeword>=0.6.0 --no-deps
-pip install scipy
+TD=$(mktemp -d) && echo "from setuptools import setup; setup(name='tflite-runtime', version='2.14.0', packages=[])" > $TD/setup.py && pip install $TD
 pip install -r requirements.txt
 ```
 
@@ -60,7 +59,7 @@ verbosity: brief
 
 openwakeword_model: ~/sandvoice/models/sand_voice.onnx
 wake_phrase: sand voice
-wake_word_sensitivity: 0.5
+wake_word_sensitivity: 0.25
 
 log_level: info
 
@@ -103,11 +102,11 @@ card 1: Device [USB PnP Sound Device], device 0: ...     ← USB mic
 
 ### Input (microphone)
 
-SandVoice automatically selects the first `hw:N,M` USB input device on Linux — no configuration needed. If you have multiple USB audio devices, the first one found is used.
+SandVoice automatically selects the first hardware `hw:N,M` input device on Linux — no configuration needed. If you have multiple hardware audio devices, the first one enumerated by PyAudio is used.
 
 ### Output (speaker)
 
-SandVoice automatically detects USB output devices and sets `AUDIODEV` accordingly. If you want to force a specific output device (e.g. 3.5mm jack instead of USB), set `AUDIODEV` in your shell before launching:
+On Linux, SandVoice scans ALSA hardware devices and sets `SDL_AUDIODRIVER=alsa` and `AUDIODEV` to the first `hw:N,M` output device found (preferring a combined in+out device). If `AUDIODEV` is already set in your environment, it is used as-is. To force a specific output device (e.g. 3.5mm jack), set `AUDIODEV` before launching:
 
 ```bash
 # Use 3.5mm jack (card 0)

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -179,6 +179,10 @@ plan/
 **Document**: [completed/49-cache-warmup-skip-fresh-entries.md](./completed/49-cache-warmup-skip-fresh-entries.md)
 **Description**: Fix cache warmup to skip live API/LLM calls when the SQLite-persisted entry is still fresh. Adds a fresh-entry early return in the `refresh_only=True` path for the weather and greeting plugins. Warmup is now instant when the cache is warm from a recent run. Pattern documented in `docs/PATTERNS.md`.
 
+### Priority 5: Raspberry Pi Compatibility
+**Document**: [completed/05-raspberry-pi-compatibility.md](./completed/05-raspberry-pi-compatibility.md)
+**Description**: Setup guide for Raspberry Pi 3B deployment (headless, USB audio). Covers system deps, installation, audio configuration (USB mic, 3.5mm jack, USB headset), and wake word setup. All code changes covered by Plans 52–55.
+
 ### Priority 52: Replace Porcupine with openWakeWord
 **Document**: [completed/52-replace-porcupine-with-openwakeword.md](./completed/52-replace-porcupine-with-openwakeword.md)
 **Description**: Swap the Picovoice Porcupine engine for openWakeWord (MIT, no account required). New `common/openwakeword_detector.py` wraps openWakeWord behind Porcupine's interface. Pins `onnxruntime==1.20.0` for Pi 3B stability. Adds `openwakeword_model` config key.
@@ -217,10 +221,6 @@ plan/
 ---
 
 ## Backlog 📋
-
-### Priority 5: Raspberry Pi Compatibility
-**Document**: [backlog/05-raspberry-pi-compatibility.md](./backlog/05-raspberry-pi-compatibility.md)
-**Description**: Documentation and setup guide for Raspberry Pi 3B deployment (headless, USB audio). Depends on Plans 52–55 for all code changes; this plan covers only `docs/raspberry-pi-setup.md`.
 
 ### Priority 14: Energy-Based Speech Detection
 **Document**: [backlog/14-energy-based-speech-detection.md](./backlog/14-energy-based-speech-detection.md)

--- a/plan/completed/05-raspberry-pi-compatibility.md
+++ b/plan/completed/05-raspberry-pi-compatibility.md
@@ -1,6 +1,6 @@
 # Raspberry Pi Compatibility
 
-**Status**: 📋 Backlog
+**Status**: ✅ Completed
 **Priority**: 5
 **Platforms**: Raspberry Pi 3B (primary target)
 


### PR DESCRIPTION
## Summary
- Add `docs/raspberry-pi-setup.md` covering system dependencies, installation, audio configuration (USB mic, 3.5mm jack, USB headset), wake word setup, and running SandVoice
- Mark plan 05 as completed and move to `plan/completed/`
- Update INDEX.md

All code prerequisites (Plans 52–55) are merged and validated on live hardware (Pi 3B + USB mic + 3.5mm speaker).

## Test plan
- [ ] Review `docs/raspberry-pi-setup.md` for accuracy against live Pi setup