### PR TITLE
Plans 14 and 62: VAD energy pre-filter and Silero VAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,6 @@ vad_enabled: enabled
 
 The default wake phrase is **"sand voice"**, using the model at `models/sand_voice.onnx` (included in the repo). You can use any built-in openWakeWord model (e.g. `hey_jarvis`, `alexa`) or train your own — see [docs/CUSTOM_WAKE_WORDS.md](docs/CUSTOM_WAKE_WORDS.md).
 
-**Raspberry Pi / Linux install note:** `tflite-runtime` (a transitive dependency of openWakeWord) has no compatible wheels for current Python versions on Linux. Install a no-op stub before running `pip install -r requirements.txt`:
-
-```bash
-TD=$(mktemp -d) && echo "from setuptools import setup; setup(name='tflite-runtime', version='2.14.0', packages=[])" > $TD/setup.py && pip install $TD
-pip install -r requirements.txt
-```
-
 ## API keys
 
 | Key | Required | Used by |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Talk to an LLM. Hear it talk back.
 
-SandVoice is a Python voice assistant that turns microphone input into an AI conversation — transcribing speech, routing requests to the right plugin, and playing the response through your speakers. It runs on macOS and Raspberry Pi.
+SandVoice is a Python voice assistant that turns microphone input into an AI conversation — transcribing speech, routing requests to the right plugin, and playing the response through your speakers.
+
+Run it on your laptop, or plug a Raspberry Pi into a USB mic and speaker and turn it into a private, always-on home assistant — your own voice-activated AI, without handing your home to a big tech device.
 
 ## Modes
 
@@ -54,6 +56,26 @@ vad_enabled: enabled
 ```
 
 The default wake phrase is **"sand voice"**, using the model at `models/sand_voice.onnx` (included in the repo). You can use any built-in openWakeWord model (e.g. `hey_jarvis`, `alexa`) or train your own — see [docs/CUSTOM_WAKE_WORDS.md](docs/CUSTOM_WAKE_WORDS.md).
+
+## Raspberry Pi — home voice assistant
+
+Wake word mode running on a Raspberry Pi 3B is SandVoice's most compelling use case:
+a standalone, always-on device you can place anywhere in the house. Say the wake
+phrase, ask anything, and hear the response — no screen, no keyboard, no subscription.
+
+Traditional smart speakers like Alexa and Google Home are built around fixed command
+sets and scripted answers. SandVoice is backed by a large language model — it can hold
+a real conversation, answer complex questions, explain things, help you think through a
+problem, and handle follow-up questions naturally. It also knows about the weather,
+latest news, and anything else a plugin can reach.
+
+Unlike those devices, SandVoice runs on hardware you own. Your voice is transcribed and
+answered via OpenAI, but the device, the config, and the wake word model are entirely
+yours. You can use the default "sand voice" phrase, swap in a built-in model like
+`hey_jarvis`, or train a custom wake word for any phrase you want.
+
+**What you need:** Raspberry Pi 3B (or newer), a USB microphone, and any speaker
+(3.5mm or USB). Full setup guide: [docs/raspberry-pi-setup.md](docs/raspberry-pi-setup.md)
 
 ## API keys
 
@@ -237,7 +259,6 @@ def process(user_input, route, s):
 | `realtime_websearch` | Live web search via Responses API | — |
 | `technical` | Technical/code questions | — |
 | `greeting` | Greetings and small talk | — |
-| `echo` | Echoes back what you said (example/test) | — |
 | `realtime` | Web search (scraping-based, **legacy**) | — |
 
 ### Adding a plugin
@@ -387,6 +408,3 @@ For the `news` plugin, `rss_url` overrides the `rss_news` config value and is us
 
 > **Note**: `cache_auto_refresh` requires `cache_enabled: enabled`. If the scheduler is disabled, the startup warmup still runs but no periodic tasks are registered.
 
-## Platform notes
-
-SandVoice targets macOS M1 and Raspberry Pi 3B. Audio settings are auto-detected where possible. If you run into microphone issues, try setting `channels: 1` in config.

--- a/plan/INDEX.md
+++ b/plan/INDEX.md
@@ -222,9 +222,9 @@ plan/
 
 ## Backlog 📋
 
-### Priority 14: Energy-Based Speech Detection
+### Priority 14: Adaptive Energy Pre-Filter for VAD
 **Document**: [backlog/14-energy-based-speech-detection.md](./backlog/14-energy-based-speech-detection.md)
-**Description**: Add ambient noise calibration and energy thresholding to reduce false positives from constant background audio.
+**Description**: Add adaptive noise-floor calibration and RMS energy pre-filtering inside `VadRecorder`. Frames below `noise_floor × multiplier` are forced to non-speech before WebRTC VAD runs. Fixes false positives from TV audio, fans, and distant speech. ~60 lines, no new dependencies, self-contained in `vad_recorder.py`.
 
 ### Priority 18: TTS Micro-Pauses and Pacing
 **Document**: [backlog/18-tts-micro-pauses-and-pacing.md](./backlog/18-tts-micro-pauses-and-pacing.md)
@@ -266,6 +266,10 @@ plan/
 ### Priority 60: Lazy pygame Import
 **Document**: [backlog/60-lazy-pygame-import.md](./backlog/60-lazy-pygame-import.md)
 **Description**: Move `import pygame` and the existing module-level SDL output device probe into `Audio.initialize_audio()`. Ensures `_suppress_alsa_errors()` runs before any PyAudio or SDL initialization, eliminating import-time side effects. Minimal-change alternative to Plan 61.
+
+### Priority 62: Silero VAD — Neural End-of-Speech Detection
+**Document**: [backlog/62-silero-vad-neural-endpoint-detection.md](./backlog/62-silero-vad-neural-endpoint-detection.md)
+**Description**: Replace WebRTC VAD with Silero VAD (neural LSTM, ~1.5 MB ONNX). Dramatically better accuracy for TV/music/background-speech scenarios. Uses `onnxruntime` (already installed). Energy pre-filter from Plan 14 stays as the cheap first-stage gate. Requires Pi 3B latency benchmark before committing. Supersedes dropped Plan 15.
 
 ### Priority 61: Replace pygame with miniaudio
 **Document**: [backlog/61-replace-pygame-with-miniaudio.md](./backlog/61-replace-pygame-with-miniaudio.md)

--- a/plan/backlog/14-energy-based-speech-detection.md
+++ b/plan/backlog/14-energy-based-speech-detection.md
@@ -1,126 +1,135 @@
-# Plan 14: Energy-Based Speech Detection
+# Plan 14: Adaptive Energy Pre-Filter for VAD
+
+## Status: 📋 Backlog
 
 ## Problem Statement
-WebRTC VAD detects any sound as potential speech, including constant background noise like music or podcasts. We need to distinguish actual speech (variable energy, speech patterns) from ambient noise (relatively constant energy).
+
+WebRTC VAD at aggressiveness 3 still classifies low-level ambient noise (TV dialogue,
+fan hum, distant speech, mic self-noise) as speech. The `vad_silence_duration` counter
+never resets because the VAD never sees a silence frame, so SandVoice keeps recording
+until `vad_timeout` fires. This causes the system to record several extra seconds of
+silence/noise after the user finishes speaking, increasing latency and sometimes sending
+garbage audio to the STT API.
+
+Repro: TV on in the background, or a second person speaking more than ~2m from the mic.
+
+## Root Cause
+
+WebRTC VAD is a rule-based signal-processing model from ~2012. It works on spectral
+features and zero-crossing rate. At aggressiveness 3 it is strict about what counts
+as speech, but low-level broadband noise (TV, music, room tone) has enough energy in
+speech-frequency bands to pass. An energy gate eliminates these false positives before
+WebRTC ever runs.
 
 ## Goals
-1. Measure ambient noise baseline during IDLE state
-2. Only consider frames as speech if energy exceeds baseline + threshold
-3. Auto-calibrate on startup and periodically
-4. Reduce false positives from constant background audio
+
+1. Add an adaptive noise-floor calibration phase at the start of each recording
+2. Pre-filter frames whose RMS energy is below `noise_floor × multiplier` before
+   passing them to WebRTC VAD
+3. Keep all changes inside `common/vad_recorder.py` — no changes to wake_word.py or
+   any other module
+4. No new dependencies (struct math, no numpy)
+5. Config toggle + tunable multiplier
 
 ## Technical Approach
 
-### Energy Detection Concept
-- **Ambient noise** (music, HVAC, fans): Relatively constant energy level
-- **Human speech**: Variable energy with pauses, higher peaks above ambient
-- **Key insight**: Speech energy spikes above ambient; background is steady
+### Calibration phase (pre-speech)
 
-### Algorithm
-1. During IDLE, sample ambient noise level (RMS energy)
-2. Calculate baseline as rolling average of ambient samples
-3. During LISTENING, only count frame as "speech" if:
-   - Energy > baseline + threshold_db
-   - AND webrtcvad also says it's speech
-4. Periodically recalibrate baseline (every N seconds in IDLE)
+While `speech_detected` is False, collect the RMS of each frame. After
+`vad_energy_calibration_frames` frames (default 15 × 30ms = 450ms), compute
+`noise_floor = mean(rms_values)`.
 
-## Implementation
+Once calibrated, for every subsequent frame:
 
-### Phase 1: Energy Measurement Utility
-```python
-# In common/audio_utils.py (new file)
-import numpy as np
-
-def calculate_rms_energy(audio_frames: bytes, sample_width: int = 2) -> float:
-    """Calculate RMS energy of audio frames in dB."""
-    samples = np.frombuffer(audio_frames, dtype=np.int16)
-    rms = np.sqrt(np.mean(samples.astype(np.float32) ** 2))
-    if rms == 0:
-        return -96.0  # Floor
-    return 20 * np.log10(rms / 32768.0)
-
-def is_above_threshold(energy_db: float, baseline_db: float, threshold_db: float) -> bool:
-    """Check if energy exceeds baseline by threshold."""
-    return energy_db > (baseline_db + threshold_db)
+```
+rms = compute_rms(pcm)
+if calibrated and rms < noise_floor * multiplier:
+    is_speech = False   # override — below energy gate
+else:
+    is_speech = vad.is_speech(pcm, sample_rate)
 ```
 
-### Phase 2: Ambient Calibration in IDLE
-```python
-# In wake_word.py, during _state_idle()
-class WakeWordMode:
-    def __init__(self, ...):
-        self.ambient_baseline_db = -40.0  # Default
-        self.calibration_samples = []
+### RMS computation (no numpy)
 
-    def _calibrate_ambient(self, audio_frames):
-        """Update ambient baseline with new sample."""
-        energy = calculate_rms_energy(audio_frames)
-        self.calibration_samples.append(energy)
-        if len(self.calibration_samples) > 50:  # ~1.5 seconds
-            self.calibration_samples.pop(0)
-        self.ambient_baseline_db = np.mean(self.calibration_samples)
+```python
+import struct, math
+
+def _rms(pcm: bytes) -> float:
+    samples = struct.unpack_from(f"{len(pcm)//2}h", pcm)
+    if not samples:
+        return 0.0
+    return math.sqrt(sum(s * s for s in samples) / len(samples))
 ```
 
-### Phase 3: Enhanced VAD in LISTENING
-```python
-def _is_speech_frame(self, audio_frames) -> bool:
-    """Combined VAD + energy detection."""
-    # Standard VAD check
-    vad_says_speech = self.vad.is_speech(audio_frames, self.sample_rate)
+Typical noise floor on a USB mic in a quiet room: RMS 80–200.
+Typical noise floor with TV at background volume: RMS 300–600.
+Speech peaks: RMS 2000–8000.
+A multiplier of 2.5 gives comfortable headroom in both cases.
 
-    if not self.config.energy_detection_enabled:
-        return vad_says_speech
+### Configuration
 
-    # Energy check
-    energy = calculate_rms_energy(audio_frames)
-    above_ambient = is_above_threshold(
-        energy,
-        self.ambient_baseline_db,
-        self.config.energy_threshold_db
-    )
+Two new config keys (both optional, both have defaults):
 
-    # Both must agree
-    return vad_says_speech and above_ambient
-```
-
-### Phase 4: Configuration
 ```yaml
-# New config options
-energy_detection_enabled: true
-energy_threshold_db: 6.0        # dB above ambient to count as speech
-energy_calibration_seconds: 2.0  # How long to sample ambient on startup
-energy_recalibrate_interval: 30  # Recalibrate every N seconds in IDLE
+vad_energy_filter: enabled           # enabled | disabled (default: enabled)
+vad_energy_threshold_multiplier: 2.5 # float > 1.0 (default: 2.5)
 ```
 
-## Testing Strategy
+`vad_energy_calibration_frames` is intentionally not exposed — 15 frames (450ms) is
+the right calibration window for all real-world cases.
 
-### Unit Tests
-- Test RMS calculation with known signals
-- Test threshold comparison logic
-- Test calibration averaging
+## Implementation Plan
 
-### Integration Tests
-- Test with silence → should calibrate low
-- Test with music → should calibrate to music level
-- Test speech over music → should detect speech peaks
+### Step 1 — `common/configuration.py`
+- Add `vad_energy_filter` (default `"enabled"`) and
+  `vad_energy_threshold_multiplier` (default `2.5`) to `_DEFAULTS`
+- Load and validate in `Config._load_config()`:
+  - `vad_energy_filter`: must be `"enabled"` or `"disabled"`
+  - `vad_energy_threshold_multiplier`: must be a float > 1.0
 
-### Manual Testing
-- Play music, say wake word, speak → should stop correctly
-- Play podcast, speak over it → should detect your speech
-- Quiet room → should work as before
+### Step 2 — `common/vad_recorder.py`
+- Add module-level `_rms(pcm)` helper (struct-only, no numpy)
+- In `VadRecorder.record()`:
+  - Before the loop: initialise `_rms_samples = []`, `_noise_floor = None`,
+    `_CALIBRATION_FRAMES = 15`
+  - Read `energy_filter_enabled` and `multiplier` from `self._config`
+  - In the loop, before the WebRTC call:
+    - If `not speech_detected` and `len(_rms_samples) < _CALIBRATION_FRAMES`:
+      append `_rms(pcm)` to `_rms_samples`
+    - When `len(_rms_samples) == _CALIBRATION_FRAMES` and `_noise_floor is None`:
+      set `_noise_floor = mean(_rms_samples)`, log at DEBUG
+    - If `energy_filter_enabled` and `_noise_floor is not None`:
+      if `_rms(pcm) < _noise_floor * multiplier`: force `is_speech = False`
+
+### Step 3 — Tests (`tests/test_vad_recorder.py`)
+- Test `_rms()` with known PCM data
+- Test that a frame below the energy gate is forced to `is_speech = False`
+- Test that a frame above the gate passes through to the WebRTC mock
+- Test that calibration uses exactly `_CALIBRATION_FRAMES` frames
+- Test that the filter is skipped when `vad_energy_filter: disabled`
+- Test the `vad_energy_threshold_multiplier` validation path
+
+### Step 4 — Docs
+- Add `vad_energy_filter` and `vad_energy_threshold_multiplier` to README config table
+- Add a note to `docs/raspberry-pi-setup.md` in the audio section
 
 ## Success Criteria
-- [ ] Ambient baseline calibrated on startup
-- [ ] Speech detected only when energy > baseline + threshold
-- [ ] Works correctly with music playing
-- [ ] No regression in quiet environment performance
 
-## Effort: Medium
+- [ ] VAD stops within `vad_silence_duration` after user stops speaking even with
+      TV audio playing at normal background volume
+- [ ] No regression in quiet-room detection (speech still detected reliably)
+- [ ] `vad_energy_filter: disabled` restores previous behavior exactly
+- [ ] >80% test coverage on new/modified code in `vad_recorder.py`
+
+## Effort: Small (≈ 60 lines of code + tests)
 
 ## Dependencies
-- numpy (already likely installed)
-- Plan 13 (VAD robustness) recommended first
+
+- Plan 35 (VadRecorder extraction) — ✅ completed
 
 ## Relationship
-- Builds on: Plan 13 (VAD Robustness)
-- Enhanced by: Plan 15 (Speech Classification)
+
+- Supersedes original Plan 14 approach (IDLE-state calibration, numpy, WakeWordMode
+  changes) — new approach is simpler and self-contained within VadRecorder
+- Prerequisite for: Plan 62 (Silero VAD) — energy gate remains as a lightweight
+  first-stage filter even after Silero replaces WebRTC

--- a/plan/backlog/62-silero-vad-neural-endpoint-detection.md
+++ b/plan/backlog/62-silero-vad-neural-endpoint-detection.md
@@ -1,0 +1,141 @@
+# Plan 62: Silero VAD — Neural End-of-Speech Detection
+
+## Status: 📋 Backlog
+
+## Problem Statement
+
+WebRTC VAD is a rule-based model from ~2012. Even with the Plan 14 energy pre-filter
+it can misfire in challenging acoustic conditions: TV dialogue at higher volumes,
+another person speaking nearby, or music with speech-like frequency content. A neural
+VAD model trained specifically to distinguish human speech from these noise sources
+provides dramatically better accuracy.
+
+## Goals
+
+1. Replace the `webrtcvad.Vad.is_speech()` call with Silero VAD inference
+2. Keep the Plan 14 energy pre-filter as the first-stage gate (cheap, always-on)
+3. Maintain the same `VadRecorder` interface — no changes outside `vad_recorder.py`
+   and `common/configuration.py`
+4. Must run acceptably on Raspberry Pi 3B (benchmark target: ≤ 15ms per 30ms frame)
+5. Graceful fallback to WebRTC VAD if the Silero model file cannot be loaded
+
+## Background: Why Silero
+
+| | WebRTC VAD | Silero VAD |
+|---|---|---|
+| Type | Rule-based (signal processing) | Neural LSTM |
+| Model size | — (no file) | ~1.5 MB ONNX |
+| False-positive rate (TV bg) | High | Low |
+| Inference latency (Pi 3B) | ~0.1ms | ~5–12ms (to confirm) |
+| Dependency | `webrtcvad` | `onnxruntime` (already installed) |
+
+Silero VAD ships as an ONNX model, so `onnxruntime` — which is already a dependency
+(via openWakeWord) — is the only inference runtime required.
+
+## Technical Approach
+
+### Model acquisition
+
+Silero VAD v5 ONNX weights are available from the official repo. The model file
+(`silero_vad.onnx`) should be bundled under `models/` alongside the existing wake
+word model. At ~1.5 MB it is small enough to commit.
+
+### Inference interface
+
+Silero VAD is stateful — it maintains an internal LSTM hidden state across frames.
+The state must be reset between utterances (i.e. at the start of each `record()` call).
+
+```python
+import onnxruntime as ort
+import numpy as np
+
+class SileroVad:
+    def __init__(self, model_path, sample_rate=16000):
+        self._session = ort.InferenceSession(model_path)
+        self._sr = sample_rate
+        self.reset()
+
+    def reset(self):
+        self._h = np.zeros((2, 1, 64), dtype=np.float32)
+        self._c = np.zeros((2, 1, 64), dtype=np.float32)
+
+    def is_speech(self, pcm: bytes) -> bool:
+        samples = np.frombuffer(pcm, dtype=np.int16).astype(np.float32) / 32768.0
+        out, self._h, self._c = self._session.run(
+            None,
+            {"input": samples[np.newaxis], "sr": np.array(self._sr), "h": self._h, "c": self._c},
+        )
+        return float(out[0]) >= 0.5   # threshold configurable
+```
+
+### Integration in VadRecorder
+
+- `VadRecorder.__init__` checks config for `vad_engine: silero | webrtc` (default `webrtc`
+  until benchmarked on Pi)
+- If `silero`: load `SileroVad`; if load fails, log a warning and fall back to `webrtcvad`
+- `is_speech` call site in `record()` becomes `self._vad.is_speech(pcm)` regardless of engine
+
+### Configuration
+
+```yaml
+vad_engine: silero          # webrtc | silero (default: webrtc)
+silero_model_path: ~/sandvoice/models/silero_vad.onnx
+silero_speech_threshold: 0.5  # probability threshold (0.0–1.0)
+```
+
+## Implementation Plan
+
+### Step 0 — Benchmark first
+Before writing any production code, benchmark Silero inference on the Pi 3B:
+- Script: `tools/benchmark_silero.py` — feed 1000 frames, measure p50/p99 latency
+- Target: p99 ≤ 15ms per 30ms frame (so VAD overhead < 50% of frame time)
+- If Pi cannot meet the target, this plan becomes macOS-only or deferred
+
+### Step 1 — `models/silero_vad.onnx`
+Download and commit the Silero VAD v5 ONNX weights.
+
+### Step 2 — `common/silero_vad.py`
+Implement `SileroVad` class (reset, is_speech). Unit tests with synthetic PCM.
+
+### Step 3 — `common/vad_recorder.py`
+- Add `vad_engine` config read in `__init__`
+- Instantiate `SileroVad` or `webrtcvad.Vad` accordingly
+- Normalise the call site: `is_speech = self._vad_is_speech(pcm)`
+- On Silero load failure: warn and fall back to WebRTC
+
+### Step 4 — `common/configuration.py`
+- Add `vad_engine` (default `"webrtc"`), `silero_model_path`, `silero_speech_threshold`
+- Validate: `vad_engine` in `{"webrtc", "silero"}`; threshold in (0.0, 1.0)
+
+### Step 5 — Tests
+- Test `SileroVad.reset()` zeroes state
+- Test probability threshold gating
+- Test fallback: if model path invalid, `VadRecorder` uses WebRTC
+- Benchmark script in `tools/`
+
+### Step 6 — Docs
+- Update README config table
+- Note Pi 3B benchmarks in plan doc after measuring
+
+## Success Criteria
+
+- [ ] TV at background volume no longer keeps the VAD loop open
+- [ ] Inference p99 latency ≤ 15ms per frame on Pi 3B (or plan scoped to macOS)
+- [ ] WebRTC fallback works when model file is missing
+- [ ] `vad_engine: webrtc` restores previous behavior exactly
+- [ ] >80% test coverage on `common/silero_vad.py`
+
+## Effort: Medium
+
+## Dependencies
+
+- Plan 14 (Adaptive Energy Pre-Filter) — prerequisite; energy gate stays as first stage
+- `onnxruntime` — already installed (via openWakeWord)
+- Silero VAD v5 ONNX weights — ~1.5 MB, to be committed to `models/`
+
+## Relationship
+
+- Supersedes dropped Plan 15 (Speech Classification / ML VAD) — same goal, but
+  `onnxruntime` is already a dependency so there is no new install requirement;
+  Pi 3B viability needs a fresh benchmark with the actual ONNX runtime
+- Builds on: Plan 14 (energy gate remains as cheap first-stage filter)


### PR DESCRIPTION
## Summary
- Rewrite **Plan 14** (Adaptive Energy Pre-Filter): self-contained in `VadRecorder`, no numpy, ~60 lines. Fixes VAD not stopping when TV/background noise is present.
- New **Plan 62** (Silero VAD neural endpoint detection): replaces WebRTC VAD with Silero ONNX model once Pi 3B latency is benchmarked.

## No code changes
Plan documents only. Implementation of Plan 14 follows in a subsequent PR on this branch.

## Test plan
- [ ] Review plan 14 for implementation accuracy against `common/vad_recorder.py`
- [ ] Review plan 62 scope and Pi benchmark requirement